### PR TITLE
Change storesList data structure

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -935,7 +935,7 @@ Dependency::Dependency(Dependency *prev)
 Dependency::~Dependency() {
   // Delete the locally-constructed relations
   Util::deletePointerVector(equalityList);
-  // Util::deletePointerVector(storesList);
+  Util::deletePointerMultiMap(storesList);
   Util::deletePointerVector(flowsToList);
 
   // Delete the locally-constructed objects
@@ -1506,6 +1506,16 @@ void Dependency::Util::deletePointerVector(std::vector<T *> &list) {
     delete *it;
   }
   list.clear();
+}
+
+template <typename Key, typename T>
+void Dependency::Util::deletePointerMultiMap(std::multimap<Key *, T *> &map) {
+  typedef typename std::multimap<Key *, T *>::iterator IteratorType;
+
+  for (IteratorType it = map.begin(), itEnd = map.end(); it != itEnd; ++it) {
+    map.erase(it);
+  }
+  map.clear();
 }
 
 bool Dependency::Util::isEnvironmentAllocation(llvm::Value *site) {

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1363,17 +1363,17 @@ Dependency::directLocalAllocationSources(VersionedValue *target) const {
     }
 
     for (std::map<Allocation *, std::vector<VersionedValue *> >::const_iterator
-             it = storesCompositeList.begin();
-         it != storesCompositeList.end(); ++it) {
+             it1 = storesCompositeList.begin();
+         it1 != storesCompositeList.end(); ++it1) {
 
       for (std::vector<VersionedValue *>::const_iterator it2 =
-               it->second.begin();
-           it2 != it->second.end(); ++it2) {
+               it1->second.begin();
+           it2 != it1->second.end(); ++it2) {
 
         if ((*it2) == target) {
           // It is possible that the first component was nil, as
           // in this case there was no source value
-          ret[0] = (*it).first;
+          ret[0] = (*it1).first;
           break;
         }
       }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -775,9 +775,9 @@ std::vector<VersionedValue *> Dependency::stores(Allocation *allocation) const {
     return ret;
   }
 
-  std::map<Allocation *, VersionedValue *>::const_iterator it2;
-  it2 = storesSingletonList.find(allocation);
-  if (it2 != storesSingletonList.end()) {
+  std::map<Allocation *, VersionedValue *>::const_iterator it;
+  it = storesSingletonList.find(allocation);
+  if (it != storesSingletonList.end()) {
     ret.push_back(storesSingletonList.at(allocation));
     return ret;
   }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -721,24 +721,24 @@ void Dependency::addPointerEquality(const VersionedValue *value,
 void Dependency::updateStore(Allocation *allocation, VersionedValue *value) {
   if (allocation->isComposite()) {
     std::map<Allocation *, std::vector<VersionedValue *> >::iterator it;
-    it = storesCompositeList.find(allocation);
-    if (it != storesCompositeList.end()) {
-      storesCompositeList.at(allocation).push_back(value);
+    it = storesCompositeMap.find(allocation);
+    if (it != storesCompositeMap.end()) {
+      storesCompositeMap.at(allocation).push_back(value);
     } else {
       std::vector<VersionedValue *> newList;
       newList.push_back(value);
-      storesCompositeList.insert(
+      storesCompositeMap.insert(
           std::pair<Allocation *, std::vector<VersionedValue *> >(allocation,
                                                                   newList));
     }
 
   } else {
     std::map<Allocation *, VersionedValue *>::iterator it;
-    it = storesSingletonList.find(allocation);
-    if (it != storesSingletonList.end()) {
-      storesSingletonList.at(allocation) = value;
+    it = storesSingletonMap.find(allocation);
+    if (it != storesSingletonMap.end()) {
+      storesSingletonMap.at(allocation) = value;
     } else {
-      storesSingletonList.insert(
+      storesSingletonMap.insert(
           std::pair<Allocation *, VersionedValue *>(allocation, value));
     }
   }
@@ -761,9 +761,9 @@ std::vector<VersionedValue *> Dependency::stores(Allocation *allocation) const {
     // In case of composite allocation, we return all possible stores
     // due to field-insensitivity of the dependency relation
     std::map<Allocation *, std::vector<VersionedValue *> >::const_iterator it;
-    it = storesCompositeList.find(allocation);
-    if (it != storesCompositeList.end()) {
-      ret = storesCompositeList.at(allocation);
+    it = storesCompositeMap.find(allocation);
+    if (it != storesCompositeMap.end()) {
+      ret = storesCompositeMap.at(allocation);
     }
 
     if (parentDependency) {
@@ -776,9 +776,9 @@ std::vector<VersionedValue *> Dependency::stores(Allocation *allocation) const {
   }
 
   std::map<Allocation *, VersionedValue *>::const_iterator it;
-  it = storesSingletonList.find(allocation);
-  if (it != storesSingletonList.end()) {
-    ret.push_back(storesSingletonList.at(allocation));
+  it = storesSingletonMap.find(allocation);
+  if (it != storesSingletonMap.end()) {
+    ret.push_back(storesSingletonMap.at(allocation));
     return ret;
   }
 
@@ -929,8 +929,8 @@ Dependency::Dependency(Dependency *prev)
 Dependency::~Dependency() {
   // Delete the locally-constructed relations
   Util::deletePointerVector(equalityList);
-  Util::deletePointerMap(storesSingletonList);
-  Util::deletePointerMapWithVectorValue(storesCompositeList);
+  Util::deletePointerMap(storesSingletonMap);
+  Util::deletePointerMapWithVectorValue(storesCompositeMap);
   Util::deletePointerVector(flowsToList);
 
   // Delete the locally-constructed objects
@@ -1352,8 +1352,8 @@ Dependency::directLocalAllocationSources(VersionedValue *target) const {
   if (ret.empty()) {
     // We try to find allocation in the local store instead
     for (std::map<Allocation *, VersionedValue *>::const_iterator it =
-             storesSingletonList.begin();
-         it != storesSingletonList.end(); ++it) {
+             storesSingletonMap.begin();
+         it != storesSingletonMap.end(); ++it) {
       if ((*it).second == target) {
         // It is possible that the first component was nil, as
         // in this case there was no source value
@@ -1363,8 +1363,8 @@ Dependency::directLocalAllocationSources(VersionedValue *target) const {
     }
 
     for (std::map<Allocation *, std::vector<VersionedValue *> >::const_iterator
-             it1 = storesCompositeList.begin();
-         it1 != storesCompositeList.end(); ++it1) {
+             it1 = storesCompositeMap.begin();
+         it1 != storesCompositeMap.end(); ++it1) {
 
       for (std::vector<VersionedValue *>::const_iterator it2 =
                it1->second.begin();
@@ -1475,9 +1475,9 @@ void Dependency::print(llvm::raw_ostream &stream, const unsigned tabNum) const {
   std::vector<PointerEquality *>::const_iterator equalityListBegin =
       equalityList.begin();
   std::map<Allocation *, VersionedValue *>::const_iterator
-  storesSingletonListBegin = storesSingletonList.begin();
+  storesSingletonListBegin = storesSingletonMap.begin();
   std::map<Allocation *, std::vector<VersionedValue *> >::const_iterator
-  storesCompositeListBegin = storesCompositeList.begin();
+  storesCompositeListBegin = storesCompositeMap.begin();
   std::vector<FlowsTo *>::const_iterator flowsToListBegin = flowsToList.begin();
   for (std::vector<PointerEquality *>::const_iterator
            it = equalityListBegin,
@@ -1490,8 +1490,8 @@ void Dependency::print(llvm::raw_ostream &stream, const unsigned tabNum) const {
   stream << "\n";
   stream << tabs << "STORAGE SINGLETON:";
   for (std::map<Allocation *, VersionedValue *>::const_iterator
-           it = storesSingletonList.begin(),
-           itEnd = storesSingletonList.end();
+           it = storesSingletonMap.begin(),
+           itEnd = storesSingletonMap.end();
        it != itEnd; ++it) {
     if (it != storesSingletonListBegin)
       stream << ",";
@@ -1504,8 +1504,8 @@ void Dependency::print(llvm::raw_ostream &stream, const unsigned tabNum) const {
   stream << "\n";
   stream << tabs << "STORAGE COMPOSITE:";
   for (std::map<Allocation *, std::vector<VersionedValue *> >::const_iterator
-           it = storesCompositeList.begin(),
-           itEnd = storesCompositeList.end();
+           it = storesCompositeMap.begin(),
+           itEnd = storesCompositeMap.end();
        it != itEnd; ++it) {
     if (it != storesCompositeListBegin)
       stream << ",";

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1497,20 +1497,20 @@ void Dependency::print(llvm::raw_ostream &stream, const unsigned tabNum) const {
   stream << "\n";
   stream << tabs << "STORAGE COMPOSITE:";
   for (std::map<Allocation *, std::vector<VersionedValue *> >::const_iterator
-           it = storesCompositeMap.begin(),
-           itEnd = storesCompositeMap.end();
-       it != itEnd; ++it) {
-    if (it != storesCompositeListBegin)
+           it1 = storesCompositeMap.begin(),
+           it1End = storesCompositeMap.end();
+       it1 != it1End; ++it1) {
+    if (it1 != storesCompositeListBegin)
       stream << ",";
     stream << "[";
-    (*it->first).print(stream);
+    (*it1->first).print(stream);
     stream << ",";
 
     std::vector<VersionedValue *>::const_iterator versionedValueListBegin =
-        it->second.begin();
+        it1->second.begin();
     for (std::vector<VersionedValue *>::const_iterator
-             it2 = it->second.begin(),
-             it2End = it->second.end();
+             it2 = it1->second.begin(),
+             it2End = it1->second.end();
          it2 != it2End; ++it2) {
       if (it2 != versionedValueListBegin)
         stream << ",";

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1552,9 +1552,9 @@ void Dependency::Util::deletePointerVector(std::vector<T *> &list) {
   list.clear();
 }
 
-template <typename Key, typename T>
-void Dependency::Util::deletePointerMap(std::map<Key *, T *> &map) {
-  typedef typename std::map<Key *, T *>::iterator IteratorType;
+template <typename K, typename T>
+void Dependency::Util::deletePointerMap(std::map<K *, T *> &map) {
+  typedef typename std::map<K *, T *>::iterator IteratorType;
 
   for (IteratorType it = map.begin(), itEnd = map.end(); it != itEnd; ++it) {
     map.erase(it);
@@ -1562,10 +1562,10 @@ void Dependency::Util::deletePointerMap(std::map<Key *, T *> &map) {
   map.clear();
 }
 
-template <typename Key, typename T>
+template <typename K, typename T>
 void Dependency::Util::deletePointerMapWithVectorValue(
-    std::map<Key *, std::vector<T *> > &map) {
-  typedef typename std::map<Key *, std::vector<T *> >::iterator IteratorType;
+    std::map<K *, std::vector<T *> > &map) {
+  typedef typename std::map<K *, std::vector<T *> >::iterator IteratorType;
 
   for (IteratorType it = map.begin(), itEnd = map.end(); it != itEnd; ++it) {
     map.erase(it);

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1355,6 +1355,8 @@ Dependency::directLocalAllocationSources(VersionedValue *target) const {
              storesSingletonList.begin();
          it != storesSingletonList.end(); ++it) {
       if ((*it).second == target) {
+        // It is possible that the first component was nil, as
+        // in this case there was no source value
         ret[0] = (*it).first;
         break;
       }
@@ -1369,6 +1371,8 @@ Dependency::directLocalAllocationSources(VersionedValue *target) const {
            it2 != it->second.end(); ++it2) {
 
         if ((*it2) == target) {
+          // It is possible that the first component was nil, as
+          // in this case there was no source value
           ret[0] = (*it).first;
           break;
         }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -228,16 +228,6 @@ void PointerEquality::print(llvm::raw_ostream &stream) const {
 
 /**/
 
-void StorageCell::print(llvm::raw_ostream &stream) const {
-  stream << "[";
-  allocation->print(stream);
-  stream << ",";
-  value->print(stream);
-  stream << "]";
-}
-
-/**/
-
 void FlowsTo::print(llvm::raw_ostream &stream) const {
   source->print(stream);
   stream << "->";

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -538,10 +538,10 @@ class Allocation {
     std::vector< PointerEquality *> equalityList;
 
     /// @brief The mapping of allocations/addresses to stored singleton value
-    std::map<Allocation *, VersionedValue *> storesSingletonList;
+    std::map<Allocation *, VersionedValue *> storesSingletonMap;
 
     /// @brief The mapping of allocations/addresses to stored singleton value
-    std::map<Allocation *, std::vector<VersionedValue *> > storesCompositeList;
+    std::map<Allocation *, std::vector<VersionedValue *> > storesCompositeMap;
 
     /// @brief Flow relations from one value to another
     std::vector<FlowsTo *> flowsToList;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -543,6 +543,10 @@ class Allocation {
     /// @brief The mapping of allocations/addresses to stored singleton value
     std::map<Allocation *, std::vector<VersionedValue *> > storesCompositeMap;
 
+    /// @brief Store the inverse map of both storesSingletonMap and
+    /// storesCompositeMap
+    std::map<VersionedValue *, std::vector<Allocation *> > storageOfMap;
+
     /// @brief Flow relations from one value to another
     std::vector<FlowsTo *> flowsToList;
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -567,7 +567,9 @@ class Allocation {
     std::vector< PointerEquality *> equalityList;
 
     /// @brief The mapping of allocations/addresses to stored value
-    unordered_map<Allocation *, VersionedValue *> storesList;
+    unordered_map<Allocation *, std::vector<VersionedValue *> > storesList;
+
+    unordered_map<VersionedValue *, Allocation *> storageOfAlloc;
 
     /// @brief Flow relations from one value to another
     std::vector<FlowsTo *> flowsToList;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -230,35 +230,6 @@ class Allocation {
     }
   };
 
-  class StorageCell {
-    // allocation stores value
-    Allocation *allocation;
-    VersionedValue* value;
-
-  public:
-    StorageCell(Allocation *allocation, VersionedValue *value)
-        : allocation(allocation), value(value) {}
-
-    ~StorageCell() {}
-
-    VersionedValue *stores(Allocation *allocation) const {
-      return this->allocation == allocation ? this->value : 0;
-    }
-
-    Allocation *storageOf(const VersionedValue *value) const {
-      return this->value == value ? this->allocation : 0;
-    }
-
-    Allocation *getAllocation() const { return this->allocation; }
-
-    void print(llvm::raw_ostream& stream) const;
-
-    void dump() const {
-      print(llvm::errs());
-      llvm::errs() << "\n";
-    }
-  };
-
   class FlowsTo {
     // target depends on source
     VersionedValue* source;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -548,6 +548,9 @@ class Allocation {
       template <typename T>
       static void deletePointerVector(std::vector<T *> &list);
 
+      template <typename Key, typename T>
+      static void deletePointerMultiMap(std::multimap<Key *, T *> &map);
+
       static bool isCompositeAllocation(llvm::Value *site);
 
       static bool isEnvironmentAllocation(llvm::Value *site);

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -31,7 +31,14 @@
 #include <llvm/Instructions.h>
 #include <llvm/Value.h>
 #endif
-
+#include <ciso646>
+#ifdef _LIBCPP_VERSION
+#include <unordered_map>
+#define unordered_map std::unordered_map
+#else
+#include <tr1/unordered_map>
+#define unordered_map std::tr1::unordered_map
+#endif
 #include "llvm/Support/raw_ostream.h"
 
 #include <vector>
@@ -560,7 +567,7 @@ class Allocation {
     std::vector< PointerEquality *> equalityList;
 
     /// @brief The mapping of allocations/addresses to stored value
-    std::vector< StorageCell *> storesList;
+    unordered_map<Allocation *, VersionedValue *> storesList;
 
     /// @brief Flow relations from one value to another
     std::vector<FlowsTo *> flowsToList;
@@ -613,7 +620,7 @@ class Allocation {
     std::vector<Allocation *>
     resolveAllocationTransitively(VersionedValue *value);
 
-    std::vector<VersionedValue *> stores(Allocation *allocation) const;
+    std::vector<VersionedValue *> stores(Allocation *allocation);
 
     /// @brief All values that flows to the target in one step, local
     /// to the current dependency / interpolation tree node
@@ -671,11 +678,11 @@ class Allocation {
 
     std::map<llvm::Value *, ref<Expr> >
     getSingletonExpressions(std::vector<const Array *> &replacements,
-                            bool coreOnly) const;
+                            bool coreOnly);
 
     std::map<llvm::Value *, std::vector<ref<Expr> > >
     getCompositeExpressions(std::vector<const Array *> &replacements,
-                            bool coreOnly) const;
+                            bool coreOnly);
 
     void bindCallArguments(llvm::Instruction *instr,
                            std::vector<ref<Expr> > &arguments);

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -567,9 +567,9 @@ class Allocation {
     std::vector< PointerEquality *> equalityList;
 
     /// @brief The mapping of allocations/addresses to stored value
-    unordered_map<Allocation *, std::vector<VersionedValue *> > storesList;
+    std::multimap<Allocation *, VersionedValue *> storesList;
 
-    unordered_map<VersionedValue *, Allocation *> storageOfAlloc;
+    // unordered_map<VersionedValue *, Allocation *> storageOfAlloc;
 
     /// @brief Flow relations from one value to another
     std::vector<FlowsTo *> flowsToList;


### PR DESCRIPTION
@domainexpert  storesList field vector is changed into `unordered_map` because in `Dependency.cpp` it iterates to find the suitable allocation so if we change it to `unordered_map` it become `[allocation, VersionedValue] `so we just need to find the key allocation, and get the corresponding `VersionedValue`.

The first attempt is change vector into map at optimize branch. However, it didn't improved much mainly because `std::map` also requires `O(log n)` to search the key. So, the second attempt is to use `unordered_map` which has average constant time `O(1)` for searching in collection.

This is the experiment results : [here](https://docs.google.com/document/d/1VWmnCJuKE6ImdtTNJDPP-z7QOdLt3lkwxQ54oHkOtyA/edit?usp=sharing)

I tried for tr examples that doesn't require max-time configuration when executed. For all 3 examples, this PR able to reduce around 40% of execution times.