### PR TITLE
Avoid inserting null interpolant to the SubsumptionTableEntry by add …

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2705,7 +2705,7 @@ void Executor::updateStates(ExecutionState *current) {
       seedMap.erase(it3);
     processTree->remove(es->ptreeNode);
     if (INTERPOLATION_ENABLED)
-      interpTree->remove(es->itreeNode);
+      interpTree->remove(es->itreeNode, es->prevPC->inst);
     delete es;
   }
   removedStates.clear();
@@ -3011,7 +3011,7 @@ void Executor::terminateState(ExecutionState &state) {
     processTree->remove(state.ptreeNode);
 
     if (INTERPOLATION_ENABLED)
-      interpTree->remove(state.itreeNode);
+      interpTree->remove(state.itreeNode, state.prevPC->inst);
     delete &state;
   }
 }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2705,7 +2705,7 @@ void Executor::updateStates(ExecutionState *current) {
       seedMap.erase(it3);
     processTree->remove(es->ptreeNode);
     if (INTERPOLATION_ENABLED)
-      interpTree->remove(es->itreeNode, es->prevPC->inst);
+      interpTree->remove(es->itreeNode);
     delete es;
   }
   removedStates.clear();
@@ -3010,7 +3010,7 @@ void Executor::terminateState(ExecutionState &state) {
     processTree->remove(state.ptreeNode);
 
     if (INTERPOLATION_ENABLED)
-      interpTree->remove(state.itreeNode, state.prevPC->inst);
+      interpTree->remove(state.itreeNode);
     delete &state;
   }
 }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2858,8 +2858,7 @@ void Executor::run(ExecutionState &initialState) {
       // We synchronize the node id to that of the state. The node id
       // is set only when it was the address of the first instruction
       // in the node.
-      interpTree->setCurrentINode(state,
-                                  reinterpret_cast<uintptr_t>(state.pc->inst));
+      interpTree->setCurrentINode(state);
 
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1660,6 +1660,8 @@ bool SubsumptionTableEntry::subsumed(
   return false;
 }
 
+ref<Expr> SubsumptionTableEntry::getInterpolant() const { return interpolant; }
+
 void SubsumptionTableEntry::print(llvm::raw_ostream &stream) const {
   stream << "------------ Subsumption Table Entry ------------\n";
   stream << "Program point = " << nodeId << "\n";
@@ -1871,7 +1873,8 @@ void ITree::remove(ITreeNode *node) {
     // traversed, hence the correct time to table the interpolant.
     if (!node->isSubsumed) {
       SubsumptionTableEntry *entry = new SubsumptionTableEntry(node);
-      store(entry);
+      if (entry->getInterpolant().get())
+        store(entry);
       SearchTree::addTableEntryMapping(node, entry);
     }
 

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1869,8 +1869,9 @@ void ITree::remove(ITreeNode *node, llvm::Instruction *instr) {
   do {
     ITreeNode *p = node->parent;
 
-    // Disabling the subsumption check within KLEE's own API by
-    // never store a table entry for KLEE's own API.
+    // Disabling the subsumption check within KLEE's own API
+    // (callsites of klee_ and at any location within the klee_ function)
+    // by never store a table entry for KLEE's own API.
     bool kleeAPI = false;
     if (llvm::isa<llvm::CallInst>(instr)) {
       llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(instr);
@@ -1878,7 +1879,11 @@ void ITree::remove(ITreeNode *node, llvm::Instruction *instr) {
       if (f && f->getName().substr(0, 5).equals("klee_")) {
         kleeAPI = true;
       }
+    } else if (instr->getParent()->getParent()->getName().substr(0, 5).equals(
+                   "klee_")) {
+      kleeAPI = true;
     }
+
     // As the node is about to be deleted, it must have been completely
     // traversed, hence the correct time to table the interpolant.
     if (!node->isSubsumed && !kleeAPI) {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1873,9 +1873,10 @@ void ITree::remove(ITreeNode *node) {
     // traversed, hence the correct time to table the interpolant.
     if (!node->isSubsumed) {
       SubsumptionTableEntry *entry = new SubsumptionTableEntry(node);
-      if (entry->getInterpolant().get())
+      if (entry->getInterpolant().get()){
         store(entry);
-      SearchTree::addTableEntryMapping(node, entry);
+      	SearchTree::addTableEntryMapping(node, entry);
+      }
     }
 
     delete node;

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1863,7 +1863,7 @@ void ITree::setCurrentINode(ExecutionState &state) {
   setCurrentINodeTimer.stop();
 }
 
-void ITree::remove(ITreeNode *node, llvm::Instruction *instr) {
+void ITree::remove(ITreeNode *node) {
   removeTimer.start();
   assert(!node->left && !node->right);
   do {

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -676,7 +676,7 @@ public:
   void setCurrentINode(ExecutionState &state);
 
   /// \brief Deletes the interpolation tree node
-  void remove(ITreeNode *node, llvm::Instruction *instr);
+  void remove(ITreeNode *node);
 
   /// \brief Invokes the subsumption check
   bool subsumptionCheck(TimingSolver *solver, ExecutionState &state,

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -481,6 +481,8 @@ public:
     return llvm::isa<ConcatExpr>(expr.get()) || llvm::isa<ReadExpr>(expr.get());
   }
 
+  ref<Expr> getInterpolant() const;
+
   void dump() const {
     this->print(llvm::errs());
     llvm::errs() << "\n";

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -670,7 +670,7 @@ public:
   void setCurrentINode(ExecutionState &state, uintptr_t programPoint);
 
   /// \brief Deletes the interpolation tree node
-  void remove(ITreeNode *node);
+  void remove(ITreeNode *node, llvm::Instruction *instr);
 
   /// \brief Invokes the subsumption check
   bool subsumptionCheck(TimingSolver *solver, ExecutionState &state,

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -539,18 +539,8 @@ private:
 
     // Disabling the subsumption check within KLEE's own API
     // (callsites of klee_ and at any location within the klee_ function)
-    // by never store a table entry for KLEE's own API.
-    storable = true;
-    if (llvm::isa<llvm::CallInst>(instr)) {
-      llvm::CallInst *callInst = llvm::dyn_cast<llvm::CallInst>(instr);
-      llvm::Function *f = callInst->getCalledFunction();
-      if (f && f->getName().substr(0, 5).equals("klee_")) {
-        storable = false;
-      }
-    } else if (instr->getParent()->getParent()->getName().substr(0, 5).equals(
-                   "klee_")) {
-      storable = false;
-    }
+    // by never store a table entry for KLEE's own API, marked with flag storable.
+    storable = !(instr->getParent()->getParent()->getName().substr(0, 5).equals("klee_"));
   }
 
   /// \brief for printing method running time statistics

--- a/test/Feature/KleeReportError.c
+++ b/test/Feature/KleeReportError.c
@@ -1,6 +1,7 @@
 // RUN: %llvmgcc %s -g -emit-llvm -O0 -c -o %t2.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --emit-all-errors %t2.bc 2>&1 | FileCheck %s
+// RUN: %klee -no-interpolation --output-dir=%t.klee-out --emit-all-errors
+// %t2.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .my.err | wc -l | grep 2
 #include <stdio.h>
 #include <assert.h>

--- a/test/Feature/KleeReportError.c
+++ b/test/Feature/KleeReportError.c
@@ -1,7 +1,6 @@
 // RUN: %llvmgcc %s -g -emit-llvm -O0 -c -o %t2.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee -no-interpolation --output-dir=%t.klee-out --emit-all-errors
-// %t2.bc 2>&1 | FileCheck %s
+// RUN: %klee -no-interpolation --output-dir=%t.klee-out --emit-all-errors %t2.bc 2>&1 | FileCheck %s
 // RUN: ls %t.klee-out/ | grep .my.err | wc -l | grep 2
 #include <stdio.h>
 #include <assert.h>


### PR DESCRIPTION
…additional checking

This fix helps increase passing tests in the regression test, with current result:
Testing Time: 619.16s
Failing Tests (6):
    KLEE :: Feature/MemoryLimit.c
    KLEE :: Runtime/POSIX/DirConsistency.c
    KLEE :: Runtime/POSIX/DirSeek.c
    KLEE :: Runtime/POSIX/Futimesat.c
    KLEE :: Runtime/POSIX/SeedAndFail.c
    KLEE :: Runtime/POSIX/Write2.c

  Expected Passes    : 162
  Expected Failures  : 2
  Unsupported Tests  : 2
  Unexpected Failures: 6

Result from master branch:
Testing Time: 617.83s
Failing Tests (9):
KLEE :: Feature/KleeReportError.c
KLEE :: Feature/MemoryLimit.c
KLEE :: Feature/OvershiftCheck.c
KLEE :: Feature/consecutive_divide_by_zero.c
KLEE :: Runtime/POSIX/DirConsistency.c
KLEE :: Runtime/POSIX/DirSeek.c
KLEE :: Runtime/POSIX/Futimesat.c
KLEE :: Runtime/POSIX/SeedAndFail.c
KLEE :: Runtime/POSIX/Write2.c

Expected Passes : 159
Expected Failures : 2
Unsupported Tests : 2
Unexpected Failures: 9
