### PR TITLE
Fixed Dependency Destructor and GetElementPtr Handling for Dependency

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1506,11 +1506,6 @@ void Dependency::Util::deletePointerVector(std::vector<T *> &list) {
 
 template <typename K, typename T>
 void Dependency::Util::deletePointerMap(std::map<K *, T *> &map) {
-  typedef typename std::map<K *, T *>::iterator IteratorType;
-
-  for (IteratorType it = map.begin(), itEnd = map.end(); it != itEnd; ++it) {
-    map.erase(it);
-  }
   map.clear();
 }
 
@@ -1520,7 +1515,7 @@ void Dependency::Util::deletePointerMapWithVectorValue(
   typedef typename std::map<K *, std::vector<T *> >::iterator IteratorType;
 
   for (IteratorType it = map.begin(), itEnd = map.end(); it != itEnd; ++it) {
-    map.erase(it);
+    it->second.clear();
   }
   map.clear();
 }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1151,8 +1151,14 @@ void Dependency::execute(llvm::Instruction *instr,
                it != itEnd; ++it) {
             addDependency((*it), newValue);
           }
-        } else
-          assert(!"missing base parameter");
+        } else {
+          // Here getelementptr forcibly uses a value not known to be an
+          // address, e.g., a loaded value, as an address. In this case, we then
+          // assume that the argument is a base allocation.
+          addPointerEquality(
+              getNewVersionedValue(instr, valueExpr),
+              getInitialAllocation(addressValue->getValue(), valueExpr));
+        }
       }
       break;
     }

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -582,8 +582,8 @@ class Allocation {
                                std::vector<ref<Expr> > &arguments);
 
     /// @brief Construct dependency due to load instruction
-    bool buildLoadDependency(llvm::Value *fromValue, ref<Expr> fromValueExpr,
-                             llvm::Value *toValue, ref<Expr> toValueExpr);
+    bool buildLoadDependency(llvm::Value *address, ref<Expr> addressExpr,
+                             llvm::Value *value, ref<Expr> valueExpr);
 
     /// @brief Direct allocation dependency local to an interpolation tree node
     std::map<VersionedValue *, Allocation *>

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2157,20 +2157,20 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
   case Instruction::GetElementPtr: {
     KGEPInstruction *kgepi = static_cast<KGEPInstruction*>(ki);
-    ref<Expr> oldBase = eval(ki, 0, state).value;
-    ref<Expr> base = oldBase;
+    ref<Expr> base = eval(ki, 0, state).value;
+    ref<Expr> oldBase = base;
 
     for (std::vector< std::pair<unsigned, uint64_t> >::iterator 
            it = kgepi->indices.begin(), ie = kgepi->indices.end(); 
          it != ie; ++it) {
       uint64_t elementSize = it->second;
       ref<Expr> index = eval(ki, it->first, state).value;
-      base = AddExpr::create(oldBase,
+      base = AddExpr::create(base,
                              MulExpr::create(Expr::createSExtToPointerWidth(index),
                                              Expr::createPointer(elementSize)));
     }
     if (kgepi->offset)
-      base = AddExpr::create(oldBase,
+      base = AddExpr::create(base,
                              Expr::createPointer(kgepi->offset));
     bindLocal(ki, state, base);
 

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1213,8 +1213,7 @@ ref<Expr>
 SubsumptionTableEntry::getSubstitution(ref<Expr> equalities,
                                        std::map<ref<Expr>, ref<Expr> > &map) {
   // It is assumed the lhs is an expression on the existentially-quantified
-  // variable whereas
-  // the rhs is an expression on the free variables.
+  // variable whereas the rhs is an expression on the free variables.
   if (llvm::isa<EqExpr>(equalities.get())) {
     ref<Expr> lhs = equalities->getKid(0);
     if (llvm::isa<ReadExpr>(lhs.get()) || llvm::isa<ConcatExpr>(lhs.get())) {


### PR DESCRIPTION
This is fix to #99 as well as to the assertion failure that triggered the invocation of the destructor of `Dependency` class, which triggered #99.