### PR TITLE
Removal of EnvironmentAllocation Class and Regression Fixes

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1296,6 +1296,10 @@ void Dependency::markAllValues(AllocationGraph *g, llvm::Value *val) {
         }
       }
     }
+
+    if (llvm::isa<llvm::Constant>(val))
+      return;
+
     assert(!"unknown value");
   }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -858,7 +858,8 @@ void Dependency::execute(llvm::Instruction *instr,
           (calleeName.equals("__ctype_b_locargs") && args.size() == 1) ||
           calleeName.equals("puts") || calleeName.equals("fflush") ||
           calleeName.equals("_Znwm") || calleeName.equals("_Znam") ||
-          calleeName.equals("strcmp") || calleeName.equals("strncmp")) {
+          calleeName.equals("strcmp") || calleeName.equals("strncmp") ||
+          (calleeName.equals("__errno_location") && args.size() == 1)) {
         getNewVersionedValue(instr, args.at(0));
       } else if (calleeName.equals("_ZNSi5seekgElSt12_Ios_Seekdir") &&
                  args.size() == 4) {

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -857,10 +857,37 @@ void Dependency::execute(llvm::Instruction *instr,
           (calleeName.equals("__ctype_b_locargs") && args.size() == 1) ||
           calleeName.equals("puts") || calleeName.equals("fflush") ||
           calleeName.equals("_Znwm") || calleeName.equals("_Znam") ||
-          calleeName.equals("strcmp") || calleeName.equals("strncmp") ||
-          calleeName.equals(
-              "_ZNSt13basic_fstreamIcSt11char_traitsIcEE7is_openEv")) {
+          calleeName.equals("strcmp") || calleeName.equals("strncmp")) {
         getNewVersionedValue(instr, args.at(0));
+      } else if (calleeName.equals("_ZNSi5seekgElSt12_Ios_Seekdir") &&
+                 args.size() == 4) {
+        VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
+        for (unsigned i = 0; i < 3; ++i) {
+          VersionedValue *arg =
+              getLatestValue(instr->getOperand(i), args.at(i + 1));
+          if (arg)
+            addDependency(arg, returnValue);
+        }
+      } else if (calleeName.equals(
+                     "_ZNSt13basic_fstreamIcSt11char_traitsIcEE7is_openEv") &&
+                 args.size() == 2) {
+        VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
+        VersionedValue *arg = getLatestValue(instr->getOperand(0), args.at(1));
+        if (arg)
+          addDependency(arg, returnValue);
+      } else if (calleeName.equals("_ZNSi5tellgEv") && args.size() == 2) {
+        VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
+        VersionedValue *arg = getLatestValue(instr->getOperand(0), args.at(1));
+        if (arg)
+          addDependency(arg, returnValue);
+      } else if (calleeName.equals("powl") && args.size() == 3) {
+        VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
+        for (unsigned i = 0; i < 2; ++i) {
+          VersionedValue *arg =
+              getLatestValue(instr->getOperand(i), args.at(i + 1));
+          if (arg)
+            addDependency(arg, returnValue);
+        }
       } else if (calleeName.equals("malloc") && args.size() == 1) {
         // malloc is an allocation-type instruction: its single argument is the
         // return address.

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -773,6 +773,7 @@ bool Dependency::buildLoadDependency(llvm::Value *address,
            allocIter = addressAllocList.begin(),
            allocIterEnd = addressAllocList.end();
        allocIter != allocIterEnd; ++allocIter) {
+
     std::vector<VersionedValue *> storedValue = stores(*allocIter);
 
     if (storedValue.empty())
@@ -992,7 +993,6 @@ void Dependency::execute(llvm::Instruction *instr,
     case llvm::Instruction::Load: {
       VersionedValue *addressValue =
           getLatestValue(instr->getOperand(0), address);
-
       if (addressValue) {
         std::vector<Allocation *> allocations =
             resolveAllocationTransitively(addressValue);
@@ -1192,6 +1192,10 @@ void Dependency::execute(llvm::Instruction *instr,
       }
 
       VersionedValue *newValue = 0;
+      if (op1) {
+        newValue = getNewVersionedValue(instr, result);
+        addDependency(op1, newValue);
+      }
       if (op2) {
         if (newValue)
           addDependency(op2, newValue);

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -882,7 +882,8 @@ void Dependency::execute(llvm::Instruction *instr,
         VersionedValue *arg = getLatestValue(instr->getOperand(0), args.at(1));
         if (arg)
           addDependency(arg, returnValue);
-      } else if (calleeName.equals("powl") && args.size() == 3) {
+      } else if ((calleeName.equals("powl") && args.size() == 3) ||
+                 (calleeName.equals("gettimeofday") && args.size() == 3)) {
         VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
         for (unsigned i = 0; i < 2; ++i) {
           VersionedValue *arg =

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1003,6 +1003,11 @@ void Dependency::execute(llvm::Instruction *instr,
           addPointerEquality(
               getNewVersionedValue(instr, argExpr),
               getInitialAllocation(instr->getOperand(0), argExpr));
+        } else if (llvm::isa<llvm::Argument>(instr->getOperand(0))) {
+          VersionedValue *arg =
+              getNewVersionedValue(instr->getOperand(0), argExpr);
+          VersionedValue *returnValue = getNewVersionedValue(instr, argExpr);
+          addDependency(arg, returnValue);
         } else {
           assert(!"operand not found");
         }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -851,15 +851,14 @@ void Dependency::execute(llvm::Instruction *instr,
       std::string getValuePrefix("klee_get_value");
 
       if ((calleeName.equals("getpagesize") && args.size() == 1) ||
-	  (calleeName.equals("ioctl") && args.size() == 4) ||
-	  (calleeName.equals("__ctype_b_loc") && args.size() == 1) ||
-	  (calleeName.equals("__ctype_b_locargs") && args.size() == 1) ||
-	  calleeName.equals("puts") ||
-	  calleeName.equals("fflush") ||
-	  calleeName.equals("_Znwm") ||
-	  calleeName.equals("_Znam") ||
-	  calleeName.equals("strcmp") ||
-	  calleeName.equals("strncmp")) {
+          (calleeName.equals("ioctl") && args.size() == 4) ||
+          (calleeName.equals("__ctype_b_loc") && args.size() == 1) ||
+          (calleeName.equals("__ctype_b_locargs") && args.size() == 1) ||
+          calleeName.equals("puts") || calleeName.equals("fflush") ||
+          calleeName.equals("_Znwm") || calleeName.equals("_Znam") ||
+          calleeName.equals("strcmp") || calleeName.equals("strncmp") ||
+          calleeName.equals(
+              "_ZNSt13basic_fstreamIcSt11char_traitsIcEE7is_openEv")) {
         getNewVersionedValue(instr, args.at(0));
       } else if (calleeName.equals("malloc") && args.size() == 1) {
         // malloc is an allocation-type instruction: its single argument is the

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1181,11 +1181,18 @@ void Dependency::execute(llvm::Instruction *instr,
       VersionedValue *op1 = getLatestValue(instr->getOperand(0), op1Expr);
       VersionedValue *op2 = getLatestValue(instr->getOperand(1), op2Expr);
 
-      VersionedValue *newValue = 0;
-      if (op1) {
-        newValue = getNewVersionedValue(instr, result);
-        addDependency(op1, newValue);
+      if (!op1 &&
+          (instr->getParent()->getParent()->getName().equals("klee_range") &&
+           instr->getOperand(0)->getName().equals("start"))) {
+        op1 = getNewVersionedValue(instr->getOperand(0), op1Expr);
       }
+      if (!op2 &&
+          (instr->getParent()->getParent()->getName().equals("klee_range") &&
+           instr->getOperand(1)->getName().equals("end"))) {
+        op2 = getNewVersionedValue(instr->getOperand(1), op2Expr);
+      }
+
+      VersionedValue *newValue = 0;
       if (op2) {
         if (newValue)
           addDependency(op2, newValue);

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -853,7 +853,13 @@ void Dependency::execute(llvm::Instruction *instr,
       if ((calleeName.equals("getpagesize") && args.size() == 1) ||
 	  (calleeName.equals("ioctl") && args.size() == 4) ||
 	  (calleeName.equals("__ctype_b_loc") && args.size() == 1) ||
-	  (calleeName.equals("__ctype_b_locargs") && args.size() == 1)) {
+	  (calleeName.equals("__ctype_b_locargs") && args.size() == 1) ||
+	  calleeName.equals("puts") ||
+	  calleeName.equals("fflush") ||
+	  calleeName.equals("_Znwm") ||
+	  calleeName.equals("_Znam") ||
+	  calleeName.equals("strcmp") ||
+	  calleeName.equals("strncmp")) {
         getNewVersionedValue(instr, args.at(0));
       } else if (calleeName.equals("malloc") && args.size() == 1) {
         // malloc is an allocation-type instruction: its single argument is the

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -138,11 +138,12 @@ ShadowArray::getShadowExpression(ref<Expr> expr,
         getShadowExpression(expr->getKid(1), replacements));
     break;
   }
-  default: {
-    assert(0 && "unhandled Expr type");
-    ret = expr;
+  case Expr::NotOptimized: {
+    ret = NotOptimizedExpr::create(getShadowExpression(expr->getKid(0), replacements));
     break;
   }
+  default:
+    assert(!"unhandled Expr type");
   }
 
   return ret;


### PR DESCRIPTION
This is a fix for #105 , which should simplify the code. In addition, this PR also:
* ensures that `test/Runtime/POSIX/Getenv.c` and `test/Runtime/Uclibc/Environ.c` regression tests succeed. Both calls system function `getenv` whose dependency construction used to depend on `EnvironmentAllocation` class,
* contains a fix for 18 issues related to regression test (`make check`) failures (issue #13), and
* ensures that `klee-examples/basic` benchmark programs has subsumption/reported error numbers unchanged.