### PR TITLE
Add a preSolving method in the subsumed method to takeover simple cases instead of calling the actual solver

### DIFF
--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1321,7 +1321,12 @@ SubsumptionTableEntry::getSimplifiableConjuncts(ref<Expr> conjunction) {
     } else if (llvm::isa<SleExpr>(conjunction.get()) ||
                llvm::isa<SltExpr>(conjunction.get()) ||
                llvm::isa<SgeExpr>(conjunction.get()) ||
-               llvm::isa<SgtExpr>(conjunction.get())) {
+               llvm::isa<SgtExpr>(conjunction.get()) ||
+               llvm::isa<UleExpr>(conjunction.get()) ||
+               llvm::isa<UltExpr>(conjunction.get()) ||
+               llvm::isa<UgeExpr>(conjunction.get()) ||
+               llvm::isa<UgtExpr>(conjunction.get()) ||
+               llvm::isa<NeExpr>(conjunction.get())) {
       conjunctsList.push_back(conjunction);
       conjunction = ConstantExpr::alloc(1, Expr::Bool);
     }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1270,23 +1270,13 @@ bool SubsumptionTableEntry::preSolving(ExecutionState &state, ref<Expr> query) {
 
       ref<Expr> constraintExpr = it1->get();
       ref<Expr> queryExpr = it2->get();
-      // llvm::errs() << "constraint : \n";
-      // constraintExpr->dump();
-      // llvm::errs() << "query : \n";
-      // queryExpr->dump();
+
       if (!constraintExpr.operator==(queryExpr)) {
         ref<Expr> negateQueryExpr =
             EqExpr::alloc(ConstantExpr::alloc(0, Expr::Bool), queryExpr);
         ref<Expr> negateConstraint =
             EqExpr::alloc(ConstantExpr::alloc(0, Expr::Bool), constraintExpr);
-        //					llvm::errs() << "negate query
-        // expr
-        //\n";
-        //					negateQueryExpr->dump();
-        //					llvm::errs() << "negate
-        // constraint
-        //\n";
-        //					negateConstraint->dump();
+
         if (constraintExpr.operator==(negateQueryExpr)) {
           return false;
         }
@@ -1366,9 +1356,6 @@ SubsumptionTableEntry::getSimplifiableConjuncts(ref<Expr> conjunction) {
 
   return std::pair<std::vector<ref<Expr> >, ref<Expr> >(conjunctsList, retExpr);
 }
-
-void SubsumptionTableEntry::getQueryList(ref<Expr> query,
-                                         std::vector<ref<Expr> > &queryList) {}
 
 ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
                                                     bool &hasExistentialsOnly) {
@@ -1628,8 +1615,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
         ref<Expr> falseExpr = ConstantExpr::alloc(0, Expr::Bool);
         constraints.addConstraint(EqExpr::alloc(falseExpr, query->getKid(0)));
 
-        //         llvm::errs() << "Querying for satisfiability check:\n";
-        //         ExprPPrinter::printQuery(llvm::errs(), constraints,
+        // llvm::errs() << "Querying for satisfiability check:\n";
+        // ExprPPrinter::printQuery(llvm::errs(), constraints,
         // falseExpr);
 
         actualSolverCallTimer.start();
@@ -1640,8 +1627,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
         result = success ? Solver::True : Solver::Unknown;
 
       } else {
-        //         llvm::errs() << "Querying for subsumption check:\n";
-        //         ExprPPrinter::printQuery(llvm::errs(), state.constraints,
+        // llvm::errs() << "Querying for subsumption check:\n";
+        // ExprPPrinter::printQuery(llvm::errs(), state.constraints,
         // query);
 
         actualSolverCallTimer.start();
@@ -1659,10 +1646,10 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
       z3solver->setCoreSolverTimeout(0);
 
     } else {
-      //       llvm::errs() << "No existential\n";
+      // llvm::errs() << "No existential\n";
 
-      //       llvm::errs() << "Querying for subsumption check:\n";
-      //       ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+      // llvm::errs() << "Querying for subsumption check:\n";
+      // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
 
       // We call the solver in the standard way if the
       // formula is unquantified.
@@ -1690,7 +1677,7 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   }
 
   if (success && result == Solver::True) {
-    //     llvm::errs() << "Solver decided validity\n";
+    // llvm::errs() << "Solver decided validity\n";
     std::vector<ref<Expr> > unsatCore;
     if (z3solver) {
       unsatCore = z3solver->getUnsatCore();

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -429,8 +429,6 @@ class SubsumptionTableEntry {
   static std::pair<std::vector<ref<Expr> >, ref<Expr> >
   getSimplifiableConjuncts(ref<Expr> conjunction);
 
-  static void getQueryList(ref<Expr> query, std::vector<ref<Expr> > &queryList);
-
   static ref<Expr> simplifyArithmeticBody(ref<Expr> existsExpr,
                                           bool &hasExistentialsOnly);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -426,6 +426,10 @@ class SubsumptionTableEntry {
 
   /// @brief Detect contradictory unary constraints in subsumption check
   /// beforehand to reduce the expensive call to the actual solver.
+  ///
+  /// \return true if there is contradictory unary constraints between state
+  /// constraints and query expression,
+  ///         otherwise, return false.
   static bool solvingUnaryConstraints(ExecutionState &state, ref<Expr> query);
 
   /// @brief Get a pair of a list of simplifiable conjuncts and the new

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -424,6 +424,13 @@ class SubsumptionTableEntry {
   static ref<Expr> simplifyExistsExpr(ref<Expr> existsExpr,
                                       bool &hasExistentialsOnly);
 
+  static bool preSolving(ExecutionState &state, ref<Expr> query);
+
+  static std::pair<std::vector<ref<Expr> >, ref<Expr> >
+  getSimplifiableConjuncts(ref<Expr> conjunction);
+
+  static void getQueryList(ref<Expr> query, std::vector<ref<Expr> > &queryList);
+
   static ref<Expr> simplifyArithmeticBody(ref<Expr> existsExpr,
                                           bool &hasExistentialsOnly);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -424,8 +424,12 @@ class SubsumptionTableEntry {
   static ref<Expr> simplifyExistsExpr(ref<Expr> existsExpr,
                                       bool &hasExistentialsOnly);
 
-  static bool preSolving(ExecutionState &state, ref<Expr> query);
+  /// @brief Detect contradictory unary constraints in subsumption check
+  /// beforehand to reduce the expensive call to the actual solver.
+  static bool solvingUnaryConstraints(ExecutionState &state, ref<Expr> query);
 
+  /// @brief Get a pair of a list of simplifiable conjuncts and the new
+  /// expression from which the simplifiable conjuncts have been removed.
   static std::pair<std::vector<ref<Expr> >, ref<Expr> >
   getSimplifiableConjuncts(ref<Expr> conjunction);
 


### PR DESCRIPTION
This PR is related to issue : https://github.com/tracer-x/klee/issues/80

For basic example, the execution time has improved in general especially for `regexp_nonrecursive2` from 0.68s into 0.50s and `arraysimple6` from 0.30s to 0.24s without affecting the subsumption rates.

For `bubble` and `tr` group example with most execution time 120s, both execution time and subsumption rates looks similar between both branches.

For `regexp` example, the execution time is also improved from 281s to 274s without affecting subsumption rates.

For `grading-examples/count`, the execution time is also improved from 2s to 0.14s without affecting subsumption rates.
