### PR TITLE
Code Commenting and Formatting

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1556,7 +1556,7 @@ bool Dependency::Util::isMainArgument(llvm::Value *site) {
 
 std::string makeTabs(const unsigned tabNum) {
   std::string tabsString;
-  for (unsigned i = 0; i < tabNum; i++) {
+  for (unsigned i = 0; i < tabNum; ++i) {
     tabsString += appendTab(tabsString);
   }
   return tabsString;

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1446,8 +1446,9 @@ void Dependency::print(llvm::raw_ostream &stream) const {
   this->print(stream, 0);
 }
 
-void Dependency::print(llvm::raw_ostream &stream, const unsigned tabNum) const {
-  std::string tabs = makeTabs(tabNum);
+void Dependency::print(llvm::raw_ostream &stream,
+                       const unsigned paddingAmount) const {
+  std::string tabs = makeTabs(paddingAmount);
   stream << tabs << "EQUALITIES:";
   std::vector<PointerEquality *>::const_iterator equalityListBegin =
       equalityList.begin();
@@ -1488,7 +1489,7 @@ void Dependency::print(llvm::raw_ostream &stream, const unsigned tabNum) const {
 
   if (parentDependency) {
     stream << "\n" << tabs << "--------- Parent Dependencies ----------\n";
-    parentDependency->print(stream, tabNum);
+    parentDependency->print(stream, paddingAmount);
   }
 }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -8,9 +8,9 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the implementation of the flow-insensitive dependency
-/// analysis to compute the allocations upon which the unsatisfiability core
-/// depends, which is used in computing the interpolant.
+/// This file contains the implementation of the dependency analysis to
+/// compute the allocations upon which the unsatisfiability core depends,
+/// which is used in computing the interpolant.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1554,9 +1554,9 @@ bool Dependency::Util::isMainArgument(llvm::Value *site) {
 
 /**/
 
-std::string makeTabs(const unsigned tabNum) {
+std::string makeTabs(const unsigned paddingAmount) {
   std::string tabsString;
-  for (unsigned i = 0; i < tabNum; ++i) {
+  for (unsigned i = 0; i < paddingAmount; ++i) {
     tabsString += appendTab(tabsString);
   }
   return tabsString;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -163,8 +163,8 @@ class Allocation {
 
     const ref<Expr> valueExpr;
 
-    /// @brief to indicate if any unsatisfiability core
-    /// depends on this value
+    /// \brief Field to indicate if any unsatisfiability core depends on this
+    /// value.
     bool core;
 
   public:
@@ -279,8 +279,8 @@ class Allocation {
                std::vector<AllocationNode *> &printed,
                const unsigned tabNum) const;
 
-    /// consumeSinkNode - Given an allocation, delete all sinks having such
-    /// allocation, and replace them as sinks with their parents.
+    /// \brief Given an allocation, delete all sinks having such allocation, and
+    /// replace them as sinks with their parents.
     ///
     /// \param The allocation to match a sink node with.
     void consumeSinkNode(Allocation *allocation);
@@ -308,9 +308,8 @@ class Allocation {
     std::set<Allocation *>
     getSinksWithAllocations(std::vector<Allocation *> valuesList) const;
 
-    /// consumeNodesWithAllocations - Given a set of allocations, delete all
-    /// sinks having an allocation in the set, and replace them as sinks with
-    /// their parents.
+    /// Given a set of allocations, delete all sinks having an allocation in the
+    /// set, and replace them as sinks with their parents.
     ///
     /// \param The allocation to match the sink nodes with.
     void consumeSinksWithAllocations(std::vector<Allocation *> allocationsList);
@@ -323,9 +322,9 @@ class Allocation {
     void print(llvm::raw_ostream &stream) const;
   };
 
-  /// \brief Dependency - implementation of field-insensitive value
-  ///        dependency for computing allocations the unsatisfiability core
-  ///        depends upon, which is used to compute the interpolant.
+  /// \brief Implementation of value dependency for computing allocations the
+  /// unsatisfiability core depends upon, which is used to compute the
+  /// interpolant.
   ///
   /// Following is the analysis rules to compute value dependency relations
   /// useful for computing the interpolant. Given a finite symbolic execution
@@ -495,35 +494,35 @@ class Allocation {
 
       static bool isEnvironmentAllocation(llvm::Value *site);
 
-      /// @brief Tests if an allocation site is main function's argument
+      /// \brief Tests if an allocation site is main function's argument
       static bool isMainArgument(llvm::Value *site);
     };
 
   private:
-    /// @brief Previous path condition
+    /// \brief Previous path condition
     Dependency *parentDependency;
 
-    /// @brief Argument values to be passed onto callee
+    /// \brief Argument values to be passed onto callee
     std::vector<VersionedValue *> argumentValuesList;
 
-    /// @brief Equality of value to address
+    /// \brief Equality of value to address
     std::vector< PointerEquality *> equalityList;
 
-    /// @brief The mapping of allocations/addresses to stored value
+    /// \brief The mapping of allocations/addresses to stored value
     std::map<Allocation *, VersionedValue *> storesMap;
 
-    /// @brief Store the inverse map of both storesMap
+    /// \brief Store the inverse map of both storesMap
     std::map<VersionedValue *, std::vector<Allocation *> > storageOfMap;
 
-    /// @brief Flow relations from one value to another
+    /// \brief Flow relations from one value to another
     std::vector<FlowsTo *> flowsToList;
 
     std::vector< VersionedValue *> valuesList;
 
     std::vector<Allocation *> versionedAllocationsList;
 
-    /// @brief allocations of this node and its ancestors
-    /// that are needed for the core and dominates other allocations.
+    /// \brief allocations of this node and its ancestors that are needed for
+    /// the core and dominates other allocations.
     std::set<Allocation *> coreAllocations;
 
     VersionedValue *getNewVersionedValue(llvm::Value *value,
@@ -538,12 +537,12 @@ class Allocation {
     std::vector<Allocation *> getAllVersionedAllocations(bool coreOnly =
                                                              false) const;
 
-    /// @brief Gets the latest version of the allocation.
+    /// \brief Gets the latest version of the allocation.
     Allocation *getLatestAllocation(llvm::Value *allocation,
                                     ref<Expr> address) const;
 
-    /// @brief similar to getLatestValue, but we don't check for whether
-    /// the value is constant or not
+    /// \brief Gets the latest version of the allocation, but without checking
+    /// for whether the value is constant or not
     VersionedValue *getLatestValueNoConstantCheck(llvm::Value *value) const;
 
     void addPointerEquality(const VersionedValue *value,
@@ -563,17 +562,17 @@ class Allocation {
 
     std::vector<VersionedValue *> stores(Allocation *allocation) const;
 
-    /// @brief All values that flows to the target in one step, local
-    /// to the current dependency / interpolation tree node
+    /// \brief All values that flows to the target in one step, local to the
+    /// current dependency / interpolation tree node
     std::vector<VersionedValue *> directLocalFlowSources(VersionedValue *target) const;
 
-    /// @brief All values that flows to the target in one step
+    /// \brief All values that flows to the target in one step
     std::vector<VersionedValue *> directFlowSources(VersionedValue *target) const;
 
-    /// @brief All values that could flow to the target
+    /// \brief All values that could flow to the target
     std::vector<VersionedValue *> allFlowSources(VersionedValue *target) const;
 
-    /// @brief All the end sources that can flow to the target
+    /// \brief All the end sources that can flow to the target
     std::vector<VersionedValue *>
     allFlowSourcesEnds(VersionedValue *target) const;
 
@@ -581,25 +580,25 @@ class Allocation {
     populateArgumentValuesList(llvm::CallInst *site,
                                std::vector<ref<Expr> > &arguments);
 
-    /// @brief Construct dependency due to load instruction
+    /// \brief Construct dependency due to load instruction
     bool buildLoadDependency(llvm::Value *fromValue, ref<Expr> fromValueExpr,
                              llvm::Value *toValue, ref<Expr> toValueExpr);
 
-    /// @brief Direct allocation dependency local to an interpolation tree node
+    /// \brief Direct allocation dependency local to an interpolation tree node
     std::map<VersionedValue *, Allocation *>
     directLocalAllocationSources(VersionedValue *target) const;
 
-    /// @brief Direct allocation dependency
+    /// \brief Direct allocation dependency
     std::map<VersionedValue *, Allocation *>
     directAllocationSources(VersionedValue *target) const;
 
-    /// @brief Builds dependency graph between memory allocations
+    /// \brief Builds dependency graph between memory allocations
     void recursivelyBuildAllocationGraph(AllocationGraph *g,
                                          VersionedValue *value,
                                          Allocation *alloc,
                                          Allocation *parentAllocation) const;
 
-    /// @brief Builds dependency graph between memory allocations
+    /// \brief Builds dependency graph between memory allocations
     void buildAllocationGraph(AllocationGraph *g, VersionedValue *value) const;
 
   public:
@@ -611,10 +610,10 @@ class Allocation {
 
     VersionedValue *getLatestValue(llvm::Value *value, ref<Expr> valueExpr);
 
-    /// @brief Abstract dependency state transition with argument(s)
+    /// \brief Abstract dependency state transition with argument(s)
     void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
 
-    /// @brief Build dependencies from PHI node
+    /// \brief Build dependencies from PHI node
     void executePHI(llvm::Instruction *instr, unsigned int incomingBlock,
                     ref<Expr> valueExpr);
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -736,8 +736,7 @@ class Allocation {
     void print(llvm::raw_ostream &stream, const unsigned paddingAmount) const;
   };
 
-
-  std::string makeTabs(const unsigned tab_num);
+  std::string makeTabs(const unsigned paddingAmount);
 
   std::string appendTab(const std::string &prefix);
 

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -164,7 +164,7 @@ void ExecutionState::popFrame(KInstruction *ki, ref<Expr> returnValue) {
   stack.pop_back();
 
   if (INTERPOLATION_ENABLED && site && ki)
-    itreeNode->popAbstractDependencyFrame(site, ki->inst, returnValue);
+    itreeNode->bindReturnValue(site, ki->inst, returnValue);
 }
 
 void ExecutionState::addSymbolic(const MemoryObject *mo, const Array *array) { 

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -724,7 +724,6 @@ void SearchTree::setAsCore(PathCondition *pathCondition) {
   instance->pathConditionMap[pathCondition]->pathConditionTable[pathCondition].second = true;
 }
 
-/// @brief Save the graph
 void SearchTree::save(std::string dotFileName) {
   if (!OUTPUT_INTERPOLATION_TREE)
     return;
@@ -1054,24 +1053,24 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
 
 ref<Expr> SubsumptionTableEntry::replaceExpr(ref<Expr> originalExpr,
                                              ref<Expr> replacedExpr,
-                                             ref<Expr> substituteExpr) {
+                                             ref<Expr> replacementExpr) {
   // We only handle binary expressions
   if (!llvm::isa<BinaryExpr>(originalExpr) ||
       llvm::isa<ConcatExpr>(originalExpr))
     return originalExpr;
 
   if (originalExpr->getKid(0) == replacedExpr)
-    return ShadowArray::createBinaryOfSameKind(originalExpr, substituteExpr,
+    return ShadowArray::createBinaryOfSameKind(originalExpr, replacementExpr,
                                                originalExpr->getKid(1));
 
   if (originalExpr->getKid(1) == replacedExpr)
     return ShadowArray::createBinaryOfSameKind(
-        originalExpr, originalExpr->getKid(0), substituteExpr);
+        originalExpr, originalExpr->getKid(0), replacementExpr);
 
   return ShadowArray::createBinaryOfSameKind(
       originalExpr,
-      replaceExpr(originalExpr->getKid(0), replacedExpr, substituteExpr),
-      replaceExpr(originalExpr->getKid(1), replacedExpr, substituteExpr));
+      replaceExpr(originalExpr->getKid(0), replacedExpr, replacementExpr),
+      replaceExpr(originalExpr->getKid(1), replacedExpr, replacementExpr));
 }
 
 bool SubsumptionTableEntry::containShadowExpr(ref<Expr> expr,

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -885,13 +885,6 @@ bool SubsumptionTableEntry::hasFree(std::set<const Array *> &existentials,
 }
 
 ref<Expr>
-SubsumptionTableEntry::simplifyWithFourierMotzkin(ref<Expr> existsExpr) {
-  // This is a template for Fourier-Motzkin elimination. For now,
-  // we simply return the input argument.
-  return existsExpr;
-}
-
-ref<Expr>
 SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
                                               bool &hasExistentialsOnly) {
   assert(llvm::isa<ExistsExpr>(existsExpr.get()));
@@ -1048,7 +1041,7 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
     newBody = AndExpr::alloc(simplifiedInterpolant, fullEqualityConstraint);
   }
 
-  return simplifyWithFourierMotzkin(existsExpr->rebuild(&newBody));
+  return existsExpr->rebuild(&newBody);
 }
 
 ref<Expr> SubsumptionTableEntry::replaceExpr(ref<Expr> originalExpr,

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -199,34 +199,34 @@ SearchTree::PrettyExpressionBuilder::constructMulByConstant(std::string expr,
   return stream.str();
 }
 std::string
-SearchTree::PrettyExpressionBuilder::constructUDivByConstant(std::string expr_n,
+SearchTree::PrettyExpressionBuilder::constructUDivByConstant(std::string expr,
                                                              uint64_t d) {
   std::ostringstream stream;
-  stream << "(" << expr_n << " / " << d << ")";
+  stream << "(" << expr << " / " << d << ")";
   return stream.str();
 }
 std::string
-SearchTree::PrettyExpressionBuilder::constructSDivByConstant(std::string expr_n,
+SearchTree::PrettyExpressionBuilder::constructSDivByConstant(std::string expr,
                                                              uint64_t d) {
   std::ostringstream stream;
-  stream << "(" << expr_n << " / " << d << ")";
+  stream << "(" << expr << " / " << d << ")";
   return stream.str();
 }
 
 std::string
 SearchTree::PrettyExpressionBuilder::getInitialArray(const Array *root) {
-  std::string array_expr =
+  std::string arrayExpr =
       buildArray(root->name.c_str(), root->getDomain(), root->getRange());
 
   if (root->isConstantArray()) {
     for (unsigned i = 0, e = root->size; i != e; ++i) {
-      std::string prev = array_expr;
-      array_expr = writeExpr(
+      std::string prev = arrayExpr;
+      arrayExpr = writeExpr(
           prev, constructActual(ConstantExpr::alloc(i, root->getDomain())),
           constructActual(root->constantValues[i]));
     }
   }
-  return array_expr;
+  return arrayExpr;
 }
 std::string
 SearchTree::PrettyExpressionBuilder::getArrayForUpdate(const Array *root,
@@ -2207,35 +2207,36 @@ void ITreeNode::print(llvm::raw_ostream &stream) const {
   this->print(stream, 0);
 }
 
-void ITreeNode::print(llvm::raw_ostream &stream, const unsigned tabNum) const {
-  std::string tabs = makeTabs(tabNum);
-  std::string tabs_next = appendTab(tabs);
+void ITreeNode::print(llvm::raw_ostream &stream,
+                      const unsigned paddingAmount) const {
+  std::string tabs = makeTabs(paddingAmount);
+  std::string tabsNext = appendTab(tabs);
 
   stream << tabs << "ITreeNode\n";
-  stream << tabs_next << "node Id = " << nodeId << "\n";
-  stream << tabs_next << "pathCondition = ";
+  stream << tabsNext << "node Id = " << nodeId << "\n";
+  stream << tabsNext << "pathCondition = ";
   if (pathCondition == 0) {
     stream << "NULL";
   } else {
     pathCondition->print(stream);
   }
   stream << "\n";
-  stream << tabs_next << "Left:\n";
+  stream << tabsNext << "Left:\n";
   if (!left) {
-    stream << tabs_next << "NULL\n";
+    stream << tabsNext << "NULL\n";
   } else {
-    left->print(stream, tabNum + 1);
+    left->print(stream, paddingAmount + 1);
     stream << "\n";
   }
-  stream << tabs_next << "Right:\n";
+  stream << tabsNext << "Right:\n";
   if (!right) {
-    stream << tabs_next << "NULL\n";
+    stream << tabsNext << "NULL\n";
   } else {
-    right->print(stream, tabNum + 1);
+    right->print(stream, paddingAmount + 1);
     stream << "\n";
   }
   if (dependency) {
-    stream << tabs_next << "------- Abstract Dependencies ----------\n";
-    dependency->print(stream, tabNum + 1);
+    stream << tabsNext << "------- Abstract Dependencies ----------\n";
+    dependency->print(stream, paddingAmount + 1);
   }
 }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -989,8 +989,8 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
         ref<Expr> newIntpRight;
 
         // When the if condition holds, we perform substitution
-        if (findSubExpression(equalityConstraintLeft,
-                              interpolantAtom->getKid(0))) {
+        if (hasSubExpression(equalityConstraintLeft,
+                             interpolantAtom->getKid(0))) {
           // Here we perform substitution, where given
           // an interpolant atom and an equality constraint,
           // we try to find a subexpression in the equality constraint
@@ -1066,15 +1066,15 @@ ref<Expr> SubsumptionTableEntry::replaceExpr(ref<Expr> originalExpr,
       replaceExpr(originalExpr->getKid(1), replacedExpr, replacementExpr));
 }
 
-bool SubsumptionTableEntry::findSubExpression(ref<Expr> expr,
-                                              ref<Expr> subExpr) {
+bool SubsumptionTableEntry::hasSubExpression(ref<Expr> expr,
+                                             ref<Expr> subExpr) {
   if (expr == subExpr)
     return true;
   if (expr->getNumKids() < 2 && expr != subExpr)
     return false;
 
-  return findSubExpression(expr->getKid(0), subExpr) ||
-         findSubExpression(expr->getKid(1), subExpr);
+  return hasSubExpression(expr->getKid(0), subExpr) ||
+         hasSubExpression(expr->getKid(1), subExpr);
 }
 
 ref<Expr> SubsumptionTableEntry::simplifyInterpolantExpr(

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -2035,7 +2035,7 @@ StatTimer ITreeNode::addConstraintTimer;
 StatTimer ITreeNode::splitTimer;
 StatTimer ITreeNode::executeTimer;
 StatTimer ITreeNode::bindCallArgumentsTimer;
-StatTimer ITreeNode::popAbstractDependencyFrameTimer;
+StatTimer ITreeNode::bindReturnValueTimer;
 StatTimer ITreeNode::getStoredExpressionsTimer;
 StatTimer ITreeNode::getStoredCoreExpressionsTimer;
 StatTimer ITreeNode::computeCoreAllocationsTimer;
@@ -2049,8 +2049,8 @@ void ITreeNode::printTimeStat(llvm::raw_ostream &stream) {
   stream << "KLEE: done:     execute = " << executeTimer.get() * 1000 << "\n";
   stream << "KLEE: done:     bindCallArguments = "
          << bindCallArgumentsTimer.get() * 1000 << "\n";
-  stream << "KLEE: done:     popAbstractDependencyFrame = "
-         << popAbstractDependencyFrameTimer.get() * 1000 << "\n";
+  stream << "KLEE: done:     bindReturnValue = " << bindReturnValueTimer.get() *
+                                                        1000 << "\n";
   stream << "KLEE: done:     getStoredExpressions = "
          << getStoredExpressionsTimer.get() * 1000 << "\n";
   stream << "KLEE: done:     getStoredCoreExpressions = "
@@ -2125,14 +2125,13 @@ void ITreeNode::bindCallArguments(llvm::Instruction *site,
   ITreeNode::bindCallArgumentsTimer.stop();
 }
 
-void ITreeNode::popAbstractDependencyFrame(llvm::CallInst *site,
-                                           llvm::Instruction *inst,
-                                           ref<Expr> returnValue) {
+void ITreeNode::bindReturnValue(llvm::CallInst *site, llvm::Instruction *inst,
+                                ref<Expr> returnValue) {
   // TODO: This is probably where we should simplify
   // the dependency graph by removing callee values.
-  ITreeNode::popAbstractDependencyFrameTimer.start();
+  ITreeNode::bindReturnValueTimer.start();
   dependency->bindReturnValue(site, inst, returnValue);
-  ITreeNode::popAbstractDependencyFrameTimer.stop();
+  ITreeNode::bindReturnValueTimer.stop();
 }
 
 std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -2175,8 +2175,9 @@ void ITreeNode::unsatCoreMarking(std::vector<ref<Expr> > unsatCore) {
   }
 
   AllocationGraph *g = new AllocationGraph();
-  for (std::vector<ref<Expr> >::iterator it1 = unsatCore.begin();
-       it1 != unsatCore.end(); ++it1) {
+  for (std::vector<ref<Expr> >::iterator it1 = unsatCore.begin(),
+                                         it1End = unsatCore.end();
+       it1 != it1End; ++it1) {
     // FIXME: Sometimes some constraints are not in the PC. This is
     // because constraints are not properly added at state merge.
     PathCondition *cond = markerMap[it1->get()];

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1634,7 +1634,7 @@ bool SubsumptionTableEntry::subsumed(
     // path condition.
 
     // We create path condition marking structure to mark core constraints
-    state.itreeNode->unsatCoreMarking(unsatCore, state);
+    state.itreeNode->unsatCoreMarking(unsatCore);
     return true;
   }
 
@@ -2165,11 +2165,9 @@ ITreeNode::getStoredCoreExpressions(std::set<const Array *> &replacements)
   return ret;
 }
 
-void ITreeNode::unsatCoreMarking(std::vector<ref<Expr> > unsatCore,
-                                 ExecutionState &state) {
-  // State subsumed, we mark needed constraints on the
-  // path condition.
-  // We create path condition marking structure to mark core constraints
+void ITreeNode::unsatCoreMarking(std::vector<ref<Expr> > unsatCore) {
+  // State subsumed, we mark needed constraints on the path condition. We create
+  // path condition marking structure to mark core constraints
   std::map<Expr *, PathCondition *> markerMap;
   for (PathCondition *it = pathCondition; it != 0; it = it->cdr()) {
     if (llvm::isa<OrExpr>(it->car().get())) {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1068,9 +1068,9 @@ ref<Expr> SubsumptionTableEntry::replaceExpr(ref<Expr> originalExpr,
 
 bool SubsumptionTableEntry::findSubExpression(ref<Expr> expr,
                                               ref<Expr> subExpr) {
-  if (expr.operator==(subExpr))
+  if (expr == subExpr)
     return true;
-  if (expr->getNumKids() < 2 && expr.operator!=(subExpr))
+  if (expr->getNumKids() < 2 && expr != subExpr)
     return false;
 
   return findSubExpression(expr->getKid(0), subExpr) ||
@@ -1084,13 +1084,13 @@ ref<Expr> SubsumptionTableEntry::simplifyInterpolantExpr(
 
   if (llvm::isa<EqExpr>(expr) && llvm::isa<ConstantExpr>(expr->getKid(0)) &&
       llvm::isa<ConstantExpr>(expr->getKid(1))) {
-    return (expr->getKid(0).operator==(expr->getKid(1)))
+    return (expr->getKid(0) == expr->getKid(1))
                ? ConstantExpr::alloc(1, Expr::Bool)
                : ConstantExpr::alloc(0, Expr::Bool);
   } else if (llvm::isa<NeExpr>(expr) &&
              llvm::isa<ConstantExpr>(expr->getKid(0)) &&
              llvm::isa<ConstantExpr>(expr->getKid(1))) {
-    return (expr->getKid(0).operator!=(expr->getKid(1)))
+    return (expr->getKid(0) != expr->getKid(1))
                ? ConstantExpr::alloc(1, Expr::Bool)
                : ConstantExpr::alloc(0, Expr::Bool);
   }
@@ -1148,7 +1148,7 @@ ref<Expr> SubsumptionTableEntry::simplifyEqualityExpr(
   if (llvm::isa<EqExpr>(expr)) {
     if (llvm::isa<ConstantExpr>(expr->getKid(0)) &&
         llvm::isa<ConstantExpr>(expr->getKid(1))) {
-      return (expr->getKid(0).operator==(expr->getKid(1)))
+      return (expr->getKid(0) == expr->getKid(1))
                  ? ConstantExpr::alloc(1, Expr::Bool)
                  : ConstantExpr::alloc(0, Expr::Bool);
     }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -989,7 +989,7 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
         ref<Expr> newIntpRight;
 
         // When the if condition holds, we perform substitution
-        if (containShadowExpr(equalityConstraintLeft,
+        if (findSubExpression(equalityConstraintLeft,
                               interpolantAtom->getKid(0))) {
           // Here we perform substitution, where given
           // an interpolant atom and an equality constraint,
@@ -1066,15 +1066,15 @@ ref<Expr> SubsumptionTableEntry::replaceExpr(ref<Expr> originalExpr,
       replaceExpr(originalExpr->getKid(1), replacedExpr, replacementExpr));
 }
 
-bool SubsumptionTableEntry::containShadowExpr(ref<Expr> expr,
-                                              ref<Expr> shadowExpr) {
-  if (expr.operator==(shadowExpr))
+bool SubsumptionTableEntry::findSubExpression(ref<Expr> expr,
+                                              ref<Expr> subExpr) {
+  if (expr.operator==(subExpr))
     return true;
-  if (expr->getNumKids() < 2 && expr.operator!=(shadowExpr))
+  if (expr->getNumKids() < 2 && expr.operator!=(subExpr))
     return false;
 
-  return containShadowExpr(expr->getKid(0), shadowExpr) ||
-         containShadowExpr(expr->getKid(1), shadowExpr);
+  return findSubExpression(expr->getKid(0), subExpr) ||
+         findSubExpression(expr->getKid(1), subExpr);
 }
 
 ref<Expr> SubsumptionTableEntry::simplifyInterpolantExpr(

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -420,10 +420,6 @@ class SubsumptionTableEntry {
   static ref<Expr> simplifyEqualityExpr(std::vector<ref<Expr> > &equalityPack,
                                         ref<Expr> expr);
 
-  /// \brief Fourier-Motzkin elimination to approximately simplify
-  /// existentially-quantified expression.
-  static ref<Expr> simplifyWithFourierMotzkin(ref<Expr> existsExpr);
-
   /// \brief Simplify if possible an existentially-quantified expression,
   /// possibly removing the quantification.
   static ref<Expr> simplifyExistsExpr(ref<Expr> existsExpr,

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -35,7 +35,7 @@ class PathCondition;
 
 class SubsumptionTableEntry;
 
-/// Time records for method running time statistics
+/// \brief Time records for method running time statistics
 class StatTimer {
   double amount;
   double lastRecorded;
@@ -59,7 +59,7 @@ public:
 
   double get() { return (amount / (double)CLOCKS_PER_SEC); }
 
-  /// @brief Utility function to represent double-precision floating point in
+  /// \brief Utility function to represent double-precision floating point in
   /// two decimal points.
   static std::string inTwoDecimalPoints(double n) {
     std::ostringstream stream;
@@ -76,14 +76,13 @@ public:
   }
 };
 
-
-/// Storage of search tree for displaying
+/// \brief The implementation of the search tree for outputting to .dot file.
 class SearchTree {
 
-  /// @brief counter for the next visited node id
+  /// \brief counter for the next visited node id
   static unsigned long nextNodeId;
 
-  /// @brief Global search tree instance
+  /// \brief Global search tree instance
   static SearchTree *instance;
 
   /// Encapsulates functionality of expression builder
@@ -174,22 +173,22 @@ class SearchTree {
   class Node {
     friend class SearchTree;
 
-    /// @brief Interpolation tree node id
+    /// \brief Interpolation tree node id
     uintptr_t iTreeNodeId;
 
-    /// @brief The node id, also the order in which it is traversed
+    /// \brief The node id, also the order in which it is traversed
     unsigned long nodeId;
 
-    /// @brief False and true children of this node
+    /// \brief False and true children of this node
     SearchTree::Node *falseTarget, *trueTarget;
 
-    /// @brief Indicates that node is subsumed
+    /// \brief Indicates that node is subsumed
     bool subsumed;
 
-    /// @brief Conditions under which this node is visited from its parent
+    /// \brief Conditions under which this node is visited from its parent
     std::map<PathCondition *, std::pair<std::string, bool> > pathConditionTable;
 
-    /// @brief Human-readable identifier of this node
+    /// \brief Human-readable identifier of this node
     std::string name;
 
     Node(uintptr_t nodeId)
@@ -282,40 +281,40 @@ public:
 
   static void setAsCore(PathCondition *pathCondition);
 
-  /// @brief Save the graph
+  /// \brief Save the graph
   static void save(std::string dotFileName);
 };
 
 /**/
 
+/// \brief A node in a singly-linked list of conditions which constitute the
+/// path condition.
 class PathCondition {
-  /// @brief KLEE expression
+  /// \brief KLEE expression
   ref<Expr> constraint;
 
-  /// @brief KLEE expression with variables (arrays) replaced by their shadows
+  /// \brief KLEE expression with variables (arrays) replaced by their shadows
   ref<Expr> shadowConstraint;
 
-  /// @brief If shadow constraint had been generated: We generate shadow
+  /// \brief If shadow constraint had been generated: We generate shadow
   /// constraint on demand only when the constraint is required in an
   /// interpolant.
   bool shadowed;
 
-  /// @brief The set of bound variables
+  /// \brief The set of bound variables
   std::set<const Array *> boundVariables;
 
-  /// @brief The dependency information for the current
-  /// interpolation tree node
+  /// \brief The dependency information for the current interpolation tree node
   Dependency *dependency;
 
-  /// @brief the condition value from which the
-  /// constraint was generated
+  /// \brief the condition value from which the constraint was generated
   VersionedValue *condition;
 
-  /// @brief When true, indicates that the constraint should be included
-  /// in the interpolant
+  /// \brief When true, indicates that the constraint should be included in the
+  /// interpolant
   bool core;
 
-  /// @brief Previous path condition
+  /// \brief Previous path condition
   PathCondition *tail;
 
 public:
@@ -339,9 +338,11 @@ public:
   void print(llvm::raw_ostream &stream);
 };
 
+/// \brief The class that implements an entry (record) in the subsumption table.
 class SubsumptionTableEntry {
   friend class ITree;
 
+  /// \brief General substitution mechanism
   class ApplySubstitutionVisitor : public ExprVisitor {
   private:
     const std::map<ref<Expr>, ref<Expr> > &replacements;
@@ -362,13 +363,13 @@ class SubsumptionTableEntry {
     }
   };
 
-  /// @brief Statistics for actual solver call time in subsumption check
+  /// \brief Statistics for actual solver call time in subsumption check
   static StatTimer actualSolverCallTimer;
 
-  /// @brief The number of solver calls for subsumption checks
+  /// \brief The number of solver calls for subsumption checks
   static unsigned long checkSolverCount;
 
-  /// @brief The number of failed solver calls for subsumption checks
+  /// \brief The number of failed solver calls for subsumption checks
   static unsigned long checkSolverFailureCount;
 
   ref<Expr> interpolant;
@@ -383,45 +384,64 @@ class SubsumptionTableEntry {
 
   std::set<const Array *> existentials;
 
+  /// \brief Test for the existence of a variable in a set in an expression.
+  ///
+  /// \param A set of variables (KLEE arrays).
+  /// \param The expression to test for the existence of the variables in the
+  /// set.
+  /// \return true if a variable in the set is found in the expression, false
+  /// otherwise.
   static bool hasExistentials(std::set<const Array *> &existentials,
                               ref<Expr> expr);
 
+  /// \brief Test for the non-existence of a variable in a set in an expression.
+  ///
+  /// \param A set of variables (KLEE arrays).
+  /// \param The expression to test for the non-existence of the variables in
+  /// the set.
+  /// \return true if none of the variable in the set is found in the
+  /// expression, false otherwise.
   static bool hasFree(std::set<const Array *> &existentials, ref<Expr> expr);
 
   static bool containShadowExpr(ref<Expr> expr, ref<Expr> shadowExpr);
 
+  /// \brief Replace a sub-expression with another within an original expression
   static ref<Expr> replaceExpr(ref<Expr> originalExpr, ref<Expr> replacedExpr,
-                               ref<Expr> withExpr);
+                               ref<Expr> replacementExpr);
 
-  /// @brief Simplifies the interpolant condition in subsumption check
-  /// whenever it contains constant equalities or disequalities.
+  /// \brief Simplifies the interpolant condition in subsumption check whenever
+  /// it contains constant equalities or disequalities.
   static ref<Expr>
   simplifyInterpolantExpr(std::vector<ref<Expr> > &interpolantPack,
                           ref<Expr> expr);
 
-  /// @brief Simplifies the equality conditions in subsumption check
-  /// whenever it contains constant equalities.
+  /// \brief Simplifies the equality conditions in subsumption check whenever it
+  /// contains constant equalities.
   static ref<Expr> simplifyEqualityExpr(std::vector<ref<Expr> > &equalityPack,
                                         ref<Expr> expr);
 
+  /// \brief Fourier-Motzkin elimination to approximately simplify
+  /// existentially-quantified expression.
   static ref<Expr> simplifyWithFourierMotzkin(ref<Expr> existsExpr);
 
+  /// \brief Simplify if possible an existentially-quantified expression,
+  /// possibly removing the quantification.
   static ref<Expr> simplifyExistsExpr(ref<Expr> existsExpr,
                                       bool &hasExistentialsOnly);
 
-  /// @brief Detect contradictory equalities in subsumption check beforehand to
+  /// \brief Detect contradictory equalities in subsumption check beforehand to
   /// reduce the expensive call to the actual solver.
   ///
   /// \return true if there is contradictory equality constraints between state
   /// constraints and query expression, otherwise, return false.
   static bool detectConflictPrimitives(ExecutionState &state, ref<Expr> query);
 
-  /// @brief Get a conjunction of equalities that are top-level conjuncts in the
+  /// \brief Get a conjunction of equalities that are top-level conjuncts in the
   /// query.
   ///
-  /// \param conjunction - The output conjunction of top-level conjuncts in the
-  /// query expression.
-  /// \param query - The query expression.
+  /// \param The output conjunction of top-level conjuncts in the query
+  /// expression.
+  /// \param The query expression.
   /// \return false if there is an equality conjunct that is simplifiable to
   /// false, true otherwise.
   static bool fetchQueryEqualityConjuncts(std::vector<ref<Expr> > &conjunction,
@@ -437,7 +457,7 @@ class SubsumptionTableEntry {
     return !interpolant.get() && concreteAddressStoreKeys.empty();
   }
 
-  /// @brief for printing method running time statistics
+  /// \brief For printing method running time statistics
   static void printStat(llvm::raw_ostream &stream);
 
 public:
@@ -457,11 +477,15 @@ public:
 
 };
 
+/// \brief The interpolation tree node: The implementation of the tree node to
+/// be embedded in KLEE's execution state, which stores the data of
+/// interpolation functionalities.
 class ITreeNode {
   friend class ITree;
 
   friend class ExecutionState;
 
+  // Timers for profiling the execution times of the methods of this class.
   static StatTimer getInterpolantTimer;
   static StatTimer addConstraintTimer;
   static StatTimer splitTimer;
@@ -477,10 +501,10 @@ private:
 
   typedef std::pair<expression_type, expression_type> pair_type;
 
-  /// @brief The path condition
+  /// \brief The path condition
   PathCondition *pathCondition;
 
-  /// @brief Abstract stack for value dependencies
+  /// \brief Abstract stack for value dependencies
   Dependency *dependency;
 
   ITreeNode *parent, *left, *right;
@@ -489,7 +513,7 @@ private:
 
   bool isSubsumed;
 
-  /// @brief Graph for displaying as .dot file
+  /// \brief Graph for displaying as .dot file
   SearchTree *graph;
 
   void setNodeLocation(uintptr_t programPoint) {
@@ -497,7 +521,7 @@ private:
       nodeId = programPoint;
   }
 
-  /// @brief for printing method running time statistics
+  /// \brief for printing method running time statistics
   static void printTimeStat(llvm::raw_ostream &stream);
 
   void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
@@ -505,31 +529,71 @@ private:
 public:
   uintptr_t getNodeId();
 
+  /// \brief Retrieve the interpolant for this node as KLEE expression object
+  ///
+  /// \param The replacement bound variables for replacing the variables in the
+  /// path condition.
+  /// \return The interpolant expression.
   ref<Expr> getInterpolant(std::set<const Array *> &replacements) const;
 
+  /// \brief Extend the path condition with another constraint
+  ///
+  /// \param The constraint to extend the current path condition with
+  /// \param The LLVM value that corresponds to the constraint
   void addConstraint(ref<Expr> &constraint, llvm::Value *value);
 
+  /// \brief Creates fresh interpolation data holder for the two given KLEE
+  /// execution states.
+  /// This method is to be invoked after KLEE splits its own state due to state
+  /// forking.
+  ///
+  /// \param The first KLEE execution state
+  /// \param The second KLEE execution state
   void split(ExecutionState *leftData, ExecutionState *rightData);
 
+  /// \brief Record call arguments in a function call
   void bindCallArguments(llvm::Instruction *site,
                          std::vector<ref<Expr> > &arguments);
 
+  /// \brief This propagates the dependency due to the return value of a call
   void popAbstractDependencyFrame(llvm::CallInst *site, llvm::Instruction *inst,
                                   ref<Expr> returnValue);
 
+  /// \brief This retrieves the allocations known at this state, and the
+  /// expressions stored in the allocations.
+  ///
+  /// \return A pair of the store part indexed by constants, and the store part
+  /// indexed by symbolic expressions.
   std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   getStoredExpressions() const;
 
+  /// \brief This retrieves the allocations known at this state, and the
+  /// expressions stored in the allocations, as long as the allocation is
+  /// relevant as an interpolant. This function is typically used when creating
+  /// an entry in the subsumption table.
+  ///
+  /// \param The replacement bound variables: As the resulting expression will
+  /// be used for storing in the subsumption table, the variables need to be
+  /// replaced with the bound ones.
+  /// \return A pair of the store part indexed by constants, and the store part
+  /// indexed by symbolic expressions.
   std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   getStoredCoreExpressions(std::set<const Array *> &replacements) const;
 
+  /// \brief Marking the core constraints on the path condition, and all the
+  /// relevant values on the dependency graph, given an unsatistiability core.
   void unsatCoreMarking(std::vector<ref<Expr> > unsatCore,
                         ExecutionState &state);
 
+  /// \brief Compute the allocations that are relevant for the interpolant.
   void computeCoreAllocations(AllocationGraph *g);
 
+  /// \brief Print the content of the tree node object to the LLVM error stream.
   void dump() const;
 
+  /// \brief Print the content of the tree node object into a stream.
+  ///
+  /// \param The stream to print the data to.
   void print(llvm::raw_ostream &stream) const;
 
 private:
@@ -540,11 +604,15 @@ private:
   void print(llvm::raw_ostream &stream, const unsigned tabNum) const;
 };
 
+/// \brief The top-level structure that implements the interpolation
+/// functionality
 class ITree {
   typedef std::vector<ref<Expr> > ExprList;
   typedef ExprList::iterator iterator;
   typedef ExprList::const_iterator const_iterator;
 
+  // Several static fields for profiling the execution time of this class's
+  // methods.
   static StatTimer setCurrentINodeTimer;
   static StatTimer removeTimer;
   static StatTimer subsumptionCheckTimer;
@@ -552,7 +620,7 @@ class ITree {
   static StatTimer splitTimer;
   static StatTimer executeOnNodeTimer;
 
-  // @brief Number of subsumption checks for statistical purposes
+  /// \brief Number of subsumption checks for statistical purposes
   static unsigned long subsumptionCheckCount;
 
   ITreeNode *currentINode;
@@ -562,10 +630,10 @@ class ITree {
   void printNode(llvm::raw_ostream &stream, ITreeNode *n,
                  std::string edges) const;
 
-  /// @brief Displays method running time statistics
+  /// \brief Displays method running time statistics
   static void printTimeStat(llvm::raw_ostream &stream);
 
-  /// @brief Displays subsumption table statistics
+  /// \brief Displays subsumption table statistics
   void printTableStat(llvm::raw_ostream &stream) const;
 
 public:
@@ -575,42 +643,76 @@ public:
 
   ~ITree();
 
+  /// \brief Store an entry into the subsumption table.
   void store(SubsumptionTableEntry *subItem);
 
+  /// \brief Set the reference to the KLEE state in the current interpolation
+  /// data holder (interpolation tree node) that is currently being processed.
+  /// This also sets the id of the interpolation tree node to be the given
+  /// pointer value.
+  ///
+  /// \param The KLEE execution state to associate the current node with.
+  /// \param The id to be set for the current node.
   void setCurrentINode(ExecutionState &state, uintptr_t programPoint);
 
+  /// \brief Deletes the interpolation tree node
   void remove(ITreeNode *node);
 
+  /// \brief Invokes the subsumption check
   bool subsumptionCheck(TimingSolver *solver, ExecutionState &state,
                         double timeout);
 
+  /// \brief Mark the path condition in the interpolation tree node associated
+  /// with the given KLEE execution state.
   void markPathCondition(ExecutionState &state, TimingSolver *solver);
 
+  /// \brief Creates fresh interpolation data holder for the two given KLEE
+  /// execution states.
+  /// This method is to be invoked after KLEE splits its own state due to state
+  /// forking.
   std::pair<ITreeNode *, ITreeNode *>
   split(ITreeNode *parent, ExecutionState *left, ExecutionState *right);
 
+  /// \brief Abstractly execute an instruction of no argument for building
+  /// dependency information.
   void execute(llvm::Instruction *instr);
 
+  /// \brief Abstractly execute an instruction of one argument for building
+  /// dependency information.
   void execute(llvm::Instruction *instr, ref<Expr> arg1);
 
+  /// \brief Abstractly execute an instruction of two arguments for building
+  /// dependency information.
   void execute(llvm::Instruction *instr, ref<Expr> arg1, ref<Expr> arg2);
 
+  /// \brief Abstractly execute an instruction of three arguments for building
+  /// dependency information.
   void execute(llvm::Instruction *instr, ref<Expr> arg1, ref<Expr> arg2,
                ref<Expr> arg3);
 
+  /// \brief Abstractly execute an instruction of a number of arguments for
+  /// building dependency information.
   void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
 
+  /// \brief Abstractly execute a PHI instruction for building dependency
+  /// information.
   void executePHI(llvm::Instruction *instr, unsigned int incomingBlock,
                   ref<Expr> valueExpr);
 
+  /// \brief General method for executing an instruction for building dependency
+  /// information, given a particular interpolation tree node.
   static void executeOnNode(ITreeNode *node, llvm::Instruction *instr,
                             std::vector<ref<Expr> > &args);
 
+  /// \brief Print the content of the tree node object into a stream.
+  ///
+  /// \param The stream to print the data to.
   void print(llvm::raw_ostream &stream);
 
+  /// \brief Print the content of the tree node object to the LLVM error stream
   void dump();
 
-  /// @brief Outputs interpolation statistics to standard error.
+  /// \brief Outputs interpolation statistics to LLVM error stream.
   void dumpInterpolationStat();
 };
 }

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -403,6 +403,7 @@ class SubsumptionTableEntry {
   /// expression, false otherwise.
   static bool hasFree(std::set<const Array *> &existentials, ref<Expr> expr);
 
+  /// \brief Determines if a subexpression is in an expression
   static bool findSubExpression(ref<Expr> expr, ref<Expr> subExpr);
 
   /// \brief Replace a sub-expression with another within an original expression

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -582,8 +582,7 @@ public:
 
   /// \brief Marking the core constraints on the path condition, and all the
   /// relevant values on the dependency graph, given an unsatistiability core.
-  void unsatCoreMarking(std::vector<ref<Expr> > unsatCore,
-                        ExecutionState &state);
+  void unsatCoreMarking(std::vector<ref<Expr> > unsatCore);
 
   /// \brief Compute the allocations that are relevant for the interpolant.
   void computeCoreAllocations(AllocationGraph *g);

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -404,7 +404,7 @@ class SubsumptionTableEntry {
   static bool hasFree(std::set<const Array *> &existentials, ref<Expr> expr);
 
   /// \brief Determines if a subexpression is in an expression
-  static bool findSubExpression(ref<Expr> expr, ref<Expr> subExpr);
+  static bool hasSubExpression(ref<Expr> expr, ref<Expr> subExpr);
 
   /// \brief Replace a sub-expression with another within an original expression
   static ref<Expr> replaceExpr(ref<Expr> originalExpr, ref<Expr> replacedExpr,

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -491,7 +491,7 @@ class ITreeNode {
   static StatTimer splitTimer;
   static StatTimer executeTimer;
   static StatTimer bindCallArgumentsTimer;
-  static StatTimer popAbstractDependencyFrameTimer;
+  static StatTimer bindReturnValueTimer;
   static StatTimer getStoredExpressionsTimer;
   static StatTimer getStoredCoreExpressionsTimer;
   static StatTimer computeCoreAllocationsTimer;
@@ -556,8 +556,8 @@ public:
                          std::vector<ref<Expr> > &arguments);
 
   /// \brief This propagates the dependency due to the return value of a call
-  void popAbstractDependencyFrame(llvm::CallInst *site, llvm::Instruction *inst,
-                                  ref<Expr> returnValue);
+  void bindReturnValue(llvm::CallInst *site, llvm::Instruction *inst,
+                       ref<Expr> returnValue);
 
   /// \brief This retrieves the allocations known at this state, and the
   /// expressions stored in the allocations.

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -391,8 +391,8 @@ class SubsumptionTableEntry {
   /// set.
   /// \return true if a variable in the set is found in the expression, false
   /// otherwise.
-  static bool hasExistentials(std::set<const Array *> &existentials,
-                              ref<Expr> expr);
+  static bool hasVariableInSet(std::set<const Array *> &existentials,
+                               ref<Expr> expr);
 
   /// \brief Test for the non-existence of a variable in a set in an expression.
   ///
@@ -401,7 +401,8 @@ class SubsumptionTableEntry {
   /// the set.
   /// \return true if none of the variable in the set is found in the
   /// expression, false otherwise.
-  static bool hasFree(std::set<const Array *> &existentials, ref<Expr> expr);
+  static bool hasVariableNotInSet(std::set<const Array *> &existentials,
+                                  ref<Expr> expr);
 
   /// \brief Determines if a subexpression is in an expression
   static bool hasSubExpression(ref<Expr> expr, ref<Expr> subExpr);

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -709,7 +709,7 @@ public:
   /// \param The stream to print the data to.
   void print(llvm::raw_ostream &stream);
 
-  /// \brief Print the content of the tree node object to the LLVM error stream
+  /// \brief Print the content of the tree object to the LLVM error stream
   void dump();
 
   /// \brief Outputs interpolation statistics to LLVM error stream.

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -403,7 +403,7 @@ class SubsumptionTableEntry {
   /// expression, false otherwise.
   static bool hasFree(std::set<const Array *> &existentials, ref<Expr> expr);
 
-  static bool containShadowExpr(ref<Expr> expr, ref<Expr> shadowExpr);
+  static bool findSubExpression(ref<Expr> expr, ref<Expr> subExpr);
 
   /// \brief Replace a sub-expression with another within an original expression
   static ref<Expr> replaceExpr(ref<Expr> originalExpr, ref<Expr> replacedExpr,


### PR DESCRIPTION
This PR is for resolving issues #9 and #12 .

I could identify some refactoring tasks to be done further, but they are for a separate PR after this one is merged. They are:
* Reimplement SubsumptionTableEntry::replaceExpr using ApplySubstitutionVisitor
* Reimplement SubsumptionTableEntry::hasSubExpression using ApplySubstitutionVisitor
* Make small methods inlined.
* `unsatCoreMarking` and `markPathCondition` possibly unifiable into the same method.



