### PR TITLE
Handle llvmArgValue with pointer type in executePHI

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1277,13 +1277,11 @@ void Dependency::executePHI(llvm::Instruction *instr,
     addDependency(val, getNewVersionedValue(instr, valueExpr));
   } else if (llvm::isa<llvm::Constant>(llvmArgValue)) {
     getNewVersionedValue(instr, valueExpr);
-  } else {
-    if (llvmArgValue->getType()->isPointerTy()) {
+  } else if (llvmArgValue->getType()->isPointerTy()) {
       addPointerEquality(getNewVersionedValue(llvmArgValue, valueExpr),
                          getInitialAllocation(llvmArgValue, valueExpr));
-    } else {
+  } else {
       assert(!"operand not found");
-    }
   }
 }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1277,11 +1277,8 @@ void Dependency::executePHI(llvm::Instruction *instr,
     addDependency(val, getNewVersionedValue(instr, valueExpr));
   } else if (llvm::isa<llvm::Constant>(llvmArgValue)) {
     getNewVersionedValue(instr, valueExpr);
-  } else if (llvmArgValue->getType()->isPointerTy()) {
-      addPointerEquality(getNewVersionedValue(llvmArgValue, valueExpr),
-                         getInitialAllocation(llvmArgValue, valueExpr));
   } else {
-      assert(!"operand not found");
+    assert(!"operand not found");
   }
 }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1278,7 +1278,12 @@ void Dependency::executePHI(llvm::Instruction *instr,
   } else if (llvm::isa<llvm::Constant>(llvmArgValue)) {
     getNewVersionedValue(instr, valueExpr);
   } else {
-    assert(!"operand not found");
+    if (llvmArgValue->getType()->isPointerTy()) {
+      addPointerEquality(getNewVersionedValue(llvmArgValue, valueExpr),
+                         getInitialAllocation(llvmArgValue, valueExpr));
+    } else {
+      assert(!"operand not found");
+    }
   }
 }
 


### PR DESCRIPTION
This is a fix for executing `coreutils pinky` program.