### PR TITLE
Return getNewVersionedValue as default return of getLatestValue in De…

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -531,8 +531,9 @@ VersionedValue *Dependency::getLatestValue(llvm::Value *value,
     ret = getNewVersionedValue(value, valueExpr);
     if (value->getType()->isPointerTy())
       addPointerEquality(ret, getInitialAllocation(value, valueExpr));
+    return ret;
   }
-  return ret;
+  return getNewVersionedValue(value, valueExpr);
 }
 
 VersionedValue *


### PR DESCRIPTION
…pendency.cpp

This PR makes the execution time of `scalability/Regexp.c` become 19.80s from 78.81. The complete result from both branches are:

Result from this PR:
```
KLEE: done: total instructions = 102498
KLEE: done: completed paths = 478, among which
KLEE: done:     early-terminating paths (instruction time limit, solver timeout, max-depth reached) = 0
KLEE: done:     subsumed paths = 213
KLEE: done:     error paths = 37
KLEE: done:     program exit paths = 228
KLEE: done: generated tests = 443, among which
KLEE: done:     early-terminating tests (instruction time limit, solver timeout, max-depth reached) = 0
KLEE: done:     subsumed tests = 213
KLEE: done:     error tests = 2
KLEE: done:     program exit tests = 228

```
Result from master:
```
KLEE: done: total instructions = 986871
KLEE: done: completed paths = 2538, among which
KLEE: done:     early-terminating paths (instruction time limit, solver timeout, max-depth reached) = 0
KLEE: done:     subsumed paths = 1072
KLEE: done:     error paths = 237
KLEE: done:     program exit paths = 1229
KLEE: done: generated tests = 2303, among which
KLEE: done:     early-terminating tests (instruction time limit, solver timeout, max-depth reached) = 0
KLEE: done:     subsumed tests = 1072
KLEE: done:     error tests = 2
KLEE: done:     program exit tests = 1229

```
I think it is interesting to investigate why the execution time will be much less when taking this approach. I have also noticed the subsumption result is different.  @domainexpert  Please let me know what you think.. Thank you.