### PR TITLE
Prevent graph cycle before adding a new edge

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1444,24 +1444,26 @@ Dependency::directAllocationSources(VersionedValue *target) const {
 }
 
 void Dependency::recursivelyBuildAllocationGraph(
-    AllocationGraph *g, VersionedValue *target, Allocation *alloc,
-    Allocation *parentAlloc) const {
-  if (!target)
+    AllocationGraph *g, VersionedValue *source, Allocation *target,
+    std::set<Allocation *> parentTargets) const {
+  if (!source)
     return;
 
   std::vector<Allocation *> ret;
   std::map<VersionedValue *, Allocation *> sourceEdges =
-      directAllocationSources(target);
+      directAllocationSources(source);
 
   for (std::map<VersionedValue *, Allocation *>::iterator
            it = sourceEdges.begin(),
            itEnd = sourceEdges.end();
        it != itEnd; ++it) {
-    // FIXME: Cheap detection of direct and 2-nodes cycles. In general, any
-    // cycle should not be allowed.
-    if (it->second != alloc && it->second != parentAlloc) {
-      g->addNewEdge(it->second, alloc);
-      recursivelyBuildAllocationGraph(g, it->first, it->second, alloc);
+    // Here we prevent construction of cycle in the graph by checking if the
+    // source equals target or included as an ancestor.
+    if (it->second != target &&
+        parentTargets.find(it->second) == parentTargets.end()) {
+      g->addNewEdge(it->second, target);
+      parentTargets.insert(target);
+      recursivelyBuildAllocationGraph(g, it->first, it->second, parentTargets);
     }
   }
 }
@@ -1477,7 +1479,8 @@ void Dependency::buildAllocationGraph(AllocationGraph *g,
            itEnd = sourceEdges.end();
        it != itEnd; ++it) {
     g->addNewSink(it->second);
-    recursivelyBuildAllocationGraph(g, it->first, it->second, 0);
+    recursivelyBuildAllocationGraph(g, it->first, it->second,
+                                    std::set<Allocation *>());
   }
 }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -17,7 +17,6 @@
 #include "Dependency.h"
 
 #include "klee/CommandLine.h"
-#include <queue>
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
 #include <llvm/IR/Constants.h>
@@ -227,53 +226,6 @@ void AllocationGraph::addNewSink(Allocation *candidateSink) {
   AllocationNode *newNode = new AllocationNode(candidateSink, 0);
   allNodes.push_back(newNode);
   sinks.push_back(newNode);
-}
-
-bool AllocationGraph::isReachable(Allocation *source, Allocation *target) {
-  AllocationNode *sourceNode = 0;
-  AllocationNode *targetNode = 0;
-
-  for (std::vector<AllocationNode *>::iterator it = allNodes.begin(),
-                                               itEnd = allNodes.end();
-       it != itEnd; ++it) {
-    if (!targetNode && (*it)->getAllocation() == target) {
-      targetNode = (*it);
-      if (sourceNode)
-        break;
-    }
-
-    if (!sourceNode && (*it)->getAllocation() == source) {
-      sourceNode = (*it);
-      if (targetNode)
-        break;
-    }
-  }
-
-  if (!sourceNode || !targetNode) {
-    return false;
-  } else {
-    // Using BFS to check path between source to target
-    std::queue<AllocationNode *> queue;
-    queue.push(sourceNode);
-
-    while (!queue.empty()) {
-      AllocationNode *currNode = queue.front();
-      queue.pop();
-
-      for (std::vector<AllocationNode *>::const_iterator
-               it = currNode->getParents().begin(),
-               itEnd = currNode->getParents().end();
-           it != itEnd; ++it) {
-
-        if (*it == targetNode) {
-          return true;
-        } else {
-          queue.push(*it);
-        }
-      }
-    }
-  }
-  return false;
 }
 
 void AllocationGraph::addNewEdge(Allocation *source, Allocation *target) {
@@ -1505,9 +1457,9 @@ void Dependency::recursivelyBuildAllocationGraph(
            it = sourceEdges.begin(),
            itEnd = sourceEdges.end();
        it != itEnd; ++it) {
-    // Prevent graph cycle: a new edge(u,v) is only inserted if there is no path
-    // from v to u.
-    if (!g->isReachable(alloc, it->second)) {
+    // FIXME: Cheap detection of direct and 2-nodes cycles. In general, any
+    // cycle should not be allowed.
+    if (it->second != alloc && it->second != parentAlloc) {
       g->addNewEdge(it->second, alloc);
       recursivelyBuildAllocationGraph(g, it->first, it->second, alloc);
     }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -946,7 +946,8 @@ void Dependency::execute(llvm::Instruction *instr,
         VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
         VersionedValue *arg = getLatestValue(instr->getOperand(0), args.at(0));
         addDependency(arg, returnValue);
-      } else if ((calleeName.equals("fchmodat") && args.size() == 5)) {
+      } else if (((calleeName.equals("fchmodat") && args.size() == 5)) ||
+                 (calleeName.equals("fchownat") && args.size() == 6)) {
         VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
         for (unsigned i = 0; i < 2; ++i) {
           VersionedValue *arg =
@@ -955,6 +956,7 @@ void Dependency::execute(llvm::Instruction *instr,
             addDependency(arg, returnValue);
         }
       } else {
+        llvm::errs() << calleeName << " argument size: " << args.size();
         assert(!"unhandled external function");
       }
     }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -946,6 +946,14 @@ void Dependency::execute(llvm::Instruction *instr,
         VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
         VersionedValue *arg = getLatestValue(instr->getOperand(0), args.at(0));
         addDependency(arg, returnValue);
+      } else if ((calleeName.equals("fchmodat") && args.size() == 5)) {
+        VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
+        for (unsigned i = 0; i < 2; ++i) {
+          VersionedValue *arg =
+              getLatestValue(instr->getOperand(i), args.at(i + 1));
+          if (arg)
+            addDependency(arg, returnValue);
+        }
       } else {
         assert(!"unhandled external function");
       }

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -607,10 +607,10 @@ class Allocation {
     directAllocationSources(VersionedValue *target) const;
 
     /// \brief Builds dependency graph between memory allocations
-    void recursivelyBuildAllocationGraph(AllocationGraph *g,
-                                         VersionedValue *value,
-                                         Allocation *alloc,
-                                         Allocation *parentAllocation) const;
+    void
+    recursivelyBuildAllocationGraph(AllocationGraph *g, VersionedValue *source,
+                                    Allocation *target,
+                                    std::set<Allocation *> parentTargets) const;
 
     /// \brief Builds dependency graph between memory allocations
     void buildAllocationGraph(AllocationGraph *g, VersionedValue *value) const;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -310,6 +310,12 @@ class Allocation {
 
     void addNewEdge(Allocation *source, Allocation *target);
 
+    /// \brief Detect if there is a path from one allocation node to another
+    /// allocation node in the allocation graph.
+    ///
+    /// \param The allocation to match with its allocation node.
+    bool isReachable(Allocation *from, Allocation *to);
+
     std::set<Allocation *> getSinkAllocations() const;
 
     std::set<Allocation *>

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -310,12 +310,6 @@ class Allocation {
 
     void addNewEdge(Allocation *source, Allocation *target);
 
-    /// \brief Detect if there is a path from one allocation node to another
-    /// allocation node in the allocation graph.
-    ///
-    /// \param The allocation to match with its allocation node.
-    bool isReachable(Allocation *from, Allocation *to);
-
     std::set<Allocation *> getSinkAllocations() const;
 
     std::set<Allocation *>

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1752,7 +1752,7 @@ void ITree::printTableStat(llvm::raw_ostream &stream) const {
                 (double)subsumptionCheckCount) << "\n";
 }
 
-void ITree::dumpInterpolationStat() {
+void ITree::dumpInterpolationStat() const {
   bool useColors = llvm::errs().is_displayed();
   if (useColors)
     llvm::errs().changeColor(llvm::raw_ostream::GREEN,

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -725,7 +725,7 @@ public:
   void dump() const;
 
   /// \brief Outputs interpolation statistics to LLVM error stream.
-  void dumpInterpolationStat();
+  void dumpInterpolationStat() const;
 };
 }
 #endif /* ITREE_H_ */


### PR DESCRIPTION
This PR is a refinement of https://github.com/tracer-x/klee/pull/97. This PR attempts to detect graph cycle in general. The graph cycle prevention can be done by inserting a new edge(u,v) only if there's no path between v to u.  This PR also includes handling external function which needed by `coreutils`.