### PR TITLE
Made ITree::dumpInterpolationStat method const

### DIFF
--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1752,7 +1752,7 @@ void ITree::printTableStat(llvm::raw_ostream &stream) const {
                 (double)subsumptionCheckCount) << "\n";
 }
 
-void ITree::dumpInterpolationStat() {
+void ITree::dumpInterpolationStat() const {
   bool useColors = llvm::errs().is_displayed();
   if (useColors)
     llvm::errs().changeColor(llvm::raw_ostream::GREEN,

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -725,7 +725,7 @@ public:
   void dump() const;
 
   /// \brief Outputs interpolation statistics to LLVM error stream.
-  void dumpInterpolationStat();
+  void dumpInterpolationStat() const;
 };
 }
 #endif /* ITREE_H_ */


### PR DESCRIPTION
As suggested in https://github.com/tracer-x/klee/pull/106, this new PR made one more method as const. However, `ITree::printTimeStat , SubsumptionTableEntry::printStat`, and 
`ITreeNode::printTimeStat `actually cannot use `const` because they are static method.