### PR TITLE
Option to Eliminate Quantifiers By Strengthening Subsumption Check Query

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -74,6 +74,8 @@ extern llvm::cl::opt<bool> NoInterpolation;
 extern llvm::cl::opt<bool> OutputTree;
 
 extern llvm::cl::opt<bool> InterpolationStat;
+
+extern llvm::cl::opt<bool> NoExistential;
 #endif
 
 #ifdef SUPPORT_METASMT

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -101,6 +101,19 @@ llvm::cl::opt<bool> InterpolationStat(
     "interpolation-stat",
     llvm::cl::desc(
         "Displays an execution profile of the interpolation routines."));
+
+llvm::cl::opt<bool> NoExistential(
+    "no-existential",
+    llvm::cl::desc(
+        "This option avoids existential quantification in subsumption "
+        "check by equating each existential variable with its corresponding "
+        "free variable. For example, when checking if x < 10 is subsumed by "
+        "another state where there is x' s.t., x' <= 0 && x = x' + 20 (here "
+        "the existential variable x' represents the value of x before adding "
+        "20), we strengthen the query by adding the constraint x' = x. This "
+        "has an effect of removing all existentially-quantified variables "
+        "most solvers are not very powerful at solving, however, at likely "
+        "less number of subsumptions due to the strengthening of the query."));
 #endif
 
 #ifdef SUPPORT_METASMT

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -500,7 +500,11 @@ Dependency::getSingletonExpressions(std::vector<const Array *> &replacements,
         ret[site] = expr;
       } else if (v->isCore()) {
         ref<Expr> expr = v->getExpression();
+#if 0
         ret[site] = ShadowArray::getShadowExpression(expr, replacements);
+#else
+        ret[site] = expr;
+#endif
       }
     }
   }
@@ -543,8 +547,12 @@ Dependency::getCompositeExpressions(std::vector<const Array *> &replacements,
         elemList.push_back((*valueIter)->getExpression());
       } else if ((*valueIter)->isCore()) {
         std::vector<ref<Expr> > &elemList = ret[site];
+#if 0
         elemList.push_back(ShadowArray::getShadowExpression(
             (*valueIter)->getExpression(), replacements));
+#else
+        elemList.push_back((*valueIter)->getExpression());
+#endif
       }
     }
   }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -16,6 +16,8 @@
 
 #include "Dependency.h"
 
+#include "klee/CommandLine.h"
+
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Intrinsics.h>
@@ -500,11 +502,11 @@ Dependency::getSingletonExpressions(std::vector<const Array *> &replacements,
         ret[site] = expr;
       } else if (v->isCore()) {
         ref<Expr> expr = v->getExpression();
-#if 0
-        ret[site] = ShadowArray::getShadowExpression(expr, replacements);
-#else
-        ret[site] = expr;
-#endif
+        if (NoExistential) {
+          ret[site] = expr;
+        } else {
+          ret[site] = ShadowArray::getShadowExpression(expr, replacements);
+        }
       }
     }
   }
@@ -547,12 +549,12 @@ Dependency::getCompositeExpressions(std::vector<const Array *> &replacements,
         elemList.push_back((*valueIter)->getExpression());
       } else if ((*valueIter)->isCore()) {
         std::vector<ref<Expr> > &elemList = ret[site];
-#if 0
-        elemList.push_back(ShadowArray::getShadowExpression(
-            (*valueIter)->getExpression(), replacements));
-#else
-        elemList.push_back((*valueIter)->getExpression());
-#endif
+        if (NoExistential) {
+          elemList.push_back((*valueIter)->getExpression());
+        } else {
+          elemList.push_back(ShadowArray::getShadowExpression(
+              (*valueIter)->getExpression(), replacements));
+        }
       }
     }
   }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1361,8 +1361,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
         result = success ? Solver::True : Solver::Unknown;
 
       } else {
-        llvm::errs() << "Querying for subsumption check:\n";
-        ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+        // llvm::errs() << "Querying for subsumption check:\n";
+        // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
 
         actualSolverCallTimer.start();
         success = z3solver->directComputeValidity(

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -772,12 +772,10 @@ PathCondition::packInterpolant(std::vector<const Array *> &replacements) {
   for (PathCondition *it = this; it != 0; it = it->tail) {
     if (it->core) {
       if (!it->shadowed) {
-#if 0
         it->shadowConstraint =
-            ShadowArray::getShadowExpression(it->constraint, replacements);
-#else
-        it->shadowConstraint = it->constraint;
-#endif
+            (NoExistential ? it->constraint
+                           : ShadowArray::getShadowExpression(it->constraint,
+                                                              replacements));
         it->shadowed = true;
       }
       if (res.get()) {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -772,8 +772,12 @@ PathCondition::packInterpolant(std::vector<const Array *> &replacements) {
   for (PathCondition *it = this; it != 0; it = it->tail) {
     if (it->core) {
       if (!it->shadowed) {
+#if 0
         it->shadowConstraint =
             ShadowArray::getShadowExpression(it->constraint, replacements);
+#else
+        it->shadowConstraint = it->constraint;
+#endif
         it->shadowed = true;
       }
       if (res.get()) {
@@ -1359,8 +1363,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
         result = success ? Solver::True : Solver::Unknown;
 
       } else {
-        // llvm::errs() << "Querying for subsumption check:\n";
-        // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+        llvm::errs() << "Querying for subsumption check:\n";
+        ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
 
         actualSolverCallTimer.start();
         success = z3solver->directComputeValidity(


### PR DESCRIPTION
@feliciahalim @nguyenquocbinh This PR Introduces `-no-existential` option to avoid existential quantification in subsumption check by equating each existential variable with its corresponding free variable. For example, when checking if x < 10 is subsumed by another state where there is x' s.t., x' <= 0 && x = x' + 20 (here the existential variable x' represents the value of x before adding 20), we strengthen the query by adding the constraint x' = x. This has an effect of removing all existentially-quantified variables most solvers are not very powerful at solving, however, at likely less number of subsumptions due to the strengthening of the query.