### PR TITLE
Removal of 2-cycles in the construction of AllocationGraph objects

### DIFF
--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -596,7 +596,8 @@ class Allocation {
     /// @brief Builds dependency graph between memory allocations
     void recursivelyBuildAllocationGraph(AllocationGraph *g,
                                          VersionedValue *value,
-                                         Allocation *alloc) const;
+                                         Allocation *alloc,
+                                         Allocation *parentAllocation) const;
 
     /// @brief Builds dependency graph between memory allocations
     void buildAllocationGraph(AllocationGraph *g, VersionedValue *value) const;


### PR DESCRIPTION
The fix is in Dependency::recursivelyBuildAllocationGraph(). This will prevent many cases of computer crashes (frozen) due to stack overflow caused by cycles in the allocation graph.