### PR TITLE
Remove PathConditionMarker and move getStoredExpressions method from subsumed method

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2858,13 +2858,13 @@ void Executor::run(ExecutionState &initialState) {
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
 
-      // llvm::errs() << "\nCurrent state:\n";
-      // processTree->dump();
-      // interpTree->dump();
-      // state.itreeNode->dump();
-      // llvm::errs() << "------------------- Executing New Instruction "
-      //                 "-----------------------\n";
-      // state.pc->inst->dump();
+      //      llvm::errs() << "\nCurrent state:\n";
+      //      processTree->dump();
+      //      interpTree->dump();
+      //      state.itreeNode->dump();
+      //      llvm::errs() << "------------------- Executing New Instruction "
+      //                      "-----------------------\n";
+      //      state.pc->inst->dump();
     }
 
     if (INTERPOLATION_ENABLED &&

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1272,14 +1272,13 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
   return ret;
 }
 
-bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
-                                     ExecutionState &state, double timeout) {
+bool SubsumptionTableEntry::subsumed(
+    TimingSolver *solver, ExecutionState &state, double timeout,
+    const std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
+        storedExpressions) {
   // Quick check for subsumption in case the interpolant is empty
   if (empty())
     return true;
-
-  std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
-  storedExpressions = state.itreeNode->getStoredExpressions();
 
   Dependency::ConcreteStore stateConcreteAddressStore = storedExpressions.first;
 
@@ -1772,10 +1771,14 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
   if (entryList.empty())
     return false;
 
+  std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
+  storedExpressions = state.itreeNode->getStoredExpressions();
+
   for (std::vector<SubsumptionTableEntry *>::iterator it = entryList.begin(),
                                                       itEnd = entryList.end();
        it != itEnd; ++it) {
-    if ((*it)->subsumed(solver, state, timeout)) {
+
+    if ((*it)->subsumed(solver, state, timeout, storedExpressions)) {
       // We mark as subsumed such that the node will not be
       // stored into table (the table already contains a more
       // general entry).

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1272,6 +1272,29 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
   return ret;
 }
 
+void SubsumptionTableEntry::unsatCoreMarking(std::vector<ref<Expr> > unsatCore,
+                                             ExecutionState &state) {
+  // State subsumed, we mark needed constraints on the
+  // path condition.
+  // We create path condition marking structure to mark core constraints
+  std::map<Expr *, PathCondition *> markerMap =
+      state.itreeNode->makeMarkerMap();
+  AllocationGraph *g = new AllocationGraph();
+  for (std::vector<ref<Expr> >::iterator it1 = unsatCore.begin();
+       it1 != unsatCore.end(); it1++) {
+    // FIXME: Sometimes some constraints are not in the PC. This is
+    // because constraints are not properly added at state merge.
+    PathCondition *cond = markerMap[it1->get()];
+    if (cond)
+      cond->setAsCore(g);
+  }
+  // llvm::errs() << "AllocationGraph\n";
+  // g->dump();
+  // We mark memory allocations needed for the unsatisfiabilty core
+  state.itreeNode->computeCoreAllocations(g);
+  delete g; // Delete the AllocationGraph object
+}
+
 bool SubsumptionTableEntry::subsumed(
     TimingSolver *solver, ExecutionState &state, double timeout,
     const std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
@@ -1563,26 +1586,7 @@ bool SubsumptionTableEntry::subsumed(
     // path condition.
 
     // We create path condition marking structure to mark core constraints
-    std::map<Expr *, PathCondition *> markerMap =
-        state.itreeNode->makeMarkerMap();
-
-    AllocationGraph *g = new AllocationGraph();
-    for (std::vector<ref<Expr> >::iterator it1 = unsatCore.begin();
-         it1 != unsatCore.end(); it1++) {
-      // FIXME: Sometimes some constraints are not in the PC. This is
-      // because constraints are not properly added at state merge.
-      PathCondition *cond = markerMap[it1->get()];
-      if (cond)
-        cond->setAsCore(g);
-    }
-
-    // llvm::errs() << "AllocationGraph\n";
-    // g->dump();
-
-    // We mark memory allocations needed for the unsatisfiabilty core
-    state.itreeNode->computeCoreAllocations(g);
-
-    delete g; // Delete the AllocationGraph object
+    unsatCoreMarking(unsatCore, state);
     return true;
   }
     // Here the solver could not decide that the subsumption is valid.

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1956,8 +1956,6 @@ void ITree::dump() { this->print(llvm::errs()); }
 StatTimer ITreeNode::getInterpolantTimer;
 StatTimer ITreeNode::addConstraintTimer;
 StatTimer ITreeNode::splitTimer;
-StatTimer ITreeNode::makeMarkerMapTimer;
-StatTimer ITreeNode::deleteMarkerMapTimer;
 StatTimer ITreeNode::executeTimer;
 StatTimer ITreeNode::bindCallArgumentsTimer;
 StatTimer ITreeNode::popAbstractDependencyFrameTimer;
@@ -1971,10 +1969,6 @@ void ITreeNode::printTimeStat(llvm::raw_ostream &stream) {
   stream << "KLEE: done:     addConstraintTime = " << addConstraintTimer.get() *
                                                           1000 << "\n";
   stream << "KLEE: done:     splitTime = " << splitTimer.get() * 1000 << "\n";
-  stream << "KLEE: done:     makeMarkerMap = " << makeMarkerMapTimer.get() *
-                                                      1000 << "\n";
-  stream << "KLEE: done:     deleteMarkerMap = " << deleteMarkerMapTimer.get() *
-                                                        1000 << "\n";
   stream << "KLEE: done:     execute = " << executeTimer.get() * 1000 << "\n";
   stream << "KLEE: done:     bindCallArguments = "
          << bindCallArgumentsTimer.get() * 1000 << "\n";
@@ -2099,7 +2093,6 @@ void ITreeNode::unsatCoreMarking(std::vector<ref<Expr> > unsatCore,
   // State subsumed, we mark needed constraints on the
   // path condition.
   // We create path condition marking structure to mark core constraints
-  ITreeNode::makeMarkerMapTimer.start();
   std::map<Expr *, PathCondition *> markerMap;
   for (PathCondition *it = pathCondition; it != 0; it = it->cdr()) {
     if (llvm::isa<OrExpr>(it->car().get())) {
@@ -2112,7 +2105,6 @@ void ITreeNode::unsatCoreMarking(std::vector<ref<Expr> > unsatCore,
     }
     markerMap[it->car().get()] = it;
   }
-  ITreeNode::makeMarkerMapTimer.stop();
 
   AllocationGraph *g = new AllocationGraph();
   for (std::vector<ref<Expr> >::iterator it1 = unsatCore.begin();

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -421,6 +421,8 @@ class SubsumptionTableEntry {
 
   /// @brief for printing method running time statistics
   static void printStat(llvm::raw_ostream &stream);
+  void unsatCoreMarking(std::vector<ref<Expr> > unsatCore,
+                        ExecutionState &state);
 
 public:
   const uintptr_t nodeId;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -421,8 +421,6 @@ class SubsumptionTableEntry {
 
   /// @brief for printing method running time statistics
   static void printStat(llvm::raw_ostream &stream);
-  void unsatCoreMarking(std::vector<ref<Expr> > unsatCore,
-                        ExecutionState &state);
 
 public:
   const uintptr_t nodeId;
@@ -581,6 +579,9 @@ public:
 
   std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   getStoredCoreExpressions(std::set<const Array *> &replacements) const;
+
+  void unsatCoreMarking(std::vector<ref<Expr> > unsatCore,
+                        ExecutionState &state);
 
   void computeCoreAllocations(AllocationGraph *g);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -566,8 +566,6 @@ public:
 
   void split(ExecutionState *leftData, ExecutionState *rightData);
 
-  std::map<Expr *, PathCondition *> makeMarkerMap() const;
-
   void bindCallArguments(llvm::Instruction *site,
                          std::vector<ref<Expr> > &arguments);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -339,21 +339,6 @@ public:
   void print(llvm::raw_ostream &stream);
 };
 
-class PathConditionMarker {
-  bool maybeCore;
-
-  PathCondition *pathCondition;
-
-public:
-  PathConditionMarker(PathCondition *pathCondition);
-
-  ~PathConditionMarker();
-
-  void setAsCore(AllocationGraph *g);
-
-  void setAsMaybeCore();
-};
-
 class SubsumptionTableEntry {
   friend class ITree;
 
@@ -579,10 +564,7 @@ public:
 
   void split(ExecutionState *leftData, ExecutionState *rightData);
 
-  std::map<Expr *, PathConditionMarker *> makeMarkerMap() const;
-
-  static void
-  deleteMarkerMap(std::map<Expr *, PathConditionMarker *> &markerMap);
+  std::map<Expr *, PathCondition *> makeMarkerMap() const;
 
   void bindCallArguments(llvm::Instruction *site,
                          std::vector<ref<Expr> > &arguments);

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -429,7 +429,9 @@ public:
 
   ~SubsumptionTableEntry();
 
-  bool subsumed(TimingSolver *solver, ExecutionState &state, double timeout);
+  bool subsumed(
+      TimingSolver *solver, ExecutionState &state, double timeout,
+      std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore> const);
 
   void dump() const;
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -518,8 +518,6 @@ class ITreeNode {
   static StatTimer getInterpolantTimer;
   static StatTimer addConstraintTimer;
   static StatTimer splitTimer;
-  static StatTimer makeMarkerMapTimer;
-  static StatTimer deleteMarkerMapTimer;
   static StatTimer executeTimer;
   static StatTimer bindCallArgumentsTimer;
   static StatTimer popAbstractDependencyFrameTimer;


### PR DESCRIPTION
This PR is related to https://github.com/tracer-x/klee/issues/81. 

The result shows there is execution time improvement for` scalability/regexp` example from 281.09 to 130.75 without affecting subsumption and error rates.

For `bubble` and `tr` group example, execution time performance looks similar with master branch, both subsumption rates does not differ with result from the master branch. I also noticed non-deterministic behavior in `bubble9_unsafe` where the subsumptions can be 2 or 0 at other time.

For `basic example`, the execution time improvement can also be slightly seen in some examples without affecting the number of subsumption and error rates.