### PR TITLE
Made print / dump methods const

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1635,9 +1635,8 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
       // of the solver to decide its satisfiability, and no generation
       // of the unsatisfiability core.
       if (INTERPOLATION_ENABLED && ((!branches.first && branches.second) ||
-                                    (branches.first && !branches.second))) {
+                                    (branches.first && !branches.second)))
         interpTree->execute(i);
-      }
     }
     break;
   }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -721,7 +721,9 @@ void SearchTree::setAsCore(PathCondition *pathCondition) {
 
   assert(SearchTree::instance && "Search tree graph not initialized");
 
-  instance->pathConditionMap[pathCondition]->pathConditionTable[pathCondition].second = true;
+  instance->pathConditionMap[pathCondition]
+      ->pathConditionTable[pathCondition]
+      .second = true;
 }
 
 void SearchTree::save(std::string dotFileName) {
@@ -794,14 +796,14 @@ PathCondition::packInterpolant(std::set<const Array *> &replacements) {
   return res;
 }
 
-void PathCondition::dump() {
+void PathCondition::dump() const {
   this->print(llvm::errs());
   llvm::errs() << "\n";
 }
 
-void PathCondition::print(llvm::raw_ostream &stream) {
+void PathCondition::print(llvm::raw_ostream &stream) const {
   stream << "[";
-  for (PathCondition *it = this; it != 0; it = it->tail) {
+  for (const PathCondition *it = this; it != 0; it = it->tail) {
     it->constraint->print(stream);
     stream << ": " << (it->core ? "core" : "non-core");
     if (it->tail != 0)
@@ -1209,7 +1211,7 @@ SubsumptionTableEntry::getSubstitution(ref<Expr> equalities,
   // variable whereas the rhs is an expression on the free variables.
   if (llvm::isa<EqExpr>(equalities.get())) {
     ref<Expr> lhs = equalities->getKid(0);
-    if (llvm::isa<ReadExpr>(lhs.get()) || llvm::isa<ConcatExpr>(lhs.get())) {
+    if (isVariable(lhs)) {
       map[lhs] = equalities->getKid(1);
       return ConstantExpr::alloc(1, Expr::Bool);
     }
@@ -1646,11 +1648,6 @@ bool SubsumptionTableEntry::subsumed(
   return false;
 }
 
-void SubsumptionTableEntry::dump() const {
-  this->print(llvm::errs());
-  llvm::errs() << "\n";
-}
-
 void SubsumptionTableEntry::print(llvm::raw_ostream &stream) const {
   stream << "------------ Subsumption Table Entry ------------\n";
   stream << "Program point = " << nodeId << "\n";
@@ -1995,7 +1992,7 @@ void ITree::printNode(llvm::raw_ostream &stream, ITreeNode *n,
   }
 }
 
-void ITree::print(llvm::raw_ostream &stream) {
+void ITree::print(llvm::raw_ostream &stream) const {
   stream << "------------------------- ITree Structure "
             "---------------------------\n";
   stream << this->root->nodeId;
@@ -2005,11 +2002,12 @@ void ITree::print(llvm::raw_ostream &stream) {
   this->printNode(stream, this->root, "");
   stream << "\n------------------------- Subsumption Table "
             "-------------------------\n";
-  for (std::map<uintptr_t, std::vector<SubsumptionTableEntry *> >::iterator
+  for (std::map<uintptr_t,
+                std::vector<SubsumptionTableEntry *> >::const_iterator
            it = subsumptionTable.begin(),
            itEnd = subsumptionTable.end();
        it != itEnd; ++it) {
-    for (std::vector<SubsumptionTableEntry *>::iterator
+    for (std::vector<SubsumptionTableEntry *>::const_iterator
              it1 = it->second.begin(),
              it1End = it->second.end();
          it1 != it1End; ++it1) {
@@ -2018,7 +2016,7 @@ void ITree::print(llvm::raw_ostream &stream) {
   }
 }
 
-void ITree::dump() { this->print(llvm::errs()); }
+void ITree::dump() const { this->print(llvm::errs()); }
 
 /**/
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -333,9 +333,9 @@ public:
 
   ref<Expr> packInterpolant(std::set<const Array *> &replacements);
 
-  void dump();
+  void dump() const;
 
-  void print(llvm::raw_ostream &stream);
+  void print(llvm::raw_ostream &stream) const;
 };
 
 /// \brief The class that implements an entry (record) in the subsumption table.
@@ -469,7 +469,22 @@ public:
       TimingSolver *solver, ExecutionState &state, double timeout,
       std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore> const);
 
-  void dump() const;
+  /// Tests if the argument is a variable. A variable here is defined to be
+  /// either a symbolic concatenation or a symbolic read. A concatenation in
+  /// KLEE concatenates reads, and hence can be considered to be a symbolic
+  /// read.
+  ///
+  /// \param A KLEE expression.
+  /// \return true if the parameter is either a concatenation or a read,
+  ///         otherwise, return false.
+  static bool isVariable(ref<Expr> expr) {
+    return llvm::isa<ConcatExpr>(expr.get()) || llvm::isa<ReadExpr>(expr.get());
+  }
+
+  void dump() const {
+    this->print(llvm::errs());
+    llvm::errs() << "\n";
+  }
 
   void print(llvm::raw_ostream &stream) const;
 
@@ -704,10 +719,10 @@ public:
   /// \brief Print the content of the tree node object into a stream.
   ///
   /// \param The stream to print the data to.
-  void print(llvm::raw_ostream &stream);
+  void print(llvm::raw_ostream &stream) const;
 
   /// \brief Print the content of the tree object to the LLVM error stream
-  void dump();
+  void dump() const;
 
   /// \brief Outputs interpolation statistics to LLVM error stream.
   void dumpInterpolationStat();


### PR DESCRIPTION
Some nice ideas borrowed from the development branch. Const methods are safer and may execute faster.