### PR TITLE
Change from vector of SubsumptionTableEntry into set 

### DIFF
--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1742,8 +1742,7 @@ void ITree::printTimeStat(llvm::raw_ostream &stream) {
 
 void ITree::printTableStat(llvm::raw_ostream &stream) const {
   double programPointNumber = 0.0, entryNumber = 0.0;
-  for (std::map<uintptr_t,
-                std::vector<SubsumptionTableEntry *> >::const_iterator
+  for (std::map<uintptr_t, std::set<SubsumptionTableEntry *> >::const_iterator
            it = subsumptionTable.begin(),
            itEnd = subsumptionTable.end();
        it != itEnd; ++it) {
@@ -1791,13 +1790,12 @@ ITree::ITree(ExecutionState *_root) {
 }
 
 ITree::~ITree() {
-  for (std::map<uintptr_t, std::vector<SubsumptionTableEntry *> >::iterator
+  for (std::map<uintptr_t, std::set<SubsumptionTableEntry *> >::iterator
            it = subsumptionTable.begin(),
            itEnd = subsumptionTable.end();
        it != itEnd; ++it) {
-    for (std::vector<SubsumptionTableEntry *>::iterator
-             it1 = it->second.begin(),
-             it1End = it->second.end();
+    for (std::set<SubsumptionTableEntry *>::iterator it1 = it->second.begin(),
+                                                     it1End = it->second.end();
          it1 != it1End; ++it1) {
       delete *it1;
     }
@@ -1822,7 +1820,7 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
     return false;
 
   subsumptionCheckTimer.start();
-  std::vector<SubsumptionTableEntry *> entryList =
+  std::set<SubsumptionTableEntry *> entryList =
       subsumptionTable[state.itreeNode->getNodeId()];
 
   if (entryList.empty())
@@ -1831,8 +1829,8 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
   std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   storedExpressions = state.itreeNode->getStoredExpressions();
 
-  for (std::vector<SubsumptionTableEntry *>::iterator it = entryList.begin(),
-                                                      itEnd = entryList.end();
+  for (std::set<SubsumptionTableEntry *>::iterator it = entryList.begin(),
+                                                   itEnd = entryList.end();
        it != itEnd; ++it) {
 
     if ((*it)->subsumed(solver, state, timeout, storedExpressions)) {
@@ -1852,7 +1850,7 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
 }
 
 void ITree::store(SubsumptionTableEntry *subItem) {
-  subsumptionTable[subItem->nodeId].push_back(subItem);
+  subsumptionTable[subItem->nodeId].insert(subItem);
 }
 
 void ITree::setCurrentINode(ExecutionState &state) {
@@ -2016,12 +2014,11 @@ void ITree::print(llvm::raw_ostream &stream) const {
   this->printNode(stream, this->root, "");
   stream << "\n------------------------- Subsumption Table "
             "-------------------------\n";
-  for (std::map<uintptr_t,
-                std::vector<SubsumptionTableEntry *> >::const_iterator
+  for (std::map<uintptr_t, std::set<SubsumptionTableEntry *> >::const_iterator
            it = subsumptionTable.begin(),
            itEnd = subsumptionTable.end();
        it != itEnd; ++it) {
-    for (std::vector<SubsumptionTableEntry *>::const_iterator
+    for (std::set<SubsumptionTableEntry *>::const_iterator
              it1 = it->second.begin(),
              it1End = it->second.end();
          it1 != it1End; ++it1) {

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -646,7 +646,7 @@ class ITree {
 
   ITreeNode *currentINode;
 
-  std::map<uintptr_t, std::vector<SubsumptionTableEntry *> > subsumptionTable;
+  std::map<uintptr_t, std::set<SubsumptionTableEntry *> > subsumptionTable;
 
   void printNode(llvm::raw_ostream &stream, ITreeNode *n,
                  std::string edges) const;


### PR DESCRIPTION
By using `set` instead of `vector`, we could prevent redundant subsumption checking on the same entry.

In `klee-examples/basic,` there's no difference in subsumption result, but the execution time mostly faster for example: `regexp_nonrecursive2` (0.50 to 0.39), `loop_safe2`(0.31 to 0.28) , `bubble`(0.28 to 0.24), `arraysimple5`(0.34 to 0.29)

In `klee-examples/Regexp`, execution time from 95.61 to 94.31 without difference in subsumption.

It also does not change the current result of regression test:
```
********************
Testing Time: 616.14s
********************
Failing Tests (4):
    KLEE :: Feature/MemoryLimit.c
    KLEE :: Runtime/POSIX/DirConsistency.c
    KLEE :: Runtime/POSIX/DirSeek.c
    KLEE :: Runtime/POSIX/Write2.c

  Expected Passes    : 164
  Expected Failures  : 2
  Unsupported Tests  : 2
  Unexpected Failures: 4

```