### PR TITLE
Fix to Issues in Handling of Symbolic Addresses

### DIFF
--- a/include/klee/Expr.h
+++ b/include/klee/Expr.h
@@ -531,16 +531,16 @@ public:
 
 class ExistsExpr : public NonConstantExpr {
 public:
-  std::vector<const Array *> variables;
+  std::set<const Array *> variables;
   ref<Expr> body;
 
-  static ref<Expr> alloc(std::vector<const Array *> variables, ref<Expr> body) {
+  static ref<Expr> alloc(std::set<const Array *> variables, ref<Expr> body) {
     ref<Expr> r(new ExistsExpr(variables, body));
     r->computeHash();
     return r;
   }
 
-  static ref<Expr> create(std::vector<const Array *> variables, ref<Expr> body);
+  static ref<Expr> create(std::set<const Array *> variables, ref<Expr> body);
 
   Width getWidth() const { return Bool; }
 
@@ -564,7 +564,7 @@ public:
   static bool classof(const ExistsExpr *E) { return true; }
 
 private:
-  ExistsExpr(std::vector<const Array *> variables, ref<Expr> body)
+  ExistsExpr(std::set<const Array *> variables, ref<Expr> body)
       : variables(variables), body(body) {}
 };
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -336,14 +336,14 @@ std::set<Allocation *> AllocationGraph::getSinkAllocations() const {
 }
 
 std::set<Allocation *> AllocationGraph::getSinksWithAllocations(
-    std::vector<Allocation *> valuesList) const {
+    std::vector<Allocation *> allocationsList) const {
   std::set<Allocation *> sinkAllocations;
 
   for (std::vector<AllocationNode *>::const_iterator it = sinks.begin(),
                                                      itEnd = sinks.end();
        it != itEnd; ++it) {
-    if (std::find(valuesList.begin(), valuesList.end(),
-                  (*it)->getAllocation()) != valuesList.end())
+    if (std::find(allocationsList.begin(), allocationsList.end(),
+                  (*it)->getAllocation()) != allocationsList.end())
       sinkAllocations.insert((*it)->getAllocation());
   }
 
@@ -435,11 +435,19 @@ Allocation *Dependency::getNewAllocationVersion(llvm::Value *allocation,
   return getInitialAllocation(allocation, address);
 }
 
-std::vector<Allocation *> Dependency::getAllVersionedAllocations() const {
-  std::vector<Allocation *> allAlloc = versionedAllocationsList;
+std::vector<Allocation *>
+Dependency::getAllVersionedAllocations(bool coreOnly) const {
+  std::vector<Allocation *> allAlloc;
+
+  if (coreOnly)
+    std::copy(coreAllocations.begin(), coreAllocations.end(),
+              std::back_inserter(allAlloc));
+  else
+    allAlloc = versionedAllocationsList;
+
   if (parentDependency) {
     std::vector<Allocation *> parentVersionedAllocations =
-        parentDependency->getAllVersionedAllocations();
+        parentDependency->getAllVersionedAllocations(coreOnly);
     allAlloc.insert(allAlloc.begin(), parentVersionedAllocations.begin(),
                     parentVersionedAllocations.end());
   }
@@ -449,27 +457,14 @@ std::vector<Allocation *> Dependency::getAllVersionedAllocations() const {
 std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
 Dependency::getStoredExpressions(std::set<const Array *> &replacements,
                                  bool coreOnly) const {
-  std::vector<Allocation *> allAlloc = getAllVersionedAllocations();
+  std::vector<Allocation *> allAlloc = getAllVersionedAllocations(coreOnly);
   ConcreteStore concreteStore;
   SymbolicStore symbolicStore;
 
   for (std::vector<Allocation *>::iterator allocIter = allAlloc.begin(),
                                            allocIterEnd = allAlloc.end();
        allocIter != allocIterEnd; ++allocIter) {
-    if (coreOnly && std::find(coreAllocations.begin(), coreAllocations.end(),
-                              *allocIter) == coreAllocations.end())
-      continue;
-
     std::vector<VersionedValue *> stored = stores(*allocIter);
-
-    llvm::errs() << "ALLOCATION: ";
-    (*allocIter)->dump();
-
-    llvm::errs() << "STORED VALUES:\n";
-    for (std::vector<VersionedValue *>::iterator itx = stored.begin(), itxEnd = stored.end(); itx != itxEnd; ++itx) {
-	(*itx)->dump();
-    }
-    llvm::errs() << "END OF STORED VALUES\n";
 
     // We should only get the latest value and no other
     assert(stored.size() <= 1);
@@ -478,11 +473,8 @@ Dependency::getStoredExpressions(std::set<const Array *> &replacements,
       VersionedValue *v = stored.at(0);
 
       if ((*allocIter)->hasConstantAddress()) {
-	llvm::errs() << "HAS CONSTANT ADDRESS\n";
         if (!coreOnly) {
           ref<Expr> expr = v->getExpression();
-          llvm::errs() << "VALUE IS: ";
-          expr->dump();
           llvm::Value *llvmAlloc = (*allocIter)->getSite();
           uint64_t uintAddress = (*allocIter)->getUIntAddress();
           ref<Expr> address = (*allocIter)->getAddress();
@@ -490,8 +482,6 @@ Dependency::getStoredExpressions(std::set<const Array *> &replacements,
               AddressValuePair(address, expr);
         } else if (v->isCore()) {
           ref<Expr> expr = v->getExpression();
-          llvm::errs() << "VALUE IS: ";
-          expr->dump();
           llvm::Value *base = (*allocIter)->getSite();
           uint64_t uintAddress = (*allocIter)->getUIntAddress();
           ref<Expr> address = (*allocIter)->getAddress();
@@ -504,7 +494,6 @@ Dependency::getStoredExpressions(std::set<const Array *> &replacements,
           }
         }
       } else {
-	llvm::errs() << "HAS NON-CONSTANT ADDRESS\n";
         ref<Expr> address = (*allocIter)->getAddress();
         if (!coreOnly) {
           ref<Expr> expr = v->getExpression();

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -44,7 +44,7 @@ class ShadowArray {
   static std::map<const Array *, const Array *> shadowArray;
 
   static UpdateNode *getShadowUpdate(const UpdateNode *chain,
-                                     std::vector<const Array *> &replacements);
+                                     std::set<const Array *> &replacements);
 
 public:
   static ref<Expr> createBinaryOfSameKind(ref<Expr> originalExpr,
@@ -52,8 +52,8 @@ public:
 
   static void addShadowArrayMap(const Array *source, const Array *target);
 
-  static ref<Expr>
-  getShadowExpression(ref<Expr> expr, std::vector<const Array *> &replacements);
+  static ref<Expr> getShadowExpression(ref<Expr> expr,
+                                       std::set<const Array *> &replacements);
 
   static std::string getShadowName(std::string name) {
     return "__shadow__" + name;
@@ -620,7 +620,7 @@ class Allocation {
     void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
 
     std::pair<ConcreteStore, SymbolicStore>
-    getStoredExpressions(std::vector<const Array *> &replacements,
+    getStoredExpressions(std::set<const Array *> &replacements,
                          bool coreOnly) const;
 
     void bindCallArguments(llvm::Instruction *instr,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -538,7 +538,8 @@ class Allocation {
     Allocation *getNewAllocationVersion(llvm::Value *allocation,
                                         ref<Expr> &address);
 
-    std::vector<Allocation *> getAllVersionedAllocations() const;
+    std::vector<Allocation *> getAllVersionedAllocations(bool coreOnly =
+                                                             false) const;
 
     /// @brief Gets the latest version of the allocation.
     Allocation *getLatestAllocation(llvm::Value *allocation,

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2858,18 +2858,17 @@ void Executor::run(ExecutionState &initialState) {
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
 
-      llvm::errs() << "\nCurrent state:\n";
-      processTree->dump();
-      interpTree->dump();
-      state.itreeNode->dump();
-      llvm::errs() << "------------------- Executing New Instruction "
-                      "-----------------------\n";
-      state.pc->inst->dump();
+      // llvm::errs() << "\nCurrent state:\n";
+      // processTree->dump();
+      // interpTree->dump();
+      // state.itreeNode->dump();
+      // llvm::errs() << "------------------- Executing New Instruction "
+      //                 "-----------------------\n";
+      // state.pc->inst->dump();
     }
 
     if (INTERPOLATION_ENABLED &&
         interpTree->subsumptionCheck(solver, state, coreSolverTimeout)) {
-      llvm::errs() << "STATE SUBSUMED\n";
       terminateStateOnSubsumption(state);
     } else
       {

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2858,17 +2858,18 @@ void Executor::run(ExecutionState &initialState) {
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
 
-      // llvm::errs() << "\nCurrent state:\n";
-      // processTree->dump();
-      // interpTree->dump();
-      // state.itreeNode->dump();
-      // llvm::errs() << "------------------- Executing New Instruction "
-      //                 "-----------------------\n";
-      // state.pc->inst->dump();
+      llvm::errs() << "\nCurrent state:\n";
+      processTree->dump();
+      interpTree->dump();
+      state.itreeNode->dump();
+      llvm::errs() << "------------------- Executing New Instruction "
+                      "-----------------------\n";
+      state.pc->inst->dump();
     }
 
     if (INTERPOLATION_ENABLED &&
         interpTree->subsumptionCheck(solver, state, coreSolverTimeout)) {
+      llvm::errs() << "STATE SUBSUMED\n";
       terminateStateOnSubsumption(state);
     } else
       {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -847,15 +847,6 @@ SubsumptionTableEntry::SubsumptionTableEntry(ITreeNode *node)
   for (Dependency::ConcreteStore::iterator it = concreteAddressStore.begin(),
                                            itEnd = concreteAddressStore.end();
        it != itEnd; ++it) {
-
-    llvm::errs() << "  FOUND CONCRETE: ";
-    it->first->dump();
-    for (std::map<uint64_t, Dependency::AddressValuePair>::iterator it1 = it->second.begin(),
-	it1End = it->second.end(); it1 != it1End; ++it1) {
-	llvm::errs() << "    MAPPING:\n";
-	it1->second.first->dump();
-	it1->second.second->dump();
-    }
     concreteAddressStoreKeys.push_back(it->first);
   }
 
@@ -863,15 +854,10 @@ SubsumptionTableEntry::SubsumptionTableEntry(ITreeNode *node)
   for (Dependency::SymbolicStore::iterator it = symbolicAddressStore.begin(),
                                            itEnd = symbolicAddressStore.end();
        it != itEnd; ++it) {
-    llvm::errs() << "  FOUND SYMBOLIC: ";
-    it->first->dump();
     symbolicAddressStoreKeys.push_back(it->first);
   }
 
   existentials = replacements;
-
-  llvm::errs() << "STORED INTERPOLANT: ";
-  this->dump();
 }
 
 SubsumptionTableEntry::~SubsumptionTableEntry() {}
@@ -1485,8 +1471,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
 
   if (!existentials.empty()) {
     ref<Expr> existsExpr = ExistsExpr::create(existentials, query);
-    llvm::errs() << "Before simplification:\n";
-    ExprPPrinter::printQuery(llvm::errs(), state.constraints, existsExpr);
+    // llvm::errs() << "Before simplification:\n";
+    // ExprPPrinter::printQuery(llvm::errs(), state.constraints, existsExpr);
     query = simplifyExistsExpr(existsExpr, queryHasNoFreeVariables);
   }
 
@@ -1505,7 +1491,7 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
     ++checkSolverCount;
 
     if (!existentials.empty() && llvm::isa<ExistsExpr>(query)) {
-      llvm::errs() << "Existentials not empty\n";
+      // llvm::errs() << "Existentials not empty\n";
 
       // Instantiate a new Z3 solver to make sure we use Z3
       // without pre-solving optimizations. It would be nice
@@ -1527,8 +1513,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
         ref<Expr> falseExpr = ConstantExpr::alloc(0, Expr::Bool);
         constraints.addConstraint(EqExpr::alloc(falseExpr, query->getKid(0)));
 
-        llvm::errs() << "Querying for satisfiability check:\n";
-        ExprPPrinter::printQuery(llvm::errs(), constraints, falseExpr);
+        // llvm::errs() << "Querying for satisfiability check:\n";
+        // ExprPPrinter::printQuery(llvm::errs(), constraints, falseExpr);
 
         actualSolverCallTimer.start();
         success = z3solver->getValue(Query(constraints, falseExpr), tmpExpr);
@@ -1538,8 +1524,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
         result = success ? Solver::True : Solver::Unknown;
 
       } else {
-        llvm::errs() << "Querying for subsumption check:\n";
-        ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+        // llvm::errs() << "Querying for subsumption check:\n";
+        // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
 
         actualSolverCallTimer.start();
         success = z3solver->directComputeValidity(
@@ -1556,10 +1542,10 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
       z3solver->setCoreSolverTimeout(0);
 
     } else {
-      llvm::errs() << "No existential\n";
+      // llvm::errs() << "No existential\n";
 
-      llvm::errs() << "Querying for subsumption check:\n";
-      ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+      // llvm::errs() << "Querying for subsumption check:\n";
+      // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
 
       // We call the solver in the standard way if the
       // formula is unquantified.
@@ -1583,7 +1569,7 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   }
 
   if (success && result == Solver::True) {
-    llvm::errs() << "Solver decided validity\n";
+    // llvm::errs() << "Solver decided validity\n";
     std::vector<ref<Expr> > unsatCore;
     if (z3solver) {
       unsatCore = z3solver->getUnsatCore();
@@ -1608,7 +1594,7 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
     // which was eventually called from solver->evaluate
     // is conservative, where it returns Solver::Unknown even in case when
     // invalidity is established by the solver.
-    llvm::errs() << "Solver did not decide validity\n";
+    // llvm::errs() << "Solver did not decide validity\n";
 
     ++checkSolverFailureCount;
     if (z3solver)

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -295,10 +295,13 @@ class PathCondition {
   /// @brief KLEE expression with variables (arrays) replaced by their shadows
   ref<Expr> shadowConstraint;
 
-  /// @brief If shadow consraint had been generated: We generate shadow
-  /// constraint
-  /// on demand only when the constraint is required in an interpolant
+  /// @brief If shadow constraint had been generated: We generate shadow
+  /// constraint on demand only when the constraint is required in an
+  /// interpolant.
   bool shadowed;
+
+  /// @brief The set of bound variables
+  std::set<const Array *> boundVariables;
 
   /// @brief The dependency information for the current
   /// interpolation tree node
@@ -329,7 +332,7 @@ public:
 
   bool isCore() const;
 
-  ref<Expr> packInterpolant(std::vector<const Array *> &replacements);
+  ref<Expr> packInterpolant(std::set<const Array *> &replacements);
 
   void dump();
 
@@ -393,12 +396,12 @@ class SubsumptionTableEntry {
 
   std::vector<llvm::Value *> symbolicAddressStoreKeys;
 
-  std::vector<const Array *> existentials;
+  std::set<const Array *> existentials;
 
-  static bool hasExistentials(std::vector<const Array *> &existentials,
+  static bool hasExistentials(std::set<const Array *> &existentials,
                               ref<Expr> expr);
 
-  static bool hasFree(std::vector<const Array *> &existentials, ref<Expr> expr);
+  static bool hasFree(std::set<const Array *> &existentials, ref<Expr> expr);
 
   static bool containShadowExpr(ref<Expr> expr, ref<Expr> shadowExpr);
 
@@ -570,7 +573,7 @@ private:
 public:
   uintptr_t getNodeId();
 
-  ref<Expr> getInterpolant(std::vector<const Array *> &replacements) const;
+  ref<Expr> getInterpolant(std::set<const Array *> &replacements) const;
 
   void addConstraint(ref<Expr> &constraint, llvm::Value *value);
 
@@ -591,7 +594,7 @@ public:
   getStoredExpressions() const;
 
   std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
-  getStoredCoreExpressions(std::vector<const Array *> &replacements) const;
+  getStoredCoreExpressions(std::set<const Array *> &replacements) const;
 
   void computeCoreAllocations(AllocationGraph *g);
 

--- a/lib/Expr/Expr.cpp
+++ b/lib/Expr/Expr.cpp
@@ -188,8 +188,8 @@ unsigned ConstantExpr::computeHash() {
 
 unsigned ExistsExpr::computeHash() {
   unsigned res = body->hash() * Expr::MAGIC_HASH_CONSTANT;
-  for (std::vector<const Array *>::iterator it = variables.begin(),
-                                            itEnd = variables.end();
+  for (std::set<const Array *>::iterator it = variables.begin(),
+                                         itEnd = variables.end();
        it != itEnd; ++it) {
     res <<= 1;
     res ^= (*it)->hash() * Expr::MAGIC_HASH_CONSTANT;
@@ -486,7 +486,7 @@ ref<ConstantExpr> ConstantExpr::Sge(const ref<ConstantExpr> &RHS) {
 
 /***/
 
-ref<Expr> ExistsExpr::create(std::vector<const Array *> variables,
+ref<Expr> ExistsExpr::create(std::set<const Array *> variables,
                              ref<Expr> body) {
   return alloc(variables, body);
 }

--- a/lib/Expr/ExprPPrinter.cpp
+++ b/lib/Expr/ExprPPrinter.cpp
@@ -289,7 +289,7 @@ private:
 
   void printExists(const ExistsExpr *xe, PrintContext &PC, unsigned indent) {
     PC << "(";
-    for (std::vector<const Array *>::const_iterator
+    for (std::set<const Array *>::const_iterator
              itBegin = xe->variables.begin(),
              itEnd = xe->variables.end(), it = itBegin;
          it != itEnd; ++it) {

--- a/lib/Expr/ExprSMTLIBPrinter.cpp
+++ b/lib/Expr/ExprSMTLIBPrinter.cpp
@@ -413,8 +413,8 @@ void ExprSMTLIBPrinter::printExistsExpr(const ref<ExistsExpr> &e) {
   p->pushIndent();
   printSeperator();
   *p << "(";
-  for (std::vector<const Array *>::iterator it = e->variables.begin(),
-                                            itEnd = e->variables.end();
+  for (std::set<const Array *>::iterator it = e->variables.begin(),
+                                         itEnd = e->variables.end();
        it != itEnd; ++it) {
     *p << (*it)->name;
     printSeperator();

--- a/lib/Solver/Z3Builder.cpp
+++ b/lib/Solver/Z3Builder.cpp
@@ -592,7 +592,7 @@ Z3_ast Z3Builder::getArrayForUpdate(const Array *root,
 }
 
 void
-Z3Builder::pushQuantificationContext(std::vector<const Array *> existentials) {
+Z3Builder::pushQuantificationContext(std::set<const Array *> existentials) {
   quantificationContext =
       new QuantificationContext(ctx, existentials, quantificationContext);
 }
@@ -1047,12 +1047,12 @@ Z3_ast Z3Builder::constructActual(ref<Expr> e, int *width_out) {
 /***/
 
 Z3Builder::QuantificationContext::QuantificationContext(
-    Z3_context _ctx, std::vector<const Array *> _existentials,
+    Z3_context _ctx, std::set<const Array *> _existentials,
     QuantificationContext *_parent)
     : parent(_parent) {
   unsigned index = _existentials.size();
-  for (std::vector<const Array *>::iterator it = _existentials.begin(),
-                                            itEnd = _existentials.end();
+  for (std::set<const Array *>::iterator it = _existentials.begin(),
+                                         itEnd = _existentials.end();
        it != itEnd; ++it) {
     --index;
     Z3_symbol symb = Z3_mk_string_symbol(_ctx, (*it)->name.c_str());

--- a/lib/Solver/Z3Builder.h
+++ b/lib/Solver/Z3Builder.h
@@ -45,7 +45,7 @@ class Z3Builder {
 
   public:
     QuantificationContext(Z3_context _ctx,
-                          std::vector<const Array *> _existentials,
+                          std::set<const Array *> _existentials,
                           QuantificationContext *_parent);
 
     ~QuantificationContext();
@@ -146,7 +146,7 @@ private:
   // Handling of quantification contexts
   QuantificationContext *quantificationContext;
 
-  void pushQuantificationContext(std::vector<const Array *> existentials);
+  void pushQuantificationContext(std::set<const Array *> existentials);
 
   void popQuantificationContext();
 


### PR DESCRIPTION
Comparing memory allocations (representing program state) is important in subsumption checks. Sometimes, however, the allocations are referenced via symbolic (non-constant) address. Test cases in tracer-x/klee-examples#30 exhibit issues with the current handling symbolic addresses, which is fixed in this PR. For the basic examples https://github.com/tracer-x/klee-examples/tree/master/basic , this PR resulted in no loss in error reports (previous: 5, new: the same 5). The number of subsumptions, however differ in 2 examples: `basic/bubble.c` (previous: 6, now: 4) and `basic/regexp_nonrecursive2.c` (previous: 26, now: 27), however, the new 4 subsumptions in bubble.c are more effective in reducing search space than the previous 6, as they succeed earlier in the execution. As a result, the new run only traverses 16 symbolic execution tree nodes, compared the previous run which traversed 20 nodes. For `basic/regexp_nonrecursive2.c`, the 1 extra subsumption in the new run is correct, although there is no reduction in the number of nodes traversed (106). These somehow indicate that this PR results in more successful subsumptions.  `basic/bubble.c` runs about 0.1 seconds faster, however, `scalability/Regexp.c` now runs in 278 s compared to about 14 s previously. Some of the subsumptions that resulted in the previous 14 s running time were probably incorrect, however, I will raise a new issue to check this. 