### PR TITLE
Bug Fix for Average table entries per subsumption checkpoint and More info

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3832,9 +3832,9 @@ void Executor::runFunctionAsMain(Function *f,
 	#ifdef SUPPORT_Z3
 		// Print interpolation time statistics
 		if (InterpolationStat)
-		  interpreterHandler->assignSubsumptionStats(ITree::getInterpolationStat());
-	#endif
-
+                  interpreterHandler->assignSubsumptionStats(
+                      ITree::getInterpolationStat());
+        #endif
   }
 
   // hack to clear memory objects

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3829,12 +3829,12 @@ void Executor::runFunctionAsMain(Function *f,
     delete interpTree;
     interpTree = 0;
 
-	#ifdef SUPPORT_Z3
+#ifdef SUPPORT_Z3
 		// Print interpolation time statistics
 		if (InterpolationStat)
                   interpreterHandler->assignSubsumptionStats(
                       ITree::getInterpolationStat());
-        #endif
+#endif
   }
 
   // hack to clear memory objects

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3830,10 +3830,9 @@ void Executor::runFunctionAsMain(Function *f,
     interpTree = 0;
 
 #ifdef SUPPORT_Z3
-		// Print interpolation time statistics
-		if (InterpolationStat)
-                  interpreterHandler->assignSubsumptionStats(
-                      ITree::getInterpolationStat());
+    // Print interpolation time statistics
+    if (InterpolationStat)
+      interpreterHandler->assignSubsumptionStats(ITree::getInterpolationStat());
 #endif
   }
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3826,14 +3826,15 @@ void Executor::runFunctionAsMain(Function *f,
     SearchTree::save(interpreterHandler->getOutputFilename("tree.dot"));
     SearchTree::deallocate();
 
-#ifdef SUPPORT_Z3
-    // Print interpolation time statistics
-    if (InterpolationStat)
-      interpreterHandler->assignSubsumptionStats(ITree::getInterpolationStat());
-#endif
-
     delete interpTree;
     interpTree = 0;
+
+	#ifdef SUPPORT_Z3
+		// Print interpolation time statistics
+		if (InterpolationStat)
+		  interpreterHandler->assignSubsumptionStats(ITree::getInterpolationStat());
+	#endif
+
   }
 
   // hack to clear memory objects

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1750,6 +1750,12 @@ void ITree::printTableStat(std::stringstream &stream) {
       << StatTimer::inTwoDecimalPoints(entryNumber / programPointNumber)
       << "\n";
 
+  stream << "KLEE: done:     Number of solver calls = "
+         << SubsumptionTableEntry::checkSolverCount << "\n";
+
+  stream << "KLEE: done:     Number of subsumption check = "
+         << subsumptionCheckCount << "\n";
+
   stream << "KLEE: done:     Average solver calls per subsumption check = "
          << StatTimer::inTwoDecimalPoints(
                 (double)SubsumptionTableEntry::checkSolverCount /

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1753,7 +1753,7 @@ void ITree::printTableStat(std::stringstream &stream) {
   stream << "KLEE: done:     Number of solver calls = "
          << SubsumptionTableEntry::checkSolverCount << "\n";
 
-  stream << "KLEE: done:     Number of subsumption check = "
+  stream << "KLEE: done:     Number of subsumption checks = "
          << subsumptionCheckCount << "\n";
 
   stream << "KLEE: done:     Average solver calls per subsumption check = "


### PR DESCRIPTION
.. regarding Number of solver calls and Number of subsumption check.

This Bug Fix is caused by putting the code 
```
    if (InterpolationStat)
      interpreterHandler->assignSubsumptionStats(ITree::getInterpolationStat());

```
before   `delete interpTree;` where the code should be put after  `delete interpTree;` because this code need to access variable `entryNumber`  and `programPointNumber` that is updated in the destructor of ITree.