### PR TITLE
Added Subsumption Edge Numbering In the Interpolation Tree Graph

### DIFF
--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -195,11 +195,31 @@ class SearchTree {
     }
   };
 
+  class NumberedEdge {
+    SearchTree::Node *source;
+    SearchTree::Node *destination;
+    unsigned long number;
+
+  public:
+    NumberedEdge(SearchTree::Node *_source, SearchTree::Node *_destination,
+                 unsigned long _number)
+        : source(_source), destination(_destination), number(_number) {}
+
+    ~NumberedEdge() {
+      delete source;
+      delete destination;
+    }
+
+    std::string render() const;
+  };
+
   SearchTree::Node *root;
   std::map<ITreeNode *, SearchTree::Node *> itreeNodeMap;
   std::map<SubsumptionTableEntry *, SearchTree::Node *> tableEntryMap;
-  std::map<SearchTree::Node *, SearchTree::Node *> subsumptionEdges;
+  std::vector<SearchTree::NumberedEdge *> subsumptionEdges;
   std::map<PathCondition *, SearchTree::Node *> pathConditionMap;
+
+  unsigned long subsumptionEdgeNumber;
 
   static std::string recurseRender(const SearchTree::Node *node);
 


### PR DESCRIPTION
The interpolation tree graph is the `tree.pdf` generated in the KLEE output directory after a run. Numbering the subsumption edges eases debugging especially when matching the edges with the debug log to check the correctness of the subsumption.