### PR TITLE
Handle Coreutils Cat

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1015,8 +1015,6 @@ void Dependency::execute(llvm::Instruction *instr,
           addPointerEquality(
               getNewVersionedValue(instr, argExpr),
               getInitialAllocation(instr->getOperand(0), argExpr));
-        } else {
-          assert(!"operand not found");
         }
       }
       break;

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1046,6 +1046,8 @@ void Dependency::execute(llvm::Instruction *instr,
           addPointerEquality(
               getNewVersionedValue(instr, argExpr),
               getInitialAllocation(instr->getOperand(0), argExpr));
+        } else {
+          assert(!"operand not found");
         }
       }
       break;

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -542,6 +542,12 @@ VersionedValue *Dependency::getLatestValue(llvm::Value *value,
       return *it;
   }
 
+  if (llvm::isa<llvm::PointerType>(value->getType())) {
+    VersionedValue *ret = getNewVersionedValue(value, valueExpr);
+    addPointerEquality(ret, getInitialAllocation(value, valueExpr));
+    return ret;
+  }
+
   if (parentDependency)
     return parentDependency->getLatestValue(value, valueExpr);
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -542,12 +542,6 @@ VersionedValue *Dependency::getLatestValue(llvm::Value *value,
       return *it;
   }
 
-  if (llvm::isa<llvm::PointerType>(value->getType())) {
-    VersionedValue *ret = getNewVersionedValue(value, valueExpr);
-    addPointerEquality(ret, getInitialAllocation(value, valueExpr));
-    return ret;
-  }
-
   if (parentDependency)
     return parentDependency->getLatestValue(value, valueExpr);
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2870,7 +2870,7 @@ void Executor::run(ExecutionState &initialState) {
       //      state.itreeNode->dump();
       //      llvm::errs() << "------------------- Executing New Instruction "
       //                      "-----------------------\n";
-      //      state.pc->inst->dump();
+      //	  state.pc->inst->dump();
     }
 
     if (INTERPOLATION_ENABLED &&

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2870,7 +2870,7 @@ void Executor::run(ExecutionState &initialState) {
       //      state.itreeNode->dump();
       //      llvm::errs() << "------------------- Executing New Instruction "
       //                      "-----------------------\n";
-      //	  state.pc->inst->dump();
+      //      state.pc->inst->dump();
     }
 
     if (INTERPOLATION_ENABLED &&


### PR DESCRIPTION
This is fixes for run-time error when executing `cat` in `coreutils-6.10`. Please use updated version of https://github.com/tracer-x/klee-examples/tree/coreutils as I have updated the `Makefile` that able to run cat with specified parameters.