### PR TITLE
Manage the subsumption check

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -79,7 +79,6 @@ extern llvm::cl::opt<bool> NoExistential;
 
 extern llvm::cl::opt<int> MaxFailSubsumption;
 
-extern llvm::cl::opt<int> SubsumptionTableSize;
 #endif
 
 #ifdef SUPPORT_METASMT

--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -78,6 +78,8 @@ extern llvm::cl::opt<bool> InterpolationStat;
 extern llvm::cl::opt<bool> NoExistential;
 
 extern llvm::cl::opt<int> MaxFailSubsumption;
+
+extern llvm::cl::opt<int> SubsumptionTableSize;
 #endif
 
 #ifdef SUPPORT_METASMT

--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -76,6 +76,8 @@ extern llvm::cl::opt<bool> OutputTree;
 extern llvm::cl::opt<bool> InterpolationStat;
 
 extern llvm::cl::opt<bool> NoExistential;
+
+extern llvm::cl::opt<int> MaxFailSubsumption;
 #endif
 
 #ifdef SUPPORT_METASMT

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -118,16 +118,11 @@ llvm::cl::opt<bool> NoExistential(
 llvm::cl::opt<int> MaxFailSubsumption(
     "max-fail-subsume",
     llvm::cl::desc("This option gives the user flexibility to set the maximum "
-                   "number of fail subsumption check (default=0)"),
-    llvm::cl::init(0));
-
-llvm::cl::opt<int> SubsumptionTableSize(
-    "subsumption-table-size",
-    llvm::cl::desc("This option gives the user flexibility to set the size of "
-                   "subsumption table for each particular node id such that "
-                   "when the number of entries are more than its specified "
-                   "size, the new entry will overwrite the oldest entry "
-                   "(default=0)"),
+                   "number of fail subsumption check. When this options is "
+                   "selected, the number of subsumption table size is equal to "
+                   "the number of max-fail-subsume. When the number of entries "
+                   "are more than specified max-fail-subsume, the oldest entry "
+                   "will be deleted  (default=0)"),
     llvm::cl::init(0));
 
 #endif

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -117,13 +117,12 @@ llvm::cl::opt<bool> NoExistential(
 
 llvm::cl::opt<int> MaxFailSubsumption(
     "max-fail-subsume",
-    llvm::cl::desc(
-        "To set the maximum "
-        "number of fail subsumption check. When this options is "
-        "selected, the number of subsumption table entries is equal to "
-        "the number of max-fail-subsume. When the number of entries "
-        "are more than specified max-fail-subsume, the oldest entry "
-        "will be deleted (default=0 (off))"),
+    llvm::cl::desc("To set the maximum number of fail subsumption check. When "
+                   "this options is selected, the number of subsumption table "
+                   "entries is equal to the number of max-fail-subsume. When "
+                   "the number of entries are more than specified "
+                   "max-fail-subsume, the oldest entry will be deleted "
+                   "(default=0 (off))"),
     llvm::cl::init(0));
 
 #endif

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -121,6 +121,15 @@ llvm::cl::opt<int> MaxFailSubsumption(
                    "number of fail subsumption check (default=0)"),
     llvm::cl::init(0));
 
+llvm::cl::opt<int> SubsumptionTableSize(
+    "subsumption-table-size",
+    llvm::cl::desc("This option gives the user flexibility to set the size of "
+                   "subsumption table for each particular node id such that "
+                   "when the number of entries are more than its specified "
+                   "size, the new entry will overwrite the oldest entry "
+                   "(default=0)"),
+    llvm::cl::init(0));
+
 #endif
 
 #ifdef SUPPORT_METASMT

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -117,12 +117,13 @@ llvm::cl::opt<bool> NoExistential(
 
 llvm::cl::opt<int> MaxFailSubsumption(
     "max-fail-subsume",
-    llvm::cl::desc("This option gives the user flexibility to set the maximum "
-                   "number of fail subsumption check. When this options is "
-                   "selected, the number of subsumption table size is equal to "
-                   "the number of max-fail-subsume. When the number of entries "
-                   "are more than specified max-fail-subsume, the oldest entry "
-                   "will be deleted  (default=0)"),
+    llvm::cl::desc(
+        "To set the maximum "
+        "number of fail subsumption check. When this options is "
+        "selected, the number of subsumption table entries is equal to "
+        "the number of max-fail-subsume. When the number of entries "
+        "are more than specified max-fail-subsume, the oldest entry "
+        "will be deleted (default=0 (off))"),
     llvm::cl::init(0));
 
 #endif

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -117,12 +117,10 @@ llvm::cl::opt<bool> NoExistential(
 
 llvm::cl::opt<int> MaxFailSubsumption(
     "max-fail-subsume",
-    llvm::cl::desc("To set the maximum number of fail subsumption check. When "
-                   "this options is selected, the number of subsumption table "
-                   "entries is equal to the number of max-fail-subsume. When "
-                   "the number of entries are more than specified "
-                   "max-fail-subsume, the oldest entry will be deleted "
-                   "(default=0 (off))"),
+    llvm::cl::desc("To set the maximum number of failed subsumption check. "
+                   "When this options is specified and the number of "
+                   "subsumption table entries is more than the specified "
+                   "value, the oldest entry will be deleted (default=0 (off))"),
     llvm::cl::init(0));
 
 #endif

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -114,6 +114,13 @@ llvm::cl::opt<bool> NoExistential(
         "has an effect of removing all existentially-quantified variables "
         "most solvers are not very powerful at solving, however, at likely "
         "less number of subsumptions due to the strengthening of the query."));
+
+llvm::cl::opt<int> MaxFailSubsumption(
+    "max-fail-subsume",
+    llvm::cl::desc("This option gives the user flexibility to set the maximum "
+                   "number of fail subsumption check (default=0)"),
+    llvm::cl::init(0));
+
 #endif
 
 #ifdef SUPPORT_METASMT

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1861,15 +1861,7 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
 }
 
 void ITree::store(SubsumptionTableEntry *subItem) {
-  if (SubsumptionTableSize == 0 ||
-      subsumptionTable[subItem->nodeId].size() == 0) {
     subsumptionTable[subItem->nodeId].push_back(subItem);
-  } else {
-    int index =
-        (subsumptionTable[subItem->nodeId].size() % SubsumptionTableSize) - 1;
-    assert(index >= 0 && "invalid index on subsumption table entry");
-    subsumptionTable[subItem->nodeId].at(index) = subItem;
-  }
 }
 
 void ITree::setCurrentINode(ExecutionState &state) {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1831,12 +1831,18 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
   std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   storedExpressions = state.itreeNode->getStoredExpressions();
 
+  int counterCheck = 0;
+
   // Iterate the subsumption table entry with reverse iterator because
   // the successful subsumption mostly happen in the newest entry.
   for (std::vector<SubsumptionTableEntry *>::reverse_iterator
            it = entryList.rbegin(),
            itEnd = entryList.rend();
        it != itEnd; ++it) {
+
+    if (MaxFailSubsumption > 0 && counterCheck > MaxFailSubsumption) {
+      return false;
+    }
 
     if ((*it)->subsumed(solver, state, timeout, storedExpressions)) {
       // We mark as subsumed such that the node will not be
@@ -1849,6 +1855,7 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
       subsumptionCheckTimer.stop();
       return true;
     }
+    ++counterCheck;
   }
   subsumptionCheckTimer.stop();
   return false;

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1862,7 +1862,15 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
 }
 
 void ITree::store(SubsumptionTableEntry *subItem) {
-  subsumptionTable[subItem->nodeId].push_back(subItem);
+  if (SubsumptionTableSize == 0 ||
+      subsumptionTable[subItem->nodeId].size() == 0) {
+    subsumptionTable[subItem->nodeId].push_back(subItem);
+  } else {
+    int index =
+        (subsumptionTable[subItem->nodeId].size() % SubsumptionTableSize) - 1;
+    assert(index >= 0 && "invalid index on subsumption table entry");
+    subsumptionTable[subItem->nodeId].at(index) = subItem;
+  }
 }
 
 void ITree::setCurrentINode(ExecutionState &state) {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1831,8 +1831,11 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
   std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   storedExpressions = state.itreeNode->getStoredExpressions();
 
-  for (std::vector<SubsumptionTableEntry *>::iterator it = entryList.begin(),
-                                                      itEnd = entryList.end();
+  // Iterate the subsumption table entry with reverse iterator because
+  // the successful subsumption mostly happen in the newest entry.
+  for (std::vector<SubsumptionTableEntry *>::reverse_iterator
+           it = entryList.rbegin(),
+           itEnd = entryList.rend();
        it != itEnd; ++it) {
 
     if ((*it)->subsumed(solver, state, timeout, storedExpressions)) {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1742,8 +1742,7 @@ void ITree::printTimeStat(llvm::raw_ostream &stream) {
 
 void ITree::printTableStat(llvm::raw_ostream &stream) const {
   double programPointNumber = 0.0, entryNumber = 0.0;
-  for (std::map<uintptr_t,
-                std::vector<SubsumptionTableEntry *> >::const_iterator
+  for (std::map<uintptr_t, std::deque<SubsumptionTableEntry *> >::const_iterator
            it = subsumptionTable.begin(),
            itEnd = subsumptionTable.end();
        it != itEnd; ++it) {
@@ -1791,11 +1790,11 @@ ITree::ITree(ExecutionState *_root) {
 }
 
 ITree::~ITree() {
-  for (std::map<uintptr_t, std::vector<SubsumptionTableEntry *> >::iterator
+  for (std::map<uintptr_t, std::deque<SubsumptionTableEntry *> >::iterator
            it = subsumptionTable.begin(),
            itEnd = subsumptionTable.end();
        it != itEnd; ++it) {
-    for (std::vector<SubsumptionTableEntry *>::iterator
+    for (std::deque<SubsumptionTableEntry *>::iterator
              it1 = it->second.begin(),
              it1End = it->second.end();
          it1 != it1End; ++it1) {
@@ -1822,7 +1821,7 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
     return false;
 
   subsumptionCheckTimer.start();
-  std::vector<SubsumptionTableEntry *> entryList =
+  std::deque<SubsumptionTableEntry *> entryList =
       subsumptionTable[state.itreeNode->getNodeId()];
 
   if (entryList.empty())
@@ -1835,7 +1834,7 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
 
   // Iterate the subsumption table entry with reverse iterator because
   // the successful subsumption mostly happen in the newest entry.
-  for (std::vector<SubsumptionTableEntry *>::reverse_iterator
+  for (std::deque<SubsumptionTableEntry *>::reverse_iterator
            it = entryList.rbegin(),
            itEnd = entryList.rend();
        it != itEnd; ++it) {
@@ -2034,12 +2033,11 @@ void ITree::print(llvm::raw_ostream &stream) const {
   this->printNode(stream, this->root, "");
   stream << "\n------------------------- Subsumption Table "
             "-------------------------\n";
-  for (std::map<uintptr_t,
-                std::vector<SubsumptionTableEntry *> >::const_iterator
+  for (std::map<uintptr_t, std::deque<SubsumptionTableEntry *> >::const_iterator
            it = subsumptionTable.begin(),
            itEnd = subsumptionTable.end();
        it != itEnd; ++it) {
-    for (std::vector<SubsumptionTableEntry *>::const_iterator
+    for (std::deque<SubsumptionTableEntry *>::const_iterator
              it1 = it->second.begin(),
              it1End = it->second.end();
          it1 != it1End; ++it1) {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1830,18 +1830,12 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
   std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   storedExpressions = state.itreeNode->getStoredExpressions();
 
-  int counterCheck = 0;
-
   // Iterate the subsumption table entry with reverse iterator because
   // the successful subsumption mostly happen in the newest entry.
   for (std::deque<SubsumptionTableEntry *>::reverse_iterator
            it = entryList.rbegin(),
            itEnd = entryList.rend();
        it != itEnd; ++it) {
-
-    if (MaxFailSubsumption > 0 && counterCheck > MaxFailSubsumption) {
-      return false;
-    }
 
     if ((*it)->subsumed(solver, state, timeout, storedExpressions)) {
       // We mark as subsumed such that the node will not be
@@ -1854,7 +1848,6 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
       subsumptionCheckTimer.stop();
       return true;
     }
-    ++counterCheck;
   }
   subsumptionCheckTimer.stop();
   return false;
@@ -1862,6 +1855,11 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
 
 void ITree::store(SubsumptionTableEntry *subItem) {
     subsumptionTable[subItem->nodeId].push_back(subItem);
+    if (MaxFailSubsumption > 0 &&
+        (unsigned)MaxFailSubsumption <
+            subsumptionTable[subItem->nodeId].size()) {
+      subsumptionTable[subItem->nodeId].pop_front();
+    }
 }
 
 void ITree::setCurrentINode(ExecutionState &state) {

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -646,7 +646,7 @@ class ITree {
 
   ITreeNode *currentINode;
 
-  std::map<uintptr_t, std::vector<SubsumptionTableEntry *> > subsumptionTable;
+  std::map<uintptr_t, std::deque<SubsumptionTableEntry *> > subsumptionTable;
 
   void printNode(llvm::raw_ostream &stream, ITreeNode *n,
                  std::string edges) const;


### PR DESCRIPTION
This PR currently has 3 main changes:

1. Change the subsumption check iterator into reverse iterator. From the observation of `klee-examples/Regexp.c `and 2 `coreutils` program. The successful subsumption check mostly occur on the newest entry. Therefore, to speed up finding the suitable entry for subsumption check, we can start searching from the end of the list where the newest entry is located.

2. Exhaustive search for all table entry on particular node for finding subsumption check may costly especially after studying the case of `klee-examples/Regexp` where the subsumption only occur mostly on the first, second, or third newest entry of the table. Therefore, I add the user option that enable user to specify the number of maximum fail subsumption (`max-fail-subsume`).

3. I also add another user option to specify the subsumption table size (`subsumption-table-size`) that can be used together with max-fail-subsume option. If we already set max-fail-subsume, so we might not need to store all of the entries since it may not be checked anyway. For example: if the max-fail-subsume equals to 10, we might interested to store only the 10 newest entries because the rest of entries are not checked anyway, so we can reduce the space consumption. 

Below are the experiment result for `klee-examples/Regexp.c` `-max-fail-subsume=10 -subsumption-table-size=10
`
```
KLEE: done: total instructions = 1001434
KLEE: done: completed paths = 2547, among which
KLEE: done:     early-terminating paths (instruction time limit, solver timeout, max-depth reached) = 0
KLEE: done:     subsumed paths = 1052
KLEE: done:     error paths = 237
KLEE: done:     program exit paths = 1258
KLEE: done: generated tests = 2312, among which
KLEE: done:     early-terminating tests (instruction time limit, solver timeout, max-depth reached) = 0
KLEE: done:     subsumed tests = 1052
KLEE: done:     error tests = 2
KLEE: done:     program exit tests = 1258
Execution Time : 42.33
```
compare to result from`No option
`
```
KLEE: done: total instructions = 986871
KLEE: done: completed paths = 2538, among which
KLEE: done:     early-terminating paths (instruction time limit, solver timeout, max-depth reached) = 0
KLEE: done:     subsumed paths = 1072
KLEE: done:     error paths = 237
KLEE: done:     program exit paths = 1229
KLEE: done: generated tests = 2303, among which
KLEE: done:     early-terminating tests (instruction time limit, solver timeout, max-depth reached) = 0
KLEE: done:     subsumed tests = 1072
KLEE: done:     error tests = 2
KLEE: done:     program exit tests = 1229
Execution time: 93.63
```

We might lose few numbers of subsumption, but exhaustive search to all of entries of subsumption table entry are also expensive and also we could give user the flexibility to experiment. With specifying `max-fail-subsume` and `subsumption-table-size`, the execution time is changed from 93.63 to 42.33.