### PR TITLE
Two Small Typos

### DIFF
--- a/autoconf/configure.ac
+++ b/autoconf/configure.ac
@@ -606,7 +606,7 @@ AC_SUBST(STP_CFLAGS)
 AC_SUBST(STP_LDFLAGS)
 
 dnl **************************************************************************
-dnl Find and install Z3
+dnl Find an install of Z3
 dnl **************************************************************************
 
 AC_ARG_WITH(z3,

--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -233,7 +233,7 @@ namespace klee {
   #endif /*SUPPORT_STP */
 
 #ifdef SUPPORT_Z3
-  /// Z3Solver - A solver complete solver based on Z3
+  /// Z3Solver - A complete solver based on Z3
   class Z3Solver : public Solver {
   public:
 	/// Z3Solver - Construct a new Z3Solver.


### PR DESCRIPTION
Just two small typos in `configure.ac` and `Solver.h`.