### PR TITLE
Remove element from FlowsToList that already set as core to prevent s…

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1371,8 +1371,26 @@ void Dependency::markAllValues(AllocationGraph *g, llvm::Value *val) {
   }
 
   markAllValues(g, value);
+  // Remove element of FlowsToList where its source and target already set as
+  // core.
+  // FlowsToList is frequently accessed from markAllValues method to mark the
+  // element
+  // as a core. So, we can remove the element that already set as core, to
+  // prevent
+  // set the same elements as core multiple times
+  removeCoreFromFlowsToList();
 }
+void Dependency::removeCoreFromFlowsToList() {
+  std::vector<FlowsTo *>::iterator it = flowsToList.begin();
 
+  while (it != flowsToList.end()) {
+
+    if ((*it)->getTarget()->isCore() && (*it)->getSource()->isCore()) {
+      it = flowsToList.erase(it);
+    } else
+      ++it;
+  }
+}
 void Dependency::computeCoreAllocations(AllocationGraph *g) {
   std::set<Allocation *> sinkAllocations(g->getSinkAllocations());
   coreAllocations.insert(sinkAllocations.begin(), sinkAllocations.end());

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1347,6 +1347,11 @@ void Dependency::markAllValues(AllocationGraph *g, VersionedValue *value) {
        it != itEnd; ++it) {
     (*it)->setAsCore();
   }
+  // Remove element of FlowsToList where its source and target already set as
+  // core. FlowsToList is frequently accessed from markAllValues method to mark
+  // the element as a core. So, we can remove the element that already set as
+  // core, to prevent set the same elements as core multiple times
+  removeCoreFromFlowsToList();
 }
 
 void Dependency::markAllValues(AllocationGraph *g, llvm::Value *val) {
@@ -1371,14 +1376,6 @@ void Dependency::markAllValues(AllocationGraph *g, llvm::Value *val) {
   }
 
   markAllValues(g, value);
-  // Remove element of FlowsToList where its source and target already set as
-  // core.
-  // FlowsToList is frequently accessed from markAllValues method to mark the
-  // element
-  // as a core. So, we can remove the element that already set as core, to
-  // prevent
-  // set the same elements as core multiple times
-  removeCoreFromFlowsToList();
 }
 void Dependency::removeCoreFromFlowsToList() {
   std::vector<FlowsTo *>::iterator it = flowsToList.begin();

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -663,6 +663,9 @@ class Allocation {
     /// the core.
     void markAllValues(AllocationGraph *g, llvm::Value *value);
 
+    /// \brief Remove element from FlowsToList that already set as core
+    void removeCoreFromFlowsToList();
+
     /// \brief Compute the allocations that are relevant for the interpolant
     /// (core).
     void computeCoreAllocations(AllocationGraph *g);

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -615,6 +615,9 @@ class Allocation {
     /// \brief Builds dependency graph between memory allocations
     void buildAllocationGraph(AllocationGraph *g, VersionedValue *value) const;
 
+    /// \brief Remove element from FlowsToList that already set as core
+    void removeCoreFromFlowsToList();
+
   public:
     Dependency(Dependency *prev);
 
@@ -662,9 +665,6 @@ class Allocation {
     /// \brief Given an LLVM value, retrieve all its sources and mark them as in
     /// the core.
     void markAllValues(AllocationGraph *g, llvm::Value *value);
-
-    /// \brief Remove element from FlowsToList that already set as core
-    void removeCoreFromFlowsToList();
 
     /// \brief Compute the allocations that are relevant for the interpolant
     /// (core).


### PR DESCRIPTION
…et the same elements as core multiple times.

This PR does not change the subsumption result of basic examples. It speed up the execution of `scalability/regexp`from 94.23s to 68.97s without changing the subsumption result.
