### PR TITLE
Fixed compilation errors when --with-z3 not specified

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -458,13 +458,14 @@ Dependency::getStoredExpressions(std::set<const Array *> &replacements,
           llvm::Value *base = (*allocIter)->getSite();
           uint64_t uintAddress = (*allocIter)->getUIntAddress();
           ref<Expr> address = (*allocIter)->getAddress();
-          if (NoExistential) {
-            concreteStore[base][uintAddress] = AddressValuePair(address, expr);
-          } else {
+#ifdef SUPPORT_Z3
+	  if (!NoExistential) {
             concreteStore[base][uintAddress] = AddressValuePair(
                 ShadowArray::getShadowExpression(address, replacements),
                 ShadowArray::getShadowExpression(expr, replacements));
-          }
+	  } else
+#endif
+            concreteStore[base][uintAddress] = AddressValuePair(address, expr);
         }
       } else {
         ref<Expr> address = (*allocIter)->getAddress();
@@ -475,13 +476,14 @@ Dependency::getStoredExpressions(std::set<const Array *> &replacements,
         } else if (v->isCore()) {
           ref<Expr> expr = v->getExpression();
           llvm::Value *base = v->getValue();
-          if (NoExistential) {
-            symbolicStore[base].push_back(AddressValuePair(address, expr));
-          } else {
+#ifdef SUPPORT_Z3
+          if (!NoExistential) {
             symbolicStore[base].push_back(AddressValuePair(
                 ShadowArray::getShadowExpression(address, replacements),
                 ShadowArray::getShadowExpression(expr, replacements)));
-          }
+          } else
+#endif
+            symbolicStore[base].push_back(AddressValuePair(address, expr));
         }
       }
     }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3803,9 +3803,11 @@ void Executor::runFunctionAsMain(Function *f,
     SearchTree::save(interpreterHandler->getOutputFilename("tree.dot"));
     SearchTree::deallocate();
 
+#ifdef SUPPORT_Z3
     // Print interpolation time statistics
     if (InterpolationStat)
       interpTree->dumpInterpolationStat();
+#endif
 
     delete interpTree;
     interpTree = 0;


### PR DESCRIPTION
When `--with-z3` was not specified when running `configure`. The problem was because of interdependency of code.