### PR TITLE
Infinite loop prevention by visiting node only once in the graph

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1444,24 +1444,26 @@ Dependency::directAllocationSources(VersionedValue *target) const {
 }
 
 void Dependency::recursivelyBuildAllocationGraph(
-    AllocationGraph *g, VersionedValue *target, Allocation *alloc,
-    Allocation *parentAlloc) const {
-  if (!target)
+    AllocationGraph *g, VersionedValue *source, Allocation *target,
+    std::set<Allocation *> parentTargets) const {
+  if (!source)
     return;
 
   std::vector<Allocation *> ret;
   std::map<VersionedValue *, Allocation *> sourceEdges =
-      directAllocationSources(target);
+      directAllocationSources(source);
 
   for (std::map<VersionedValue *, Allocation *>::iterator
            it = sourceEdges.begin(),
            itEnd = sourceEdges.end();
        it != itEnd; ++it) {
-    // FIXME: Cheap detection of direct and 2-nodes cycles. In general, any
-    // cycle should not be allowed.
-    if (it->second != alloc && it->second != parentAlloc) {
-      g->addNewEdge(it->second, alloc);
-      recursivelyBuildAllocationGraph(g, it->first, it->second, alloc);
+    // Here we prevent construction of cycle in the graph by checking if the
+    // source equals target or included as an ancestor.
+    if (it->second != target &&
+        parentTargets.find(it->second) == parentTargets.end()) {
+      g->addNewEdge(it->second, target);
+      parentTargets.insert(target);
+      recursivelyBuildAllocationGraph(g, it->first, it->second, parentTargets);
     }
   }
 }
@@ -1477,7 +1479,8 @@ void Dependency::buildAllocationGraph(AllocationGraph *g,
            itEnd = sourceEdges.end();
        it != itEnd; ++it) {
     g->addNewSink(it->second);
-    recursivelyBuildAllocationGraph(g, it->first, it->second, 0);
+    recursivelyBuildAllocationGraph(g, it->first, it->second,
+                                    std::set<Allocation *>());
   }
 }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -17,7 +17,6 @@
 #include "Dependency.h"
 
 #include "klee/CommandLine.h"
-#include <queue>
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
 #include <llvm/IR/Constants.h>
@@ -227,53 +226,6 @@ void AllocationGraph::addNewSink(Allocation *candidateSink) {
   AllocationNode *newNode = new AllocationNode(candidateSink, 0);
   allNodes.push_back(newNode);
   sinks.push_back(newNode);
-}
-
-bool AllocationGraph::isReachable(Allocation *source, Allocation *target) {
-  AllocationNode *sourceNode = 0;
-  AllocationNode *targetNode = 0;
-
-  for (std::vector<AllocationNode *>::iterator it = allNodes.begin(),
-                                               itEnd = allNodes.end();
-       it != itEnd; ++it) {
-    if (!targetNode && (*it)->getAllocation() == target) {
-      targetNode = (*it);
-      if (sourceNode)
-        break;
-    }
-
-    if (!sourceNode && (*it)->getAllocation() == source) {
-      sourceNode = (*it);
-      if (targetNode)
-        break;
-    }
-  }
-
-  if (!sourceNode || !targetNode) {
-    return false;
-  } else {
-    // Using BFS to check path between source to target
-    std::queue<AllocationNode *> queue;
-    queue.push(sourceNode);
-
-    while (!queue.empty()) {
-      AllocationNode *currNode = queue.front();
-      queue.pop();
-
-      for (std::vector<AllocationNode *>::const_iterator
-               it = currNode->getParents().begin(),
-               itEnd = currNode->getParents().end();
-           it != itEnd; ++it) {
-
-        if (*it == targetNode) {
-          return true;
-        } else {
-          queue.push(*it);
-        }
-      }
-    }
-  }
-  return false;
 }
 
 void AllocationGraph::addNewEdge(Allocation *source, Allocation *target) {
@@ -1505,9 +1457,9 @@ void Dependency::recursivelyBuildAllocationGraph(
            it = sourceEdges.begin(),
            itEnd = sourceEdges.end();
        it != itEnd; ++it) {
-    // Prevent graph cycle: a new edge(u,v) is only inserted if there is no path
-    // from v to u.
-    if (!g->isReachable(alloc, it->second)) {
+    // FIXME: Cheap detection of direct and 2-nodes cycles. In general, any
+    // cycle should not be allowed.
+    if (it->second != alloc && it->second != parentAlloc) {
       g->addNewEdge(it->second, alloc);
       recursivelyBuildAllocationGraph(g, it->first, it->second, alloc);
     }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -946,7 +946,8 @@ void Dependency::execute(llvm::Instruction *instr,
         VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
         VersionedValue *arg = getLatestValue(instr->getOperand(0), args.at(0));
         addDependency(arg, returnValue);
-      } else if ((calleeName.equals("fchmodat") && args.size() == 5)) {
+      } else if (((calleeName.equals("fchmodat") && args.size() == 5)) ||
+                 (calleeName.equals("fchownat") && args.size() == 6)) {
         VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
         for (unsigned i = 0; i < 2; ++i) {
           VersionedValue *arg =
@@ -955,6 +956,7 @@ void Dependency::execute(llvm::Instruction *instr,
             addDependency(arg, returnValue);
         }
       } else {
+        llvm::errs() << calleeName << " argument size: " << args.size();
         assert(!"unhandled external function");
       }
     }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -946,6 +946,14 @@ void Dependency::execute(llvm::Instruction *instr,
         VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
         VersionedValue *arg = getLatestValue(instr->getOperand(0), args.at(0));
         addDependency(arg, returnValue);
+      } else if ((calleeName.equals("fchmodat") && args.size() == 5)) {
+        VersionedValue *returnValue = getNewVersionedValue(instr, args.at(0));
+        for (unsigned i = 0; i < 2; ++i) {
+          VersionedValue *arg =
+              getLatestValue(instr->getOperand(i), args.at(i + 1));
+          if (arg)
+            addDependency(arg, returnValue);
+        }
       } else {
         assert(!"unhandled external function");
       }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -334,20 +334,27 @@ std::set<Allocation *> AllocationGraph::getSinksWithAllocations(
 }
 
 void AllocationGraph::consumeSinksWithAllocations(
-    std::vector<Allocation *> allocationsList) {
+    std::vector<Allocation *> allocationsList,
+    std::set<Allocation *> &visitedAlloc) {
   std::set<Allocation *> sinkAllocs(getSinksWithAllocations(allocationsList));
 
+  bool isUnvisitedAlloc = false;
   if (sinkAllocs.empty())
     return;
 
   for (std::set<Allocation *>::iterator it = sinkAllocs.begin(),
                                         itEnd = sinkAllocs.end();
        it != itEnd; ++it) {
-    consumeSinkNode((*it));
+    if (visitedAlloc.find(*it) == visitedAlloc.end()) { // haven't visited
+      isUnvisitedAlloc = true;
+      visitedAlloc.insert(*it);
+      consumeSinkNode((*it));
+    }
   }
 
   // Recurse until fixpoint
-  consumeSinksWithAllocations(allocationsList);
+  if (isUnvisitedAlloc)
+    consumeSinksWithAllocations(allocationsList, visitedAlloc);
 }
 
 void AllocationGraph::print(llvm::raw_ostream &stream) const {
@@ -1361,7 +1368,8 @@ void Dependency::computeCoreAllocations(AllocationGraph *g) {
     // should just contain the allocations that belong to the ancestor
     // dependency nodes, and we then recursively compute the
     // core allocations for the parent.
-    g->consumeSinksWithAllocations(versionedAllocationsList);
+    std::set<Allocation *> visitedAlloc;
+    g->consumeSinksWithAllocations(versionedAllocationsList, visitedAlloc);
     parentDependency->computeCoreAllocations(g);
   }
 }
@@ -1443,9 +1451,9 @@ Dependency::directAllocationSources(VersionedValue *target) const {
   return ret;
 }
 
-void Dependency::recursivelyBuildAllocationGraph(
-    AllocationGraph *g, VersionedValue *source, Allocation *target,
-    std::set<Allocation *> parentTargets) const {
+void Dependency::recursivelyBuildAllocationGraph(AllocationGraph *g,
+                                                 VersionedValue *source,
+                                                 Allocation *target) const {
   if (!source)
     return;
 
@@ -1457,14 +1465,8 @@ void Dependency::recursivelyBuildAllocationGraph(
            it = sourceEdges.begin(),
            itEnd = sourceEdges.end();
        it != itEnd; ++it) {
-    // Here we prevent construction of cycle in the graph by checking if the
-    // source equals target or included as an ancestor.
-    if (it->second != target &&
-        parentTargets.find(it->second) == parentTargets.end()) {
       g->addNewEdge(it->second, target);
-      parentTargets.insert(target);
-      recursivelyBuildAllocationGraph(g, it->first, it->second, parentTargets);
-    }
+      recursivelyBuildAllocationGraph(g, it->first, it->second);
   }
 }
 
@@ -1479,8 +1481,7 @@ void Dependency::buildAllocationGraph(AllocationGraph *g,
            itEnd = sourceEdges.end();
        it != itEnd; ++it) {
     g->addNewSink(it->second);
-    recursivelyBuildAllocationGraph(g, it->first, it->second,
-                                    std::set<Allocation *>());
+    recursivelyBuildAllocationGraph(g, it->first, it->second);
   }
 }
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -607,10 +607,10 @@ class Allocation {
     directAllocationSources(VersionedValue *target) const;
 
     /// \brief Builds dependency graph between memory allocations
-    void recursivelyBuildAllocationGraph(AllocationGraph *g,
-                                         VersionedValue *value,
-                                         Allocation *alloc,
-                                         Allocation *parentAllocation) const;
+    void
+    recursivelyBuildAllocationGraph(AllocationGraph *g, VersionedValue *source,
+                                    Allocation *target,
+                                    std::set<Allocation *> parentTargets) const;
 
     /// \brief Builds dependency graph between memory allocations
     void buildAllocationGraph(AllocationGraph *g, VersionedValue *value) const;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -310,6 +310,12 @@ class Allocation {
 
     void addNewEdge(Allocation *source, Allocation *target);
 
+    /// \brief Detect if there is a path from one allocation node to another
+    /// allocation node in the allocation graph.
+    ///
+    /// \param The allocation to match with its allocation node.
+    bool isReachable(Allocation *from, Allocation *to);
+
     std::set<Allocation *> getSinkAllocations() const;
 
     std::set<Allocation *>

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -310,12 +310,6 @@ class Allocation {
 
     void addNewEdge(Allocation *source, Allocation *target);
 
-    /// \brief Detect if there is a path from one allocation node to another
-    /// allocation node in the allocation graph.
-    ///
-    /// \param The allocation to match with its allocation node.
-    bool isReachable(Allocation *from, Allocation *to);
-
     std::set<Allocation *> getSinkAllocations() const;
 
     std::set<Allocation *>

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -319,7 +319,8 @@ class Allocation {
     /// set, and replace them as sinks with their parents.
     ///
     /// \param The allocation to match the sink nodes with.
-    void consumeSinksWithAllocations(std::vector<Allocation *> allocationsList);
+    void consumeSinksWithAllocations(std::vector<Allocation *> allocationsList,
+                                     std::set<Allocation *> &visitedAlloc);
 
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {
@@ -607,10 +608,9 @@ class Allocation {
     directAllocationSources(VersionedValue *target) const;
 
     /// \brief Builds dependency graph between memory allocations
-    void
-    recursivelyBuildAllocationGraph(AllocationGraph *g, VersionedValue *source,
-                                    Allocation *target,
-                                    std::set<Allocation *> parentTargets) const;
+    void recursivelyBuildAllocationGraph(AllocationGraph *g,
+                                         VersionedValue *source,
+                                         Allocation *target) const;
 
     /// \brief Builds dependency graph between memory allocations
     void buildAllocationGraph(AllocationGraph *g, VersionedValue *value) const;

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1752,7 +1752,7 @@ void ITree::printTableStat(llvm::raw_ostream &stream) const {
                 (double)subsumptionCheckCount) << "\n";
 }
 
-void ITree::dumpInterpolationStat() {
+void ITree::dumpInterpolationStat() const {
   bool useColors = llvm::errs().is_displayed();
   if (useColors)
     llvm::errs().changeColor(llvm::raw_ostream::GREEN,

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -725,7 +725,7 @@ public:
   void dump() const;
 
   /// \brief Outputs interpolation statistics to LLVM error stream.
-  void dumpInterpolationStat();
+  void dumpInterpolationStat() const;
 };
 }
 #endif /* ITREE_H_ */


### PR DESCRIPTION
This PR is actually another alternative from https://github.com/tracer-x/klee/pull/109. The previous PR prevent any cycle before adding a new edge. However, the initial design is creating a dependency graph where graph itself allow a cycle among its node, and this characteristic makes it different with the tree. Therefore, this PR will allow the cycle in the graph, but when the algorithm `AllocationGraph::consumeSinksWithAllocations` recursively visit the `allocation` node, each of the `allocation` node is only visited once to prevent the infinite loop. 

This is the result between `coreutilspr` and this branch:

`Basic-examples:` there's no number of subsumption differences with almost similar execution time. 

`regexp`: The number of subsumption had increased, followed by longer execution time
```
coreutilspr:
subsumed paths = 1072
error paths = 237
Execution time: 98.97
coreutilspr2:
KLEE: done:     subsumed paths = 1083
KLEE: done:     error paths = 241
Execution time: 126.49

```
`coreutils` : When number of subsumption is similar, the number of instruction in most cases are generally lesser.

```
number of subsumption is similar for below test cases
<program-name> < total instruction coreutilspr> <total instruction coreutilspr2> <subsumption>
echo 36854 36662 1
comm 41915 39686 11
uptime 35770 36282 2
users 36203 36281 2
seq 39079 38467 8
expr 38719 38908 2
```