### PR TITLE
Prevents Negation as Failure for Constraints

### DIFF
--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -185,6 +185,15 @@ class SearchTree {
     /// \brief Indicates that node is subsumed
     bool subsumed;
 
+#ifdef SUPPORT_CLPR
+    /// \brief Indicates that the node is join-subsumed (subsumed via klee_join)
+    bool joinSubsumed;
+
+    /// \brief Indicates that the CLP predicate of klee_join is proved, but
+    /// there was no previous proof of the predicate.
+    bool joinProved;
+#endif
+
     /// \brief Conditions under which this node is visited from its parent
     std::map<PathCondition *, std::pair<std::string, bool> > pathConditionTable;
 
@@ -193,7 +202,7 @@ class SearchTree {
 
     Node(uintptr_t nodeId)
         : iTreeNodeId(nodeId), nodeId(0), falseTarget(0), trueTarget(0),
-          subsumed(false) {}
+          subsumed(false), joinSubsumed(false), joinProved(false) {}
 
     ~Node() {
       if (falseTarget)
@@ -233,6 +242,10 @@ class SearchTree {
   std::map<SubsumptionTableEntry *, SearchTree::Node *> tableEntryMap;
   std::vector<SearchTree::NumberedEdge *> subsumptionEdges;
   std::map<PathCondition *, SearchTree::Node *> pathConditionMap;
+
+#ifdef SUPPORT_CLPR
+  std::map<llvm::Instruction *, SearchTree::Node *> joinCallsiteMap;
+#endif
 
   unsigned long subsumptionEdgeNumber;
 
@@ -280,6 +293,11 @@ public:
                                    SubsumptionTableEntry *entry);
 
   static void setAsCore(PathCondition *pathCondition);
+
+#ifdef SUPPORT_CLPR
+  static void markAsProvedByJoin(ITreeNode *iTreeNode,
+                                 llvm::Instruction *callsite);
+#endif
 
   /// \brief Save the graph
   static void save(std::string dotFileName);

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -432,6 +432,7 @@ void SpecialFunctionHandler::handleJoin(ExecutionState &state,
     // Recursive predicate holding and this callsite has been seen before,
     // terminate state.
     executor.terminateStateOnSubsumption(state);
+    SearchTree::markAsProvedByJoin(state.itreeNode, target->inst);
   }
 #endif /* SUPPORT_CLPR */
 }

--- a/lib/Solver/CLPRBuilder.cpp
+++ b/lib/Solver/CLPRBuilder.cpp
@@ -211,8 +211,43 @@ clpr::CLPTerm CLPRBuilder::sbvModExpr(unsigned width, clpr::CLPTerm dividend, cl
 }
 
 clpr::CLPTerm CLPRBuilder::notExpr(clpr::CLPTerm expr) {
-  clpr::CLPTerm ret("not");
-  ret.addArgument(expr);
+  std::string subtermName = expr.getName();
+  clpr::CLPTerm ret;
+
+  if (subtermName == "=") {
+    clpr::CLPTerm leftOperand("<");
+    clpr::CLPTerm rightOperand(">");
+
+    for (std::vector<clpr::CLPTerm>::iterator it = expr.begin(),
+                                              ie = expr.end();
+         it != ie; ++it) {
+      leftOperand.addArgument(*it);
+      rightOperand.addArgument(*it);
+    }
+
+    ret.setName(";");
+    ret.addArgument(leftOperand);
+    ret.addArgument(rightOperand);
+
+  } else {
+    if (subtermName == "<") {
+      ret.setName(">=");
+    } else if (subtermName == ">") {
+      ret.setName("<=");
+    } else if (subtermName == "<=") {
+      ret.setName(">");
+    } else if (subtermName == ">=") {
+      ret.setName("<");
+    } else {
+      assert(!"unknown negation of operator");
+    }
+    for (std::vector<clpr::CLPTerm>::iterator it = expr.begin(),
+                                              ie = expr.end();
+         it != ie; ++it) {
+      ret.addArgument(*it);
+    }
+  }
+
   return ret;
 }
 


### PR DESCRIPTION
Fixed issue #118. When negating a constraint, e.g., `(A=B)` instead of using `not(...)`, which is negation as failure, we instead modify the constraint to `(A<B);(A>B)`, that is, `A<B` or `A>B`.

Also, added subsumption edges for `klee_join` in the `tree.dot` file, where the first-proved node is labeled `(join-proved)`, and the subsumed node is labeled `(join-subsumed)`.