### PR TITLE
Added Simple Substitution of Existential with Universal

### DIFF
--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -857,6 +857,25 @@ SubsumptionTableEntry::hasExistentials(std::vector<const Array *> &existentials,
   return false;
 }
 
+bool SubsumptionTableEntry::hasFree(std::vector<const Array *> &existentials,
+                                    ref<Expr> expr) {
+  for (int i = 0, numKids = expr->getNumKids(); i < numKids; ++i) {
+    if (llvm::isa<ReadExpr>(expr)) {
+      ReadExpr *readExpr = llvm::dyn_cast<ReadExpr>(expr.get());
+      const Array *array = (readExpr->updates).root;
+      for (std::vector<const Array *>::iterator it = existentials.begin(),
+                                                itEnd = existentials.end();
+           it != itEnd; ++it) {
+        if ((*it) == array)
+          return false;
+      }
+      return true;
+    } else if (hasFree(existentials, expr->getKid(i)))
+      return true;
+  }
+  return false;
+}
+
 ref<Expr>
 SubsumptionTableEntry::simplifyWithFourierMotzkin(ref<Expr> existsExpr) {
   // This is a template for Fourier-Motzkin elimination. For now,
@@ -929,8 +948,10 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
   if (fullEqualityConstraint->isTrue()) {
     // This is the case when the result is still an existentially-quantified
     // formula, but one that does not contain free variables.
-    hasExistentialsOnly = true;
-    return existsExpr->rebuild(&simplifiedInterpolant);
+    hasExistentialsOnly = !hasFree(expr->variables, simplifiedInterpolant);
+    if (hasExistentialsOnly) {
+      return existsExpr->rebuild(&simplifiedInterpolant);
+    }
   }
 
   ref<Expr> newInterpolant;
@@ -1176,12 +1197,50 @@ ref<Expr> SubsumptionTableEntry::simplifyEqualityExpr(
   assert(!"Invalid expression type.");
 }
 
+ref<Expr>
+SubsumptionTableEntry::getSubstitution(ref<Expr> equalities,
+                                       std::map<ref<Expr>, ref<Expr> > &map) {
+  if (llvm::isa<EqExpr>(equalities.get())) {
+    ref<Expr> lhs = equalities->getKid(0);
+    if (llvm::isa<ReadExpr>(lhs.get()) || llvm::isa<ConcatExpr>(lhs.get())) {
+      map[lhs] = equalities->getKid(1);
+      return ConstantExpr::alloc(1, Expr::Bool);
+    }
+    return equalities;
+  }
+
+  if (llvm::isa<AndExpr>(equalities.get())) {
+    ref<Expr> lhs = getSubstitution(equalities->getKid(0), map);
+    ref<Expr> rhs = getSubstitution(equalities->getKid(1), map);
+    if (lhs->isTrue()) {
+      if (rhs->isTrue()) {
+        return ConstantExpr::alloc(1, Expr::Bool);
+      }
+      return rhs;
+    } else {
+      if (rhs->isTrue()) {
+        return lhs;
+      }
+      return AndExpr::alloc(lhs, rhs);
+    }
+  }
+  return equalities;
+}
+
 ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
                                                     bool &hasExistentialsOnly) {
-  assert(llvm::isa<ExistsExpr>(existsExpr));
+  assert(llvm::isa<ExistsExpr>(existsExpr.get()));
 
-  ref<Expr> ret = simplifyArithmeticBody(existsExpr, hasExistentialsOnly);
+  ref<Expr> body = llvm::dyn_cast<ExistsExpr>(existsExpr.get())->body;
+  assert(llvm::isa<AndExpr>(body.get()));
 
+  std::map<ref<Expr>, ref<Expr> > substitution;
+  ref<Expr> equalities = getSubstitution(body->getKid(1), substitution);
+  ref<Expr> interpolant =
+      ApplySubstitutionVisitor(substitution).visit(body->getKid(0));
+  ref<Expr> newBody = AndExpr::alloc(interpolant, equalities);
+  ref<Expr> ret = simplifyArithmeticBody(existsExpr->rebuild(&newBody),
+                                         hasExistentialsOnly);
   return ret;
 }
 


### PR DESCRIPTION
For resolving issue #39 . Now klee-examples/basic/addition_safe8.c has 2 subsumptions instead of 0 (as previously). In general, this patch results in more subsumptions without losing error report, however, some examples became slightly slower. Following is relevant statistics from running klee-examples/basic examples.
```
addition.c
BEFORE: 0.07user 0.00system 0:00.08elapsed 95%CPU (0avgtext+0avgdata 33392maxresident)k
KLEE: done:     subsumed paths = 2
AFTER: 0.07user 0.01system 0:00.09elapsed 96%CPU (0avgtext+0avgdata 32960maxresident)k
KLEE: done:     subsumed paths = 2

addition_safe1.c
BEFORE: 0.12user 0.00system 0:00.12elapsed 100%CPU (0avgtext+0avgdata 33408maxresident)k
KLEE: done:     subsumed paths = 4
AFTER: 0.10user 0.00system 0:00.11elapsed 100%CPU (0avgtext+0avgdata 32968maxresident)k
KLEE: done:     subsumed paths = 4

addition_safe2.c
BEFORE: 0.09user 0.00system 0:00.10elapsed 98%CPU (0avgtext+0avgdata 33676maxresident)k
KLEE: done:     subsumed paths = 3
AFTER: 0.10user 0.00system 0:00.10elapsed 97%CPU (0avgtext+0avgdata 32708maxresident)k
KLEE: done:     subsumed paths = 3

addition_safe3.c
BEFORE: 0.06user 0.00system 0:00.06elapsed 95%CPU (0avgtext+0avgdata 33120maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.05user 0.00system 0:00.06elapsed 96%CPU (0avgtext+0avgdata 33340maxresident)k
KLEE: done:     subsumed paths = 0

addition_safe4.c
BEFORE: 0.11user 0.00system 0:00.11elapsed 97%CPU (0avgtext+0avgdata 33396maxresident)k
KLEE: done:     subsumed paths = 4
AFTER: 0.11user 0.00system 0:00.11elapsed 97%CPU (0avgtext+0avgdata 32956maxresident)k
KLEE: done:     subsumed paths = 4

addition_safe5.c
BEFORE: 0.09user 0.00system 0:00.10elapsed 98%CPU (0avgtext+0avgdata 33408maxresident)k
KLEE: done:     subsumed paths = 4
AFTER: 0.10user 0.00system 0:00.10elapsed 99%CPU (0avgtext+0avgdata 33164maxresident)k
KLEE: done:     subsumed paths = 4

addition_safe6.c
BEFORE: 0.10user 0.00system 0:00.11elapsed 97%CPU (0avgtext+0avgdata 33612maxresident)k
KLEE: done:     subsumed paths = 4
AFTER: 0.10user 0.00system 0:00.10elapsed 99%CPU (0avgtext+0avgdata 33000maxresident)k
KLEE: done:     subsumed paths = 4

addition_safe8.c
BEFORE: 0.26user 0.02system 0:00.28elapsed 98%CPU (0avgtext+0avgdata 35280maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.19user 0.01system 0:00.21elapsed 98%CPU (0avgtext+0avgdata 35084maxresident)k
KLEE: done:     subsumed paths = 2

addition_safe9.c
BEFORE: 0.36user 0.02system 0:00.38elapsed 99%CPU (0avgtext+0avgdata 35968maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.08user 0.01system 0:00.09elapsed 100%CPU (0avgtext+0avgdata 33504maxresident)k
KLEE: done:     subsumed paths = 4

addition_unsafe1.c
BEFORE: 0.10user 0.00system 0:00.11elapsed 97%CPU (0avgtext+0avgdata 33000maxresident)k
KLEE: done:     subsumed paths = 4
AFTER: 0.11user 0.00system 0:00.11elapsed 99%CPU (0avgtext+0avgdata 33124maxresident)k
KLEE: done:     subsumed paths = 4

addition_unsafe2.c
BEFORE: 0.10user 0.00system 0:00.10elapsed 99%CPU (0avgtext+0avgdata 32920maxresident)k
KLEE: done:     subsumed paths = 4
AFTER: 0.10user 0.00system 0:00.10elapsed 99%CPU (0avgtext+0avgdata 33104maxresident)k
KLEE: done:     subsumed paths = 4

argument1.c
BEFORE: 0.01user 0.00system 0:00.02elapsed 100%CPU (0avgtext+0avgdata 26092maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.01user 0.00system 0:00.01elapsed 85%CPU (0avgtext+0avgdata 26180maxresident)k
KLEE: done:     subsumed paths = 0

argument2.c
BEFORE: 0.01user 0.00system 0:00.01elapsed 94%CPU (0avgtext+0avgdata 24156maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.00user 0.00system 0:00.01elapsed 85%CPU (0avgtext+0avgdata 24156maxresident)k
KLEE: done:     subsumed paths = 0

arraysimple1.c
BEFORE: 0.06user 0.00system 0:00.06elapsed 100%CPU (0avgtext+0avgdata 33312maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.06user 0.00system 0:00.06elapsed 98%CPU (0avgtext+0avgdata 33624maxresident)k
KLEE: done:     subsumed paths = 0

arraysimple2.c
BEFORE: 0.03user 0.00system 0:00.04elapsed 95%CPU (0avgtext+0avgdata 33132maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.03user 0.00system 0:00.03elapsed 96%CPU (0avgtext+0avgdata 33420maxresident)k
KLEE: done:     subsumed paths = 0

arraysimple3.c
BEFORE: 0.03user 0.00system 0:00.04elapsed 93%CPU (0avgtext+0avgdata 33468maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.04user 0.00system 0:00.04elapsed 100%CPU (0avgtext+0avgdata 33508maxresident)k
KLEE: done:     subsumed paths = 0

bubble.c
BEFORE: 0.99user 0.11system 0:01.10elapsed 100%CPU (0avgtext+0avgdata 36268maxresident)k
KLEE: done:     subsumed paths = 15
AFTER: 1.00user 0.08system 0:01.08elapsed 99%CPU (0avgtext+0avgdata 36016maxresident)k
KLEE: done:     subsumed paths = 15

even.c
BEFORE: 0.05user 0.00system 0:00.06elapsed 100%CPU (0avgtext+0avgdata 33428maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.05user 0.00system 0:00.05elapsed 94%CPU (0avgtext+0avgdata 33600maxresident)k
KLEE: done:     subsumed paths = 0

interproc.c
BEFORE: 0.12user 0.00system 0:00.13elapsed 98%CPU (0avgtext+0avgdata 33816maxresident)k
KLEE: done:     subsumed paths = 3
AFTER: 0.14user 0.00system 0:00.14elapsed 98%CPU (0avgtext+0avgdata 33464maxresident)k
KLEE: done:     subsumed paths = 3

loop_safe1.c
BEFORE: 0.10user 0.01system 0:00.11elapsed 99%CPU (0avgtext+0avgdata 33260maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.10user 0.01system 0:00.11elapsed 97%CPU (0avgtext+0avgdata 33256maxresident)k
KLEE: done:     subsumed paths = 0

loop_safe2.c
BEFORE: 0.62user 0.02system 0:00.64elapsed 100%CPU (0avgtext+0avgdata 34732maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.37user 0.00system 0:00.37elapsed 99%CPU (0avgtext+0avgdata 33616maxresident)k
KLEE: done:     subsumed paths = 0

loop_unsafe1.c
BEFORE: 0.41user 0.00system 0:00.42elapsed 99%CPU (0avgtext+0avgdata 33232maxresident)k
KLEE: done:     subsumed paths = 5
AFTER: 0.39user 0.01system 0:00.40elapsed 100%CPU (0avgtext+0avgdata 33052maxresident)k
KLEE: done:     subsumed paths = 5

malloc1.c
BEFORE: 0.01user 0.00system 0:00.01elapsed 88%CPU (0avgtext+0avgdata 24176maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.00user 0.00system 0:00.01elapsed 94%CPU (0avgtext+0avgdata 23648maxresident)k
KLEE: done:     subsumed paths = 0

polynomial.c
BEFORE: 0.05user 0.00system 0:00.06elapsed 98%CPU (0avgtext+0avgdata 33756maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.04user 0.00system 0:00.05elapsed 94%CPU (0avgtext+0avgdata 33340maxresident)k
KLEE: done:     subsumed paths = 0

regexp_nonrecursive1.c
BEFORE: 0.37user 0.00system 0:00.38elapsed 100%CPU (0avgtext+0avgdata 34080maxresident)k
KLEE: done:     subsumed paths = 1
AFTER: 0.41user 0.00system 0:00.42elapsed 99%CPU (0avgtext+0avgdata 33856maxresident)k
KLEE: done:     subsumed paths = 1

regexp_nonrecursive2.c
BEFORE: 1.34user 0.02system 0:01.37elapsed 100%CPU (0avgtext+0avgdata 34672maxresident)k
KLEE: done:     subsumed paths = 32
AFTER: 1.09user 0.01system 0:01.10elapsed 99%CPU (0avgtext+0avgdata 35196maxresident)k
KLEE: done:     subsumed paths = 32

regexp_nonrecursive3.c
BEFORE: 0.12user 0.00system 0:00.12elapsed 98%CPU (0avgtext+0avgdata 32824maxresident)k
KLEE: done:     subsumed paths = 3
AFTER: 0.10user 0.00system 0:00.10elapsed 99%CPU (0avgtext+0avgdata 33184maxresident)k
KLEE: done:     subsumed paths = 3

sp.c
BEFORE: 0.10user 0.00system 0:00.10elapsed 100%CPU (0avgtext+0avgdata 33872maxresident)k
KLEE: done:     subsumed paths = 0
AFTER: 0.07user 0.00system 0:00.08elapsed 97%CPU (0avgtext+0avgdata 33764maxresident)k
KLEE: done:     subsumed paths = 1
```