### PR TITLE
Fix for /Runtime/POSIX/SeedAndFail.c in the KLEE regression test

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -168,6 +168,8 @@ public:
   // use on structure
   ExecutionState(const std::vector<ref<Expr> > &assumptions);
 
+  ExecutionState(const KInstIterator &copyPrevPC, const std::vector<ref<Expr> > &assumptions);
+
   ExecutionState(const ExecutionState &state);
 
   ~ExecutionState();

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -164,11 +164,14 @@ private:
 public:
   ExecutionState(KFunction *kf);
 
+#ifdef SUPPORT_Z3
+  ExecutionState(const KInstIterator &copyPrevPC,
+                 const std::vector<ref<Expr> > &assumptions);
+#else
   // XXX total hack, just used to make a state so solver can
   // use on structure
   ExecutionState(const std::vector<ref<Expr> > &assumptions);
-
-  ExecutionState(const KInstIterator &copyPrevPC, const std::vector<ref<Expr> > &assumptions);
+#endif
 
   ExecutionState(const ExecutionState &state);
 

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -164,12 +164,12 @@ private:
 public:
   ExecutionState(KFunction *kf);
 
+// XXX total hack, just used to make a state so solver can
+// use on structure
 #ifdef SUPPORT_Z3
   ExecutionState(const KInstIterator &copyPrevPC,
                  const std::vector<ref<Expr> > &assumptions);
 #else
-  // XXX total hack, just used to make a state so solver can
-  // use on structure
   ExecutionState(const std::vector<ref<Expr> > &assumptions);
 #endif
 

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -167,7 +167,7 @@ public:
 // XXX total hack, just used to make a state so solver can
 // use on structure
 #ifdef SUPPORT_Z3
-  ExecutionState(const KInstIterator &copyPrevPC,
+  ExecutionState(const KInstIterator &srcPrevPC,
                  const std::vector<ref<Expr> > &assumptions);
 #else
   ExecutionState(const std::vector<ref<Expr> > &assumptions);

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -531,9 +531,10 @@ VersionedValue *Dependency::getLatestValue(llvm::Value *value,
     ret = getNewVersionedValue(value, valueExpr);
     if (value->getType()->isPointerTy())
       addPointerEquality(ret, getInitialAllocation(value, valueExpr));
+    return ret;
   }
 
-  return ret;
+  return getNewVersionedValue(value, valueExpr);
 }
 
 VersionedValue *

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -531,10 +531,9 @@ VersionedValue *Dependency::getLatestValue(llvm::Value *value,
     ret = getNewVersionedValue(value, valueExpr);
     if (value->getType()->isPointerTy())
       addPointerEquality(ret, getInitialAllocation(value, valueExpr));
-    return ret;
   }
 
-  return getNewVersionedValue(value, valueExpr);
+  return ret;
 }
 
 VersionedValue *
@@ -1047,6 +1046,18 @@ void Dependency::execute(llvm::Instruction *instr,
           VersionedValue *returnValue = getNewVersionedValue(instr, argExpr);
           if (arg)
             addDependency(arg, returnValue);
+        } else if (llvm::isa<llvm::CallInst>(instr->getOperand(0))) {
+          llvm::CallInst *callInst =
+              llvm::dyn_cast<llvm::CallInst>(instr->getOperand(0));
+          llvm::Function *f = callInst->getCalledFunction();
+          llvm::StringRef calleeName = f->getName();
+          if (calleeName.equals("write") && args.size() == 1) {
+            getNewVersionedValue(instr->getOperand(0), argExpr);
+          } else if (calleeName.equals("read") && args.size() == 1) {
+            getNewVersionedValue(instr->getOperand(0), argExpr);
+          } else {
+            assert(!"calleeName is not defined");
+          }
         } else {
           assert(!"operand not found");
         }
@@ -1295,7 +1306,8 @@ void Dependency::executePHI(llvm::Instruction *instr,
   VersionedValue *val = getLatestValue(llvmArgValue, valueExpr);
   if (val) {
     addDependency(val, getNewVersionedValue(instr, valueExpr));
-  } else if (llvm::isa<llvm::Constant>(llvmArgValue)) {
+  } else if (llvm::isa<llvm::Constant>(llvmArgValue) ||
+             llvm::isa<llvm::Argument>(llvmArgValue)) {
     getNewVersionedValue(instr, valueExpr);
   } else {
     assert(!"operand not found");

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -532,6 +532,7 @@ VersionedValue *Dependency::getLatestValue(llvm::Value *value,
     if (value->getType()->isPointerTy())
       addPointerEquality(ret, getInitialAllocation(value, valueExpr));
   }
+
   return ret;
 }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1047,7 +1047,7 @@ void Dependency::execute(llvm::Instruction *instr,
           if (arg)
             addDependency(arg, returnValue);
         } else if (llvm::isa<llvm::CallInst>(instr->getOperand(0))) {
-        	getNewVersionedValue(instr->getOperand(0), argExpr);
+          getNewVersionedValue(instr->getOperand(0), argExpr);
         } else {
           assert(!"operand not found");
         }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1047,17 +1047,7 @@ void Dependency::execute(llvm::Instruction *instr,
           if (arg)
             addDependency(arg, returnValue);
         } else if (llvm::isa<llvm::CallInst>(instr->getOperand(0))) {
-          llvm::CallInst *callInst =
-              llvm::dyn_cast<llvm::CallInst>(instr->getOperand(0));
-          llvm::Function *f = callInst->getCalledFunction();
-          llvm::StringRef calleeName = f->getName();
-          if (calleeName.equals("write") && args.size() == 1) {
-            getNewVersionedValue(instr->getOperand(0), argExpr);
-          } else if (calleeName.equals("read") && args.size() == 1) {
-            getNewVersionedValue(instr->getOperand(0), argExpr);
-          } else {
-            assert(!"calleeName is not defined");
-          }
+        	getNewVersionedValue(instr->getOperand(0), argExpr);
         } else {
           assert(!"operand not found");
         }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -78,6 +78,9 @@ ExecutionState::ExecutionState(KFunction *kf)
 ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions)
     : constraints(assumptions), queryCost(0.), ptreeNode(0), itreeNode(0) {}
 
+ExecutionState::ExecutionState(const KInstIterator &copyPrevPC, const std::vector<ref<Expr> > &assumptions)
+    : prevPC(copyPrevPC), constraints(assumptions), queryCost(0.), ptreeNode(0), itreeNode(0) {}
+
 ExecutionState::~ExecutionState() {
   for (unsigned int i=0; i<symbolics.size(); i++)
   {

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -76,8 +76,10 @@ ExecutionState::ExecutionState(KFunction *kf)
 }
 
 #ifdef SUPPORT_Z3
-ExecutionState::ExecutionState(const KInstIterator &copyPrevPC, const std::vector<ref<Expr> > &assumptions)
-    : prevPC(copyPrevPC), constraints(assumptions), queryCost(0.), ptreeNode(0), itreeNode(0) {}
+ExecutionState::ExecutionState(const KInstIterator &srcPrevPC,
+                               const std::vector<ref<Expr> > &assumptions)
+    : prevPC(srcPrevPC), constraints(assumptions), queryCost(0.), ptreeNode(0),
+      itreeNode(0) {}
 #else
 ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions)
     : constraints(assumptions), queryCost(0.), ptreeNode(0), itreeNode(0) {}

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -75,11 +75,13 @@ ExecutionState::ExecutionState(KFunction *kf)
   pushFrame(0, kf);
 }
 
-ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions)
-    : constraints(assumptions), queryCost(0.), ptreeNode(0), itreeNode(0) {}
-
+#ifdef SUPPORT_Z3
 ExecutionState::ExecutionState(const KInstIterator &copyPrevPC, const std::vector<ref<Expr> > &assumptions)
     : prevPC(copyPrevPC), constraints(assumptions), queryCost(0.), ptreeNode(0), itreeNode(0) {}
+#else
+ExecutionState::ExecutionState(const std::vector<ref<Expr> > &assumptions)
+    : constraints(assumptions), queryCost(0.), ptreeNode(0), itreeNode(0) {}
+#endif
 
 ExecutionState::~ExecutionState() {
   for (unsigned int i=0; i<symbolics.size(); i++)

--- a/lib/Core/SeedInfo.cpp
+++ b/lib/Core/SeedInfo.cpp
@@ -62,7 +62,11 @@ void SeedInfo::patchSeed(const ExecutionState &state,
                          TimingSolver *solver) {
   std::vector< ref<Expr> > required(state.constraints.begin(),
                                     state.constraints.end());
+#ifdef SUPPORT_Z3
+  ExecutionState tmp(state.prevPC, required);
+#else
   ExecutionState tmp(required);
+#endif
   tmp.addConstraint(condition);
 
   // Try and patch direct reads first, this is likely to resolve the


### PR DESCRIPTION
Fixes including:

1. Create the new constructor for `ExecutionState` that enable passing `prevPC`, as it will be used in the `addConstraint()` when Z3 Solver is enabled.

2. Register a new value as default return of `Dependency::getLatestValue()` , to avoid return a `null` value that might cause run time error