### PR TITLE
 Change the solver from z3_mk_solver_for_logic to Z3_mk_simple_solver 

### DIFF
--- a/lib/Solver/Solver.cpp
+++ b/lib/Solver/Solver.cpp
@@ -1035,9 +1035,7 @@ Z3SolverImpl::computeInitialValues(const Query &query,
                                       &values,
                                     bool &hasSolution) {
 
-  // Use quantified bit-vector array solver
-  Z3_solver the_solver = Z3_mk_solver_for_logic(
-      builder->ctx, Z3_mk_string_symbol(builder->ctx, "ABV"));
+  Z3_solver the_solver = Z3_mk_simple_solver(builder->ctx);
   Z3_solver_inc_ref(builder->ctx, the_solver);
 
   // Create solver parameter


### PR DESCRIPTION
..for better performance

There's basically 4 method of creating a solver:
>  `Z3_mk_solver	(	Z3_context 	c	)	`
>  `Z3_mk_simple_solver	(	Z3_context 	c	)	`
>  `Z3_mk_solver_for_logic	(	Z3_context 	c, Z3_symbol 	logic) 	`
>  `Z3_mk_solver_from_tactic	(	Z3_context 	c, Z3_tactic 	t )	`

I compared the performance  3 of them :  `Z3_mk_solver	(	Z3_context 	c	)	`,  `Z3_mk_solver_for_logic	(	Z3_context 	c, Z3_symbol 	logic) 	` (ABV) , and  `Z3_mk_solver_from_tactic	(	Z3_context 	c, Z3_tactic 	t )	`.  From all three, `Z3_mk_simple_solver	(	Z3_context 	c	)	` is the one that produces fastest execution time.

There's no subsumption difference in klee-examples/basic and scalability/Regexp.
When I run scalability/Regexp with option-max-fail-subsume=3, this PR reduces the execution time from 24.43 to 14.31

For `make-test` run, the execution time is also slightly faster from 607.48s to 605.66s without similar number of expected passes and failures.

```
********************
Testing Time: 605.66s
********************
Failing Tests (3):
    KLEE :: Feature/MemoryLimit.c
    KLEE :: Runtime/POSIX/DirConsistency.c
    KLEE :: Runtime/POSIX/DirSeek.c

  Expected Passes    : 165
  Expected Failures  : 2
  Unsupported Tests  : 2
  Unexpected Failures: 3
```
