### PR TITLE
Revert "Updating the Readme.md to explain the branch tracer-x-no-abstract-no-clpr"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 KLEE Symbolic Virtual Machine
 =============================
 
-####Notes: This branch (tracer-x-no-abstract-no-clpr) is a version with neither klee_abstract nor CLP(R) support.####
-
 [![Build Status](https://travis-ci.org/klee/klee.svg?branch=master)](https://travis-ci.org/klee/klee)
 
 `KLEE` is a symbolic virtual machine built on top of the LLVM compiler


### PR DESCRIPTION
Reverts tracer-x/klee#88

@feliciahalim I realized that this PR would cause issues in that it makes `tracer-x-no-abstract-no-clpr`'s commits set no longer a subset of `master`, so I request for its reversion. The problem is, when we made changes to this branch, and then merge the changes to `master` or  `tracer-x-clpr`, we will always have to change the `README.md`.