### PR TITLE
Added -clpr-log option and other edits

### DIFF
--- a/include/klee/IncompleteSolver.h
+++ b/include/klee/IncompleteSolver.h
@@ -108,11 +108,12 @@ public:
     return secondary->impl->getUnsatCore();
   }
 #ifdef SUPPORT_CLPR
-  bool validateRecursivePredicate(const ConstraintManager &constraints,
-                                  std::string predicateName,
-                                  std::vector<ref<Expr> > &arguments) {
+  bool validateRecursivePredicate(
+      const ConstraintManager &constraints,
+      std::map<const Array *, uint64_t> &arrayAddressRegistry,
+      std::string predicateName, std::vector<ref<Expr> > &arguments) const {
     return secondary->impl->validateRecursivePredicate(
-        constraints, predicateName, arguments);
+        constraints, arrayAddressRegistry, predicateName, arguments);
   }
 #endif
 };

--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -213,13 +213,15 @@ namespace klee {
     /// \brief Validate a recursive predicate by invoking CLP(R)
     ///
     /// \param the constraints of the current state.
+    /// \param the mapping of arrays to their addresses for building CLP(R)
+    /// expressions.
     /// \param the name of the predicate.
     /// \param the arguments to be passed onto the predicate.
     /// \return true if the predicate holds (valid), false otherwise.
-    virtual bool
-    validateRecursivePredicate(const ConstraintManager &constraints,
-                               std::string predicateName,
-                               std::vector<ref<Expr> > &arguments);
+    virtual bool validateRecursivePredicate(
+        const ConstraintManager &constraints,
+        std::map<const Array *, uint64_t> &arrayAddressRegistry,
+        std::string predicateName, std::vector<ref<Expr> > &arguments) const;
   #endif
   };
 

--- a/include/klee/SolverImpl.h
+++ b/include/klee/SolverImpl.h
@@ -117,13 +117,15 @@ namespace klee {
     /// \brief Validate a recursive predicate by invoking CLP(R)
     ///
     /// \param the constraints of the current state.
+    /// \param the mapping of arrays to their base address for building CLP(R)
+    /// expressions.
     /// \param the name of the predicate.
     /// \param the arguments to be passed onto the predicate.
     /// \return true if the predicate holds (valid), false otherwise.
-    virtual bool
-    validateRecursivePredicate(const ConstraintManager &constraints,
-                               std::string predicateName,
-                               std::vector<ref<Expr> > &arguments) {
+    virtual bool validateRecursivePredicate(
+        const ConstraintManager &constraints,
+        std::map<const Array *, uint64_t> &arrayAddressRegistry,
+        std::string predicateName, std::vector<ref<Expr> > &arguments) const {
       return false;
     }
   #endif

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -306,7 +306,11 @@ private:
 
   // Called on [for now] concrete reads, replaces constant with a symbolic
   // Used for testing.
-  ref<Expr> replaceReadWithSymbolic(ExecutionState &state, ref<Expr> e);
+  ref<Expr> replaceReadWithSymbolic(ExecutionState &state,
+#ifdef SUPPORT_CLPR
+                                    const MemoryObject *mo,
+#endif
+                                    ref<Expr> e);
 
   const Cell& eval(KInstruction *ki, unsigned index, 
                    ExecutionState &state) const;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -650,7 +650,12 @@ class ITree {
   std::map<uintptr_t, std::vector<SubsumptionTableEntry *> > subsumptionTable;
 
 #ifdef SUPPORT_CLPR
+  /// \brief A record of successful klee_join callsites, where the CLP predicate
+  /// has been shown to hold before.
   std::set<llvm::Instruction *> successfulJoinCallsiteList;
+
+  /// \brief This associates an array with its address
+  std::map<const Array *, uint64_t> arrayAddressRegistry;
 #endif
 
   void printNode(llvm::raw_ostream &stream, ITreeNode *n,
@@ -737,6 +742,20 @@ public:
   /// \return true if the callsite is new, false otherwise.
   bool recordJoinCallsite(llvm::Instruction *instr) {
     return successfulJoinCallsiteList.insert(instr).second;
+  }
+
+  /// \brief Register array starting address. This for substituting arrays with
+  /// its address in building CLP expression.
+  ///
+  /// \param the array to associate the address with
+  /// \param the address to associate the array with
+  void registerArrayAddress(const Array *array, uint64_t address) {
+    arrayAddressRegistry[array] = address;
+  }
+
+  /// \brief Retrieve the array address registry
+  std::map<const Array *, uint64_t> &getArrayAddressRegistry() {
+    return arrayAddressRegistry;
   }
 #endif
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -426,7 +426,8 @@ void SpecialFunctionHandler::handleJoin(ExecutionState &state,
   std::string predicateName = readStringAtAddress(state, arguments[0]);
 
   if (executor.clprSolver->validateRecursivePredicate(
-          state.constraints, predicateName, arguments) &&
+          state.constraints, executor.interpTree->getArrayAddressRegistry(),
+          predicateName, arguments) &&
       !executor.interpTree->recordJoinCallsite(target->inst)) {
     // Recursive predicate holding and this callsite has been seen before,
     // terminate state.

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -149,11 +149,11 @@ std::vector< ref<Expr> > TimingSolver::getUnsatCore() {
 }
 
 #ifdef SUPPORT_CLPR
-bool
-TimingSolver::validateRecursivePredicate(const ConstraintManager &constraints,
-                                         std::string predicateName,
-                                         std::vector<ref<Expr> > &arguments) {
-  return solver->validateRecursivePredicate(constraints, predicateName,
-                                            arguments);
+bool TimingSolver::validateRecursivePredicate(
+    const ConstraintManager &constraints,
+    std::map<const Array *, uint64_t> &arrayAddressRegistry,
+    std::string predicateName, std::vector<ref<Expr> > &arguments) const {
+  return solver->validateRecursivePredicate(constraints, arrayAddressRegistry,
+                                            predicateName, arguments);
 }
 #endif

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -71,12 +71,15 @@ namespace klee {
     /// \brief Validate a recursive predicate by invoking CLP(R)
     ///
     /// \param the constraints of the current state.
+    /// \param the mapping of array to its base address for building CLP(R)
+    /// expressions.
     /// \param the name of the predicate.
     /// \param the arguments to be passed onto the predicate.
     /// \return true if the predicate holds (valid), false otherwise.
-    bool validateRecursivePredicate(const ConstraintManager &constraint,
-                                    std::string predicateName,
-                                    std::vector<ref<Expr> > &arguments);
+    bool validateRecursivePredicate(
+        const ConstraintManager &constraint,
+        std::map<const Array *, uint64_t> &arrayAddressRegistry,
+        std::string predicateName, std::vector<ref<Expr> > &arguments) const;
   #endif
   };
 

--- a/lib/Solver/CLPRBuilder.h
+++ b/lib/Solver/CLPRBuilder.h
@@ -46,6 +46,8 @@ class CLPRBuilder {
 
   std::vector<clpr::CLPTerm> auxiliaryConstraints;
 
+  std::map<const Array *, uint64_t> arrayAddressRegistry;
+
 private:  
 
   clpr::CLPTerm bvOne(unsigned width);
@@ -119,6 +121,7 @@ private:
   clpr::CLPTerm buildArray(const char *name, unsigned indexWidth, unsigned valueWidth);
 
 public:
+  static clpr::CLPTerm globalHeap;
 
   CLPRBuilder();
   ~CLPRBuilder();
@@ -134,6 +137,24 @@ public:
     return res;
   }
 
+  /// \brief (Re-)initialize for (re-)building of CLP(R) constraints
+  ///
+  /// \param The address registry.
+  void init(std::map<const Array *, uint64_t> &_arrayAddressRegistry) {
+    auxiliaryConstraints.clear();
+    arrayAddressRegistry.clear();
+    arrayAddressRegistry = _arrayAddressRegistry;
+  }
+
+  /// \brief Gets the beginning iterator of the auxiliary constraints
+  std::vector<clpr::CLPTerm>::iterator auxiliaryConstraintsBegin() {
+    return auxiliaryConstraints.begin();
+  }
+
+  /// \brief Gets the end iterator of the auxiliary constraints
+  std::vector<clpr::CLPTerm>::iterator auxiliaryConstraintsEnd() {
+    return auxiliaryConstraints.end();
+  }
 };
 
 }

--- a/lib/Solver/CachingSolver.cpp
+++ b/lib/Solver/CachingSolver.cpp
@@ -109,11 +109,12 @@ public:
     return unsat_core_to_return;
   }
 #ifdef SUPPORT_CLPR
-  bool validateRecursivePredicate(const ConstraintManager &constraints,
-                                  std::string predicateName,
-                                  std::vector<ref<Expr> > &arguments) {
-    return solver->validateRecursivePredicate(constraints, predicateName,
-                                              arguments);
+  bool validateRecursivePredicate(
+      const ConstraintManager &constraints,
+      std::map<const Array *, uint64_t> &arrayAddressRegistry,
+      std::string predicateName, std::vector<ref<Expr> > &arguments) const {
+    return solver->validateRecursivePredicate(constraints, arrayAddressRegistry,
+                                              predicateName, arguments);
   }
 #endif
 };

--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -97,11 +97,12 @@ public:
     return unsat_core;
   }
 #ifdef SUPPORT_CLPR
-  bool validateRecursivePredicate(const ConstraintManager &constraints,
-                                  std::string predicateName,
-                                  std::vector<ref<Expr> > &arguments) {
-    return solver->validateRecursivePredicate(constraints, predicateName,
-                                              arguments);
+  bool validateRecursivePredicate(
+      const ConstraintManager &constraints,
+      std::map<const Array *, uint64_t> &arrayAddressRegistry,
+      std::string predicateName, std::vector<ref<Expr> > &arguments) const {
+    return solver->validateRecursivePredicate(constraints, arrayAddressRegistry,
+                                              predicateName, arguments);
   }
 #endif
 };

--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -413,11 +413,12 @@ public:
     return solver->getUnsatCore();
   }
 #ifdef SUPPORT_CLPR
-  bool validateRecursivePredicate(const ConstraintManager &constraints,
-                                  std::string predicateName,
-                                  std::vector<ref<Expr> > &arguments) {
-    return solver->validateRecursivePredicate(constraints, predicateName,
-                                              arguments);
+  bool validateRecursivePredicate(
+      const ConstraintManager &constraints,
+      std::map<const Array *, uint64_t> &arrayAddressRegistry,
+      std::string predicateName, std::vector<ref<Expr> > &arguments) const {
+    return solver->validateRecursivePredicate(constraints, arrayAddressRegistry,
+                                              predicateName, arguments);
   }
 #endif
 };

--- a/lib/Solver/QueryLoggingSolver.h
+++ b/lib/Solver/QueryLoggingSolver.h
@@ -80,11 +80,12 @@ public:
       return solver->getUnsatCore();
     }
 #ifdef SUPPORT_CLPR
-  bool validateRecursivePredicate(const ConstraintManager &constraints,
-                                  std::string predicateName,
-                                  std::vector<ref<Expr> > &arguments) {
-    return solver->validateRecursivePredicate(constraints, predicateName,
-                                              arguments);
+  bool validateRecursivePredicate(
+      const ConstraintManager &constraints,
+      std::map<const Array *, uint64_t> &arrayAddressRegistry,
+      std::string predicateName, std::vector<ref<Expr> > &arguments) const {
+    return solver->validateRecursivePredicate(constraints, arrayAddressRegistry,
+                                              predicateName, arguments);
   }
 #endif
 };

--- a/lib/Solver/Solver.cpp
+++ b/lib/Solver/Solver.cpp
@@ -353,11 +353,12 @@ std::vector< ref<Expr> > Solver::getUnsatCore() {
 }
 
 #ifdef SUPPORT_CLPR
-bool Solver::validateRecursivePredicate(const ConstraintManager &constraints,
-                                        std::string predicateName,
-                                        std::vector<ref<Expr> > &arguments) {
-  return impl->validateRecursivePredicate(constraints, predicateName,
-                                          arguments);
+bool Solver::validateRecursivePredicate(
+    const ConstraintManager &constraints,
+    std::map<const Array *, uint64_t> &arrayAddressRegistry,
+    std::string predicateName, std::vector<ref<Expr> > &arguments) const {
+  return impl->validateRecursivePredicate(constraints, arrayAddressRegistry,
+                                          predicateName, arguments);
 }
 #endif
 
@@ -1277,58 +1278,10 @@ public:
   SolverRunStatus getOperationStatusCode();
   std::vector< ref<Expr> > getUnsatCore();
 
-#ifdef SUPPORT_CLPR
-  bool validateRecursivePredicate(const ConstraintManager &constraints,
-                                  std::string predicateName,
-                                  std::vector<ref<Expr> > &arguments) {
-    clpr::CLPTerm queryAtom(predicateName);
-    std::vector<clpr::CLPTerm> constraintsList;
-
-    unsigned i = 0;
-    for (std::vector<ref<Expr> >::const_iterator it = ++(arguments.begin()),
-                                                 itEnd = arguments.end();
-         it != itEnd; ++it) {
-      clpr::CLPTerm clpExpr = builder->construct(*it);
-      std::ostringstream tmpVarName;
-      tmpVarName << "__clpr__arg" << i++ << "__";
-      clpr::CLPTerm varName(tmpVarName.str());
-      queryAtom.addArgument(varName);
-      clpr::CLPTerm constraint("=");
-      constraint.addArgument(varName);
-      constraint.addArgument(clpExpr);
-      constraintsList.push_back(constraint);
-    }
-
-    // Build the query
-    clpr::CLPQuery query;
-
-    // Add the constraints on the path condition
-    for (ConstraintManager::const_iterator it = constraints.begin(),
-                                           itEnd = constraints.end();
-         it != itEnd; ++it) {
-      clpr::CLPTerm clprConstraint = builder->construct(*it);
-      query.addTerm(clprConstraint);
-    }
-
-    for (std::vector<clpr::CLPTerm>::const_iterator
-             it = constraintsList.begin(),
-             itEnd = constraintsList.end();
-         it != itEnd; ++it) {
-      query.addTerm(*it);
-    }
-
-    // Remember order is important in SLDNF, the consequent has to be last.
-    clpr::CLPTerm consequent("not");
-    consequent.addArgument(queryAtom);
-    query.addTerm(consequent);
-
-    engine->query(query);
-    if (!engine->hasSolution()) {
-      return true;
-    }
-    return false;
-  }
-#endif
+  bool validateRecursivePredicate(
+      const ConstraintManager &constraints,
+      std::map<const Array *, uint64_t> &arrayAddressRegistry,
+      std::string predicateName, std::vector<ref<Expr> > &arguments) const;
 };
 
 CLPRSolverImpl::CLPRSolverImpl()
@@ -1529,6 +1482,71 @@ SolverImpl::SolverRunStatus CLPRSolverImpl::getOperationStatusCode() {
 
 std::vector< ref<Expr> > CLPRSolverImpl::getUnsatCore() {
   return unsatCore;
+}
+
+bool CLPRSolverImpl::validateRecursivePredicate(
+    const ConstraintManager &constraints,
+    std::map<const Array *, uint64_t> &arrayAddressRegistry,
+    std::string predicateName, std::vector<ref<Expr> > &arguments) const {
+  clpr::CLPTerm queryAtom(predicateName);
+  std::vector<clpr::CLPTerm> constraintsList;
+
+  // First we clear the auxiliary constraints and
+  // register the registry.
+  builder->init(arrayAddressRegistry);
+
+  // We add the global heap as the first argument always
+  queryAtom.addArgument(builder->globalHeap);
+
+  unsigned i = 0;
+  for (std::vector<ref<Expr> >::const_iterator it = ++(arguments.begin()),
+                                               itEnd = arguments.end();
+       it != itEnd; ++it) {
+    clpr::CLPTerm clpExpr = builder->construct(*it);
+    std::ostringstream tmpVarName;
+    tmpVarName << "__clpr__arg" << i++ << "__";
+    clpr::CLPTerm varName(tmpVarName.str());
+    queryAtom.addArgument(varName);
+    clpr::CLPTerm constraint("=");
+    constraint.addArgument(varName);
+    constraint.addArgument(clpExpr);
+    constraintsList.push_back(constraint);
+  }
+
+  // Build the query
+  clpr::CLPQuery query;
+
+  // Add the constraints on the path condition
+  for (ConstraintManager::const_iterator it = constraints.begin(),
+                                         itEnd = constraints.end();
+       it != itEnd; ++it) {
+    clpr::CLPTerm clprConstraint = builder->construct(*it);
+    query.addTerm(clprConstraint);
+  }
+
+  for (std::vector<clpr::CLPTerm>::const_iterator it = constraintsList.begin(),
+                                                  itEnd = constraintsList.end();
+       it != itEnd; ++it) {
+    query.addTerm(*it);
+  }
+
+  for (std::vector<clpr::CLPTerm>::iterator
+           it = builder->auxiliaryConstraintsBegin(),
+           itEnd = builder->auxiliaryConstraintsEnd();
+       it != itEnd; ++it) {
+    query.addTerm(*it);
+  }
+
+  // Remember order is important in SLDNF, the consequent has to be last.
+  clpr::CLPTerm consequent("not");
+  consequent.addArgument(queryAtom);
+  query.addTerm(consequent);
+
+  engine->query(query);
+  if (!engine->hasSolution()) {
+    return true;
+  }
+  return false;
 }
 
 #endif /* SUPPORT_CLPR */


### PR DESCRIPTION
Other edits including correcting the communication between KLEE and CLP(R) backend. Now we require that every CLP predicate has a mandatory first argument that represents the global heap of the program state. Smaller edits including making `validateRecursivePredicate` methods `const`.