### PR TITLE
WIP: Adding constraints caching (Z3 solver push / pop) for Z3 solving in subsumption checks

### DIFF
--- a/include/klee/IncompleteSolver.h
+++ b/include/klee/IncompleteSolver.h
@@ -104,8 +104,14 @@ public:
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query&);
   void setCoreSolverTimeout(double timeout);
-  std::vector< ref<Expr> > getUnsatCore() {
+  std::vector<ref<Expr> > getUnsatCore() {
     return secondary->impl->getUnsatCore();
+  }
+  void enableConstraintsCaching() {
+    secondary->impl->enableConstraintsCaching();
+  }
+  void disableConstraintsCaching() {
+    secondary->impl->disableConstraintsCaching();
   }
 };
 

--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -209,6 +209,18 @@ namespace klee {
     ///
     /// \return Vector of ref<Expr>
     virtual std::vector< ref<Expr> > getUnsatCore();
+
+    /// enableConstraintsCaching - when solving a query defined using a Query
+    /// object, cache the constraints list within the core solver. This is for
+    /// submission of queries with multiple consequents. This API enables the
+    /// feature for the series of queries to be submitted to the solver.
+    virtual void enableConstraintsCaching();
+
+    /// disableConstraintsCaching - when solving a query defined using a Query
+    /// object, cache the constraints list within the core solver. This is for
+    /// submission of queries with multiple consequents. This API disables this
+    /// feature.
+    virtual void disableConstraintsCaching();
   };
 
   #ifdef ENABLE_STP

--- a/include/klee/SolverImpl.h
+++ b/include/klee/SolverImpl.h
@@ -112,8 +112,17 @@ namespace klee {
     ///
     /// \return Vector of ref<Expr>
     virtual std::vector< ref<Expr> > getUnsatCore();
-  };
 
+    /// enableConstraintsCaching - when solving a query defined using a Query
+    /// object, cache the constraints list within the core solver. This is for
+    /// submission of queries with multiple consequents.
+    virtual void enableConstraintsCaching();
+
+    /// disableConstraintsCaching - when solving a query defined using a Query
+    /// object, cache the constraints list within the core solver. This is for
+    /// submission of queries with multiple consequents.
+    virtual void disableConstraintsCaching();
+  };
 }
 
 #endif

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1830,6 +1830,7 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
   std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
   storedExpressions = state.itreeNode->getStoredExpressions();
 
+  solver->enableConstraintsCaching();
   // Iterate the subsumption table entry with reverse iterator because
   // the successful subsumption mostly happen in the newest entry.
   for (std::deque<SubsumptionTableEntry *>::reverse_iterator
@@ -1846,10 +1847,12 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
       // Mark the node as subsumed, and create a subsumption edge
       SearchTree::markAsSubsumed(currentINode, (*it));
       subsumptionCheckTimer.stop();
+      solver->disableConstraintsCaching();
       return true;
     }
   }
   subsumptionCheckTimer.stop();
+  solver->disableConstraintsCaching();
   return false;
 }
 

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -66,6 +66,8 @@ namespace klee {
     std::pair< ref<Expr>, ref<Expr> >
     getRange(const ExecutionState&, ref<Expr> query);
     std::vector< ref<Expr> > getUnsatCore();
+    void enableConstraintsCaching() { solver->enableConstraintsCaching(); }
+    void disableConstraintsCaching() { solver->disableConstraintsCaching(); }
   };
 
 }

--- a/lib/Solver/CachingSolver.cpp
+++ b/lib/Solver/CachingSolver.cpp
@@ -109,6 +109,8 @@ public:
   char *getConstraintLog(const Query&);
   void setCoreSolverTimeout(double timeout);
   std::vector<ref<Expr> > getUnsatCore() { return unsatCoreToReturn; }
+  void enableConstraintsCaching() { solver->enableConstraintsCaching(); }
+  void disableConstraintsCaching() { solver->disableConstraintsCaching(); }
 };
 
 /** @returns the canonical version of the given query.  The reference

--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -94,6 +94,8 @@ public:
   char *getConstraintLog(const Query& query);
   void setCoreSolverTimeout(double timeout);
   std::vector<ref<Expr> > getUnsatCore() { return unsatCore; }
+  void enableConstraintsCaching() { solver->enableConstraintsCaching(); }
+  void disableConstraintsCaching() { solver->disableConstraintsCaching(); }
 };
 
 ///

--- a/lib/Solver/DummySolver.cpp
+++ b/lib/Solver/DummySolver.cpp
@@ -26,6 +26,8 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   std::vector<ref<Expr> > getUnsatCore();
+  void enableConstraintsCaching() {}
+  void disableConstraintsCaching() {}
 };
 
 DummySolverImpl::DummySolverImpl() {}

--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -409,9 +409,9 @@ public:
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query&);
   void setCoreSolverTimeout(double timeout);
-  std::vector< ref<Expr> > getUnsatCore() {
-    return solver->getUnsatCore();
-  }
+  std::vector<ref<Expr> > getUnsatCore() { return solver->getUnsatCore(); }
+  void enableConstraintsCaching() { solver->enableConstraintsCaching(); }
+  void disableConstraintsCaching() { solver->disableConstraintsCaching(); }
 };
   
 bool IndependentSolver::computeValidity(const Query& query,

--- a/lib/Solver/QueryLoggingSolver.h
+++ b/lib/Solver/QueryLoggingSolver.h
@@ -75,6 +75,8 @@ public:
   char *getConstraintLog(const Query &);
   void setCoreSolverTimeout(double timeout);
   std::vector<ref<Expr> > getUnsatCore() { return solver->getUnsatCore(); }
+  void enableConstraintsCaching() { solver->enableConstraintsCaching(); }
+  void disableConstraintsCaching() { solver->disableConstraintsCaching(); }
 };
 
 #endif /* KLEE_QUERYLOGGINGSOLVER_H */

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -82,6 +82,8 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   std::vector<ref<Expr> > getUnsatCore();
+  void enableConstraintsCaching() {}
+  void disableConstraintsCaching() {}
 };
 
 STPSolverImpl::STPSolverImpl(bool _useForkedSTP, bool _optimizeDivides)

--- a/lib/Solver/Solver.cpp
+++ b/lib/Solver/Solver.cpp
@@ -224,6 +224,10 @@ std::vector< ref<Expr> > Solver::getUnsatCore() {
   return impl->getUnsatCore();
 }
 
+void Solver::enableConstraintsCaching() { impl->enableConstraintsCaching(); }
+
+void Solver::disableConstraintsCaching() { impl->disableConstraintsCaching(); }
+
 void Query::dump() const {
   llvm::errs() << "Constraints [\n";
   for (ConstraintManager::const_iterator i = constraints.begin();

--- a/lib/Solver/SolverImpl.cpp
+++ b/lib/Solver/SolverImpl.cpp
@@ -56,3 +56,7 @@ std::vector<ref<Expr> > SolverImpl::getUnsatCore() {
   std::vector<ref<Expr> > localUnsatCore;
   return localUnsatCore;
 }
+
+void SolverImpl::enableConstraintsCaching() {}
+
+void SolverImpl::disableConstraintsCaching() {}

--- a/lib/Solver/ValidatingSolver.cpp
+++ b/lib/Solver/ValidatingSolver.cpp
@@ -32,9 +32,9 @@ public:
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query &);
   void setCoreSolverTimeout(double timeout);
-  std::vector< ref<Expr> > getUnsatCore() {
-          return solver->getUnsatCore();
-  }
+  std::vector<ref<Expr> > getUnsatCore() { return solver->getUnsatCore(); }
+  void enableConstraintsCaching() { solver->enableConstraintsCaching(); }
+  void disableConstraintsCaching() { solver->disableConstraintsCaching(); }
 };
 
 bool ValidatingSolver::computeTruth(const Query &query, bool &isValid) {


### PR DESCRIPTION
This does not seem to be effective for the reason that at any subsumption check, if Z3 is called, it is only called once, so there is no point in caching the path condition of the path that is to be subsumed within Z3.