### PR TITLE
Modify EqualityList and FlowsToList into EqualityMap and FlowsToMap accordingly

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -187,16 +187,6 @@ void VersionedValue::print(llvm::raw_ostream &stream) const {
 
 /**/
 
-void PointerEquality::print(llvm::raw_ostream &stream) const {
-  stream << "(";
-  value->print(stream);
-  stream << "==";
-  allocation->print(stream);
-  stream << ")";
-}
-
-/**/
-
 void FlowsTo::print(llvm::raw_ostream &stream) const {
   source->print(stream);
   stream << "->";

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1534,18 +1534,18 @@ void Dependency::print(llvm::raw_ostream &stream,
   std::string tabs = makeTabs(paddingAmount);
   stream << tabs << "EQUALITIES:";
   std::map<const VersionedValue *, std::vector<Allocation *> >::const_iterator
-  equalityListBegin = equalityMap.begin();
+  equalityMapBegin = equalityMap.begin();
   std::map<Allocation *, VersionedValue *>::const_iterator storesMapBegin =
       storesMap.begin();
   std::map<VersionedValue *,
            std::map<VersionedValue *, Allocation *> >::const_iterator
-  flowsToListBegin = flowsToMap.begin();
+  flowsToMapBegin = flowsToMap.begin();
   for (std::map<const VersionedValue *,
                 std::vector<Allocation *> >::const_iterator
            it = equalityMap.begin(),
            itEnd = equalityMap.end();
        it != itEnd; ++it) {
-    if (it != equalityListBegin)
+    if (it != equalityMapBegin)
       stream << ",";
     stream << "[";
     (*it->first).print(stream);
@@ -1582,7 +1582,7 @@ void Dependency::print(llvm::raw_ostream &stream,
            it = flowsToMap.begin(),
            itEnd = flowsToMap.end();
        it != itEnd; ++it) {
-    if (it != flowsToListBegin)
+    if (it != flowsToMapBegin)
       stream << ",";
     stream << "[";
     (*it->first).print(stream);

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -564,8 +564,8 @@ Allocation *Dependency::resolveAllocation(VersionedValue *val) {
   if (!val)
     return 0;
 
-  if (equalityList.find(val) != equalityList.end()) {
-    return equalityList[val].back();
+  if (equalityMap.find(val) != equalityMap.end()) {
+    return equalityMap[val].back();
   }
 
   if (parentDependency)
@@ -616,12 +616,12 @@ Dependency::resolveAllocationTransitively(VersionedValue *value) {
 
 void Dependency::addPointerEquality(const VersionedValue *value,
                                     Allocation *allocation) {
-  if (equalityList.find(value) != equalityList.end()) {
-    equalityList[value].push_back(allocation);
+  if (equalityMap.find(value) != equalityMap.end()) {
+    equalityMap[value].push_back(allocation);
   } else {
     std::vector<Allocation *> newList;
     newList.push_back(allocation);
-    equalityList.insert(
+    equalityMap.insert(
         std::make_pair<const VersionedValue *, std::vector<Allocation *> >(
             value, newList));
   }
@@ -840,7 +840,7 @@ Dependency::Dependency(Dependency *prev) : parentDependency(prev) {}
 
 Dependency::~Dependency() {
   // Delete the locally-constructed relations
-  Util::deletePointerMapWithVectorValue(equalityList);
+  Util::deletePointerMapWithVectorValue(equalityMap);
   Util::deletePointerMap(storesMap);
   Util::deletePointerMapWithVectorValue(storageOfMap);
   Util::deletePointerMapWithMapValue(flowsToMap);
@@ -1534,7 +1534,7 @@ void Dependency::print(llvm::raw_ostream &stream,
   std::string tabs = makeTabs(paddingAmount);
   stream << tabs << "EQUALITIES:";
   std::map<const VersionedValue *, std::vector<Allocation *> >::const_iterator
-  equalityListBegin = equalityList.begin();
+  equalityListBegin = equalityMap.begin();
   std::map<Allocation *, VersionedValue *>::const_iterator storesMapBegin =
       storesMap.begin();
   std::map<VersionedValue *,
@@ -1542,8 +1542,8 @@ void Dependency::print(llvm::raw_ostream &stream,
   flowsToListBegin = flowsToMap.begin();
   for (std::map<const VersionedValue *,
                 std::vector<Allocation *> >::const_iterator
-           it = equalityList.begin(),
-           itEnd = equalityList.end();
+           it = equalityMap.begin(),
+           itEnd = equalityMap.end();
        it != itEnd; ++it) {
     if (it != equalityListBegin)
       stream << ",";

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -473,7 +473,7 @@ class Allocation {
     std::vector<VersionedValue *> argumentValuesList;
 
     /// \brief Equality of value to address
-    std::map<const VersionedValue *, std::vector<Allocation *> > equalityList;
+    std::map<const VersionedValue *, std::vector<Allocation *> > equalityMap;
 
     /// \brief The mapping of allocations/addresses to stored value
     std::map<Allocation *, VersionedValue *> storesMap;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -181,35 +181,6 @@ class Allocation {
     }
   };
 
-  /// \brief A class for representing the relation between an LLVM value with an
-  /// allocation/pointer or other values assumed to be allocation/pointer.
-  class PointerEquality {
-    // value equals allocation (pointer)
-    const VersionedValue *value;
-    Allocation *allocation;
-
-  public:
-    PointerEquality(const VersionedValue *value, Allocation *allocation)
-        : value(value), allocation(allocation) {}
-
-    ~PointerEquality() {}
-
-    Allocation *equals(const VersionedValue *value) const {
-      return this->value == value ? allocation : 0;
-    }
-
-    /// \brief Print the content of the object into a stream.
-    ///
-    /// \param The stream to print the data to.
-    void print(llvm::raw_ostream& stream) const;
-
-    /// \brief Print the content of the object to the LLVM error stream
-    void dump() const {
-      print(llvm::errs());
-      llvm::errs() << "\n";
-    }
-  };
-
   /// A class for representing the flow of values from a source to a target
   class FlowsTo {
     // target depends on source

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -498,7 +498,7 @@ class Allocation {
     std::vector<VersionedValue *> argumentValuesList;
 
     /// \brief Equality of value to address
-    std::vector< PointerEquality *> equalityList;
+    std::map<const VersionedValue *, std::vector<Allocation *> > equalityList;
 
     /// \brief The mapping of allocations/addresses to stored value
     std::map<Allocation *, VersionedValue *> storesMap;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -457,6 +457,10 @@ class Allocation {
       static void
       deletePointerMapWithVectorValue(std::map<Key *, std::vector<T *> > &map);
 
+      template <typename Key, typename T>
+      static void
+      deletePointerMapWithMapValue(std::map<Key *, std::map<Key *, T *> > &map);
+
       /// \brief Tests if an allocation site is main function's argument
       static bool isMainArgument(llvm::Value *site);
     };
@@ -477,8 +481,9 @@ class Allocation {
     /// \brief Store the inverse map of both storesMap
     std::map<VersionedValue *, std::vector<Allocation *> > storageOfMap;
 
-    /// \brief Flow relations from one value to another
-    std::vector<FlowsTo *> flowsToList;
+    /// \brief Flow relations of target and its sources with allocation
+    std::map<VersionedValue *, std::map<VersionedValue *, Allocation *> >
+    flowsToMap;
 
     /// \brief The store of the versioned values
     std::vector< VersionedValue *> valuesList;


### PR DESCRIPTION
By modify `EqualityList` and `FlowsToList`  into map, we can retrieve the element faster by using find with that would take O(log n) compare to O(n) in vector/list. 

There's no subsumption difference in `klee-examples/basic` and `scalability/Regexp`.
When I run `scalability/Regexp` with option` -max-fail-subsume=3`, this PR reduces the execution time from 43.23 to 24.43

For `make-test` run, one more test case has passed and execution time is also faster.
Before:
********************
Testing Time: 616.14s
********************
Failing Tests (4):
    KLEE :: Feature/MemoryLimit.c
    KLEE :: Runtime/POSIX/DirConsistency.c
    KLEE :: Runtime/POSIX/DirSeek.c
    KLEE :: Runtime/POSIX/Write2.c

  Expected Passes    : 164
  Expected Failures  : 2
  Unsupported Tests  : 2
  Unexpected Failures: 4
After:
```
********************
Testing Time: 607.48s
********************
Failing Tests (3):
    KLEE :: Feature/MemoryLimit.c
    KLEE :: Runtime/POSIX/DirConsistency.c
    KLEE :: Runtime/POSIX/DirSeek.c

  Expected Passes    : 165
  Expected Failures  : 2
  Unsupported Tests  : 2
  Unexpected Failures: 3

```
