### PR TITLE
Replacement of Field Insensitivity with Concrete Addresses

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -443,6 +443,7 @@ std::vector<Allocation *> Dependency::getAllVersionedAllocations() const {
 std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
 Dependency::getStoredExpressions(std::vector<const Array *> &replacements,
                                  bool coreOnly) const {
+  llvm::errs() << "RETRIEVING ALLOCATIONS:\n";
   std::vector<Allocation *> allAlloc = getAllVersionedAllocations();
   ConcreteStore concreteStore;
   SymbolicStore symbolicStore;
@@ -463,6 +464,8 @@ Dependency::getStoredExpressions(std::vector<const Array *> &replacements,
       VersionedValue *v = stored.at(0);
 
       if ((*allocIter)->hasConstantAddress()) {
+        llvm::errs() << "ALLOCATION HAS CONSTANT ADDRESS\n";
+        (*allocIter)->dump();
         if (!coreOnly) {
           ref<Expr> expr = v->getExpression();
           llvm::Value *llvmAlloc = (*allocIter)->getSite();
@@ -484,6 +487,8 @@ Dependency::getStoredExpressions(std::vector<const Array *> &replacements,
           }
         }
       } else {
+        llvm::errs() << "ALLOCATION HAS SYMBOLIC ADDRESS\n";
+        (*allocIter)->dump();
         ref<Expr> address = (*allocIter)->getAddress();
         if (!coreOnly) {
           ref<Expr> expr = v->getExpression();

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -163,6 +163,8 @@ void VersionedAllocation::print(llvm::raw_ostream &stream) const {
     stream << "(I)";
   stream << "[";
   site->print(stream);
+  stream << ":";
+  address->print(stream);
   stream << "]#" << reinterpret_cast<uintptr_t>(this);
 }
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -1,4 +1,4 @@
-//===-- Dependency.h - Field-insensitive dependency -------------*- C++ -*-===//
+//===-- Dependency.h - Memory allocation dependency -------------*- C++ -*-===//
 //
 //               The Tracer-X KLEE Symbolic Virtual Machine
 //
@@ -93,8 +93,6 @@ class Allocation {
     bool hasConstantAddress() { return llvm::isa<ConstantExpr>(address.get()); }
 
     uint64_t getUIntAddress() {
-      llvm::errs() << "ADDRESS: ";
-      address->dump();
       return llvm::dyn_cast<ConstantExpr>(address.get())->getZExtValue();
     }
 
@@ -471,6 +469,12 @@ class Allocation {
   class Dependency {
 
   public:
+    typedef std::pair<ref<Expr>, ref<Expr> > AddressValuePair;
+    typedef std::map<uint64_t, AddressValuePair> ConcreteStoreMap;
+    typedef std::vector<AddressValuePair> SymbolicStoreMap;
+    typedef std::map<llvm::Value *, ConcreteStoreMap> ConcreteStore;
+    typedef std::map<llvm::Value *, SymbolicStoreMap> SymbolicStore;
+
     class Util {
 
     public:
@@ -610,8 +614,7 @@ class Allocation {
     /// @brief Abstract dependency state transition with argument(s)
     void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
 
-    std::pair<std::map<uint64_t, ref<Expr> >,
-              std::map<llvm::Value *, std::pair<ref<Expr>, ref<Expr> > > >
+    std::pair<ConcreteStore, SymbolicStore>
     getStoredExpressions(std::vector<const Array *> &replacements,
                          bool coreOnly) const;
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -250,9 +250,11 @@ class Allocation {
     class AllocationNode {
       Allocation *allocation;
       std::vector<AllocationNode *> ancestors;
+      uint64_t level;
 
     public:
-      AllocationNode(Allocation *allocation) : allocation(allocation) {
+      AllocationNode(Allocation *allocation, uint64_t _level)
+          : allocation(allocation), level(_level) {
         allocation->setAsCore();
       }
 
@@ -265,14 +267,9 @@ class Allocation {
         ancestors.push_back(node);
       }
 
-      bool isCurrentParent(AllocationNode *node) {
-        if (std::find(ancestors.begin(), ancestors.end(), node) ==
-            ancestors.end())
-          return false;
-        return true;
-      }
-
       std::vector<AllocationNode *> getParents() const { return ancestors; }
+
+      uint64_t getLevel() const { return level; }
     };
 
     std::vector<AllocationNode *> sinks;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -90,7 +90,11 @@ class Allocation {
 
     virtual void print(llvm::raw_ostream& stream) const;
 
+    bool hasConstantAddress() { return llvm::isa<ConstantExpr>(address.get()); }
+
     uint64_t getUIntAddress() {
+      llvm::errs() << "ADDRESS: ";
+      address->dump();
       return llvm::dyn_cast<ConstantExpr>(address.get())->getZExtValue();
     }
 
@@ -496,10 +500,10 @@ class Allocation {
     /// @brief Equality of value to address
     std::vector< PointerEquality *> equalityList;
 
-    /// @brief The mapping of allocations/addresses to stored singleton value
-    std::map<Allocation *, VersionedValue *> storesSingletonMap;
+    /// @brief The mapping of allocations/addresses to stored value
+    std::map<Allocation *, VersionedValue *> storesMap;
 
-    /// @brief Store the inverse map of both storesSingletonMap
+    /// @brief Store the inverse map of both storesMap
     std::map<VersionedValue *, std::vector<Allocation *> > storageOfMap;
 
     /// @brief Flow relations from one value to another
@@ -606,9 +610,10 @@ class Allocation {
     /// @brief Abstract dependency state transition with argument(s)
     void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
 
-    std::map<uint64_t, ref<Expr> >
-    getSingletonExpressions(std::vector<const Array *> &replacements,
-                            bool coreOnly) const;
+    std::pair<std::map<uint64_t, ref<Expr> >,
+              std::map<llvm::Value *, std::pair<ref<Expr>, ref<Expr> > > >
+    getStoredExpressions(std::vector<const Array *> &replacements,
+                         bool coreOnly) const;
 
     void bindCallArguments(llvm::Instruction *instr,
                            std::vector<ref<Expr> > &arguments);

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -282,6 +282,12 @@ class Allocation {
                std::vector<AllocationNode *> &printed,
                const unsigned tabNum) const;
 
+    /// consumeSinkNode - Given an allocation, delete all sinks having such
+    /// allocation, and replace them as sinks with their parents.
+    ///
+    /// \param The allocation to match a sink node with.
+    void consumeSinkNode(Allocation *allocation);
+
   public:
     AllocationGraph() {}
 
@@ -300,15 +306,17 @@ class Allocation {
 
     void addNewEdge(Allocation *source, Allocation *target);
 
-    void consumeSinkNode(Allocation *allocation);
+    std::set<Allocation *> getSinkAllocations() const;
 
-    std::vector<Allocation *> getSinkAllocations() const;
-
-    std::vector<Allocation *>
+    std::set<Allocation *>
     getSinksWithAllocations(std::vector<Allocation *> valuesList) const;
 
-    void
-    consumeNodesWithAllocations(std::vector<Allocation *> versionedAllocations);
+    /// consumeNodesWithAllocations - Given a set of allocations, delete all
+    /// sinks having an allocation in the set, and replace them as sinks with
+    /// their parents.
+    ///
+    /// \param The allocation to match the sink nodes with.
+    void consumeSinksWithAllocations(std::vector<Allocation *> allocationsList);
 
     void dump() const {
       this->print(llvm::errs());
@@ -519,7 +527,7 @@ class Allocation {
 
     /// @brief allocations of this node and its ancestors
     /// that are needed for the core and dominates other allocations.
-    std::vector<Allocation *> coreAllocations;
+    std::set<Allocation *> coreAllocations;
 
     /// @brief the basic block of the last-executed instruction
     llvm::BasicBlock *incomingBlock;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2858,13 +2858,13 @@ void Executor::run(ExecutionState &initialState) {
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
 
-      // llvm::errs() << "\nCurrent state:\n";
-      // processTree->dump();
-      // interpTree->dump();
-      // state.itreeNode->dump();
-      // llvm::errs() << "------------------- Executing New Instruction "
-      //                 "-----------------------\n";
-      // state.pc->inst->dump();
+      llvm::errs() << "\nCurrent state:\n";
+      processTree->dump();
+      interpTree->dump();
+      state.itreeNode->dump();
+      llvm::errs() << "------------------- Executing New Instruction "
+                      "-----------------------\n";
+      state.pc->inst->dump();
     }
 
     if (INTERPOLATION_ENABLED && interpTree->checkCurrentStateSubsumption(

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2858,13 +2858,13 @@ void Executor::run(ExecutionState &initialState) {
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
 
-      llvm::errs() << "\nCurrent state:\n";
-      processTree->dump();
-      interpTree->dump();
-      state.itreeNode->dump();
-      llvm::errs() << "------------------- Executing New Instruction "
-                      "-----------------------\n";
-      state.pc->inst->dump();
+      // llvm::errs() << "\nCurrent state:\n";
+      // processTree->dump();
+      // interpTree->dump();
+      // state.itreeNode->dump();
+      // llvm::errs() << "------------------- Executing New Instruction "
+      //                 "-----------------------\n";
+      // state.pc->inst->dump();
     }
 
     if (INTERPOLATION_ENABLED && interpTree->checkCurrentStateSubsumption(

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1595,6 +1595,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   // g->dump();
 
   // We mark memory allocations needed for the unsatisfiabilty core
+  llvm::errs()
+      << "SubsumptionTableEntry::subsumed: CALLING computeCoreAllocations\n";
   state.itreeNode->computeCoreAllocations(g);
 
   delete g; // Delete the AllocationGraph object
@@ -1860,6 +1862,7 @@ void ITree::markPathCondition(ExecutionState &state, TimingSolver *solver) {
   // g->dump();
 
   // Compute memory allocations needed by the unsatisfiability core
+  llvm::errs() << "ITree::markPathCondition: CALLING computeCoreAllocations\n";
   currentINode->computeCoreAllocations(g);
 
   delete g; // Delete the AllocationGraph object

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1267,10 +1267,6 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
 
 bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
                                      ExecutionState &state, double timeout) {
-
-  llvm::errs() << "CHECK SUBSUMPTION WITH TABLE ENTRY: ";
-  this->dump();
-
   // Quick check for subsumption in case the interpolant is empty
   if (empty())
     return true;
@@ -1298,10 +1294,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
         stateSymbolicAddressStore[*it1];
 
     // If the current state does not constrain the same base, subsumption fails.
-    if (rhsConcreteMap.empty() && rhsSymbolicMap.empty()) {
-      llvm::errs() << "SUBSUMPTION NOT HOLDING 1\n";
+    if (rhsConcreteMap.empty() && rhsSymbolicMap.empty())
       return false;
-    }
 
     for (Dependency::ConcreteStoreMap::const_iterator
              it2 = lhsConcreteMap.begin(),
@@ -1311,10 +1305,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
       // The address is not constrained by the current state, therefore
       // the current state is incomparable to the stored interpolant,
       // and we therefore fail the subsumption.
-      if (!rhsConcreteMap.count(it2->first)) {
-        llvm::errs() << "SUBSUMPTION NOT HOLDING 2\n";
+      if (!rhsConcreteMap.count(it2->first))
         return false;
-      }
 
       const Dependency::AddressValuePair rhsConcrete =
           rhsConcreteMap.at(it2->first);
@@ -1442,17 +1434,15 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
 
   if (!existentials.empty()) {
     ref<Expr> existsExpr = ExistsExpr::create(existentials, query);
-    llvm::errs() << "Before simplification:\n";
-    ExprPPrinter::printQuery(llvm::errs(), state.constraints, existsExpr);
+    // llvm::errs() << "Before simplification:\n";
+    // ExprPPrinter::printQuery(llvm::errs(), state.constraints, existsExpr);
     query = simplifyExistsExpr(existsExpr, queryHasNoFreeVariables);
   }
 
   // If query simplification result was false, we quickly fail without calling
   // the solver
-  if (query->isFalse()) {
-    llvm::errs() << "SUBSUMPTION NOT HOLDING 3\n";
+  if (query->isFalse())
     return false;
-  }
 
   bool success = false;
 
@@ -1486,8 +1476,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
         ref<Expr> falseExpr = ConstantExpr::alloc(0, Expr::Bool);
         constraints.addConstraint(EqExpr::alloc(falseExpr, query->getKid(0)));
 
-        llvm::errs() << "Querying for satisfiability check:\n";
-        ExprPPrinter::printQuery(llvm::errs(), constraints, falseExpr);
+        // llvm::errs() << "Querying for satisfiability check:\n";
+        // ExprPPrinter::printQuery(llvm::errs(), constraints, falseExpr);
 
         actualSolverCallTimer.start();
         success = z3solver->getValue(Query(constraints, falseExpr), tmpExpr);
@@ -1497,8 +1487,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
         result = success ? Solver::True : Solver::Unknown;
 
       } else {
-        llvm::errs() << "Querying for subsumption check:\n";
-        ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+        // llvm::errs() << "Querying for subsumption check:\n";
+        // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
 
         actualSolverCallTimer.start();
         success = z3solver->directComputeValidity(
@@ -1538,7 +1528,6 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   } else {
     if (query->isTrue())
       return true;
-    llvm::errs() << "SUBSUMPTION NOT HOLDING 4\n";
     return false;
   }
 
@@ -1574,7 +1563,6 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
     if (z3solver)
       delete z3solver;
 
-    llvm::errs() << "SUBSUMPTION NOT HOLDING 5\n";
     return false;
   }
 
@@ -1595,8 +1583,6 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   // g->dump();
 
   // We mark memory allocations needed for the unsatisfiabilty core
-  llvm::errs()
-      << "SubsumptionTableEntry::subsumed: CALLING computeCoreAllocations\n";
   state.itreeNode->computeCoreAllocations(g);
 
   delete g; // Delete the AllocationGraph object
@@ -1862,7 +1848,6 @@ void ITree::markPathCondition(ExecutionState &state, TimingSolver *solver) {
   // g->dump();
 
   // Compute memory allocations needed by the unsatisfiability core
-  llvm::errs() << "ITree::markPathCondition: CALLING computeCoreAllocations\n";
   currentINode->computeCoreAllocations(g);
 
   delete g; // Delete the AllocationGraph object

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -493,8 +493,8 @@ class ITreeNode {
   static StatTimer executeTimer;
   static StatTimer bindCallArgumentsTimer;
   static StatTimer popAbstractDependencyFrameTimer;
-  static StatTimer getConcreteAddressExpressionsTimer;
-  static StatTimer getConcreteAddressCoreExpressionsTimer;
+  static StatTimer getStoredExpressionsTimer;
+  static StatTimer getStoredCoreExpressionsTimer;
   static StatTimer computeCoreAllocationsTimer;
 
 private:

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -349,9 +349,14 @@ class SubsumptionTableEntry {
 
   ref<Expr> interpolant;
 
-  std::map<uint64_t, ref<Expr> > singletonStore;
+  std::map<uint64_t, ref<Expr> > concreteAddressStore;
 
-  std::vector<uint64_t> singletonStoreKeys;
+  std::vector<uint64_t> concreteAddressStoreKeys;
+
+  std::map<llvm::Value *, std::pair<ref<Expr>, ref<Expr> > >
+  symbolicAddressStore;
+
+  std::vector<llvm::Value *> symbolicAddressStoreKeys;
 
   std::vector<const Array *> existentials;
 
@@ -387,7 +392,9 @@ class SubsumptionTableEntry {
   static ref<Expr> getSubstitution(ref<Expr> equalities,
                                    std::map<ref<Expr>, ref<Expr> > &map);
 
-  bool empty() { return !interpolant.get() && singletonStoreKeys.empty(); }
+  bool empty() {
+    return !interpolant.get() && concreteAddressStoreKeys.empty();
+  }
 
   /// @brief for printing method running time statistics
   static void printStat(llvm::raw_ostream &stream);
@@ -487,8 +494,8 @@ class ITreeNode {
   static StatTimer executeTimer;
   static StatTimer bindCallArgumentsTimer;
   static StatTimer popAbstractDependencyFrameTimer;
-  static StatTimer getSingletonExpressionsTimer;
-  static StatTimer getSingletonCoreExpressionsTimer;
+  static StatTimer getConcreteAddressExpressionsTimer;
+  static StatTimer getConcreteAddressCoreExpressionsTimer;
   static StatTimer computeCoreAllocationsTimer;
 
 private:
@@ -541,10 +548,13 @@ public:
   void popAbstractDependencyFrame(llvm::CallInst *site, llvm::Instruction *inst,
                                   ref<Expr> returnValue);
 
-  std::map<uint64_t, ref<Expr> > getSingletonExpressions() const;
+  std::pair<std::map<uint64_t, ref<Expr> >,
+            std::map<llvm::Value *, std::pair<ref<Expr>, ref<Expr> > > >
+  getStoredExpressions() const;
 
-  std::map<uint64_t, ref<Expr> >
-  getSingletonCoreExpressions(std::vector<const Array *> &replacements) const;
+  std::pair<std::map<uint64_t, ref<Expr> >,
+            std::map<llvm::Value *, std::pair<ref<Expr>, ref<Expr> > > >
+  getStoredCoreExpressions(std::vector<const Array *> &replacements) const;
 
   void computeCoreAllocations(AllocationGraph *g);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -349,12 +349,11 @@ class SubsumptionTableEntry {
 
   ref<Expr> interpolant;
 
-  std::map<uint64_t, ref<Expr> > concreteAddressStore;
+  Dependency::ConcreteStore concreteAddressStore;
 
-  std::vector<uint64_t> concreteAddressStoreKeys;
+  std::vector<llvm::Value *> concreteAddressStoreKeys;
 
-  std::map<llvm::Value *, std::pair<ref<Expr>, ref<Expr> > >
-  symbolicAddressStore;
+  Dependency::SymbolicStore symbolicAddressStore;
 
   std::vector<llvm::Value *> symbolicAddressStoreKeys;
 
@@ -548,12 +547,10 @@ public:
   void popAbstractDependencyFrame(llvm::CallInst *site, llvm::Instruction *inst,
                                   ref<Expr> returnValue);
 
-  std::pair<std::map<uint64_t, ref<Expr> >,
-            std::map<llvm::Value *, std::pair<ref<Expr>, ref<Expr> > > >
+  std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   getStoredExpressions() const;
 
-  std::pair<std::map<uint64_t, ref<Expr> >,
-            std::map<llvm::Value *, std::pair<ref<Expr>, ref<Expr> > > >
+  std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   getStoredCoreExpressions(std::vector<const Array *> &replacements) const;
 
   void computeCoreAllocations(AllocationGraph *g);

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -349,13 +349,9 @@ class SubsumptionTableEntry {
 
   ref<Expr> interpolant;
 
-  std::map<llvm::Value *, ref<Expr> > singletonStore;
+  std::map<uint64_t, ref<Expr> > singletonStore;
 
-  std::vector<llvm::Value *> singletonStoreKeys;
-
-  std::map<llvm::Value *, std::vector<ref<Expr> > > compositeStore;
-
-  std::vector<llvm::Value *> compositeStoreKeys;
+  std::vector<uint64_t> singletonStoreKeys;
 
   std::vector<const Array *> existentials;
 
@@ -391,10 +387,7 @@ class SubsumptionTableEntry {
   static ref<Expr> getSubstitution(ref<Expr> equalities,
                                    std::map<ref<Expr>, ref<Expr> > &map);
 
-  bool empty() {
-    return !interpolant.get() && singletonStoreKeys.empty() &&
-           compositeStoreKeys.empty();
-  }
+  bool empty() { return !interpolant.get() && singletonStoreKeys.empty(); }
 
   /// @brief for printing method running time statistics
   static void printStat(llvm::raw_ostream &stream);
@@ -495,9 +488,7 @@ class ITreeNode {
   static StatTimer bindCallArgumentsTimer;
   static StatTimer popAbstractDependencyFrameTimer;
   static StatTimer getSingletonExpressionsTimer;
-  static StatTimer getCompositeExpressionsTimer;
   static StatTimer getSingletonCoreExpressionsTimer;
-  static StatTimer getCompositeCoreExpressionsTimer;
   static StatTimer computeCoreAllocationsTimer;
 
 private:
@@ -550,16 +541,10 @@ public:
   void popAbstractDependencyFrame(llvm::CallInst *site, llvm::Instruction *inst,
                                   ref<Expr> returnValue);
 
-  std::map<llvm::Value *, ref<Expr> > getSingletonExpressions() const;
+  std::map<uint64_t, ref<Expr> > getSingletonExpressions() const;
 
-  std::map<llvm::Value *, std::vector<ref<Expr> > >
-  getCompositeExpressions() const;
-
-  std::map<llvm::Value *, ref<Expr> >
+  std::map<uint64_t, ref<Expr> >
   getSingletonCoreExpressions(std::vector<const Array *> &replacements) const;
-
-  std::map<llvm::Value *, std::vector<ref<Expr> > >
-  getCompositeCoreExpressions(std::vector<const Array *> &replacements) const;
 
   void computeCoreAllocations(AllocationGraph *g);
 


### PR DESCRIPTION
This is a resolution of issue #42 . Previous field-insensitive flow dependency tracking to compute unsatisfiability core's dependent-upon allocations loses precision due to field-insensitivity of load and store for composite allocations. Changed the dependency computation mechanism to use concrete load/store addresses provided by KLEE as much as possible, although on small occassions the addresses are symbolic, in which case a logic formula similar to *ite* expression is constructed in subsumption checks. This results in simpler-to-solve and *more importantly* correct formulas in subsumption checks, and it enhances the running speed very significantly. This PR is not fully tested, and therefore incomplete, which preferably should not be allowed, but this is a special occassion as I will be away on a week of vacation. Several things to check include:
1. The number of subsumptions for `klee-examples/basic` are different with the `master` branch. The differences are possibly because the new approach is correct, whereas the `master` branch constructed the wrong formula in subsumption checks, due to matching only base of allocations for stored memory values instead of matching the exact index. However, this has to be ascertained.
2. The run on large examples (bubble9, tr and its siblings, Regexp, echo, etc.). How running times are affected or whether there are instabilities or not.
