### PR TITLE
Fix NULL sources at flowsToList 

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -687,7 +687,7 @@ Dependency::directLocalFlowSources(VersionedValue *target) const {
   for (std::vector<FlowsTo *>::const_iterator it = flowsToList.begin(),
                                               itEnd = flowsToList.end();
        it != itEnd; ++it) {
-    if ((*it)->getTarget() == target && (*it)->getSource()) {
+    if ((*it)->getTarget() == target) {
       ret.push_back((*it)->getSource());
     }
   }


### PR DESCRIPTION
... by adding additional `null` sources checking in the `directLocalFlowSources` and before `addDependency` method being called

This is also a fix for `make test`, with result:
Testing Time: 617.29s
Failing Tests (8):
    KLEE :: Feature/KleeReportError.c
    KLEE :: Feature/MemoryLimit.c
    KLEE :: Feature/OvershiftCheck.c
    KLEE :: Feature/consecutive_divide_by_zero.c
    KLEE :: Runtime/POSIX/DirConsistency.c
    KLEE :: Runtime/POSIX/DirSeek.c
    KLEE :: Runtime/POSIX/SeedAndFail.c
    KLEE :: Runtime/POSIX/Write2.c

  Expected Passes    : 160
  Expected Failures  : 2
  Unsupported Tests  : 2
  Unexpected Failures: 8

`Previously (master branch) :`
Testing Time: 617.83s
Failing Tests (9):
    KLEE :: Feature/KleeReportError.c
    KLEE :: Feature/MemoryLimit.c
    KLEE :: Feature/OvershiftCheck.c
    KLEE :: Feature/consecutive_divide_by_zero.c
    KLEE :: Runtime/POSIX/DirConsistency.c
    KLEE :: Runtime/POSIX/DirSeek.c
    KLEE :: Runtime/POSIX/Futimesat.c
    KLEE :: Runtime/POSIX/SeedAndFail.c
    KLEE :: Runtime/POSIX/Write2.c

  Expected Passes    : 159
  Expected Failures  : 2
  Unsupported Tests  : 2
  Unexpected Failures: 9