### PR TITLE
Corrected statistics for subsumption check

### DIFF
--- a/include/klee/IncompleteSolver.h
+++ b/include/klee/IncompleteSolver.h
@@ -104,9 +104,11 @@ public:
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query&);
   void setCoreSolverTimeout(double timeout);
-  std::vector< ref<Expr> > getUnsatCore() {
+  std::vector<ref<Expr> > getUnsatCore() {
     return secondary->impl->getUnsatCore();
   }
+  void startSubsumptionCheck() { secondary->impl->startSubsumptionCheck(); }
+  void endSubsumptionCheck() { secondary->impl->endSubsumptionCheck(); }
 };
 
 }

--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -209,6 +209,14 @@ namespace klee {
     ///
     /// \return Vector of ref<Expr>
     virtual std::vector< ref<Expr> > getUnsatCore();
+
+    /// startSubsumptionCheck - Mark the usage of the solver as for subsumption
+    /// check.
+    virtual void startSubsumptionCheck();
+
+    /// endSubsumptionCheck - Mark the usage of the solver as not belonging to
+    /// subsumption check.
+    virtual void endSubsumptionCheck();
   };
 
   #ifdef ENABLE_STP

--- a/include/klee/SolverImpl.h
+++ b/include/klee/SolverImpl.h
@@ -112,6 +112,14 @@ namespace klee {
     ///
     /// \return Vector of ref<Expr>
     virtual std::vector< ref<Expr> > getUnsatCore();
+
+    /// startSubsumptionCheck - Mark the usage of the solver as for subsumption
+    /// check.
+    virtual void startSubsumptionCheck();
+
+    /// endSubsumptionCheck - Mark the usage of the solver as not belonging to
+    /// subsumption check.
+    virtual void endSubsumptionCheck();
   };
 
 }

--- a/include/klee/SolverStats.h
+++ b/include/klee/SolverStats.h
@@ -27,7 +27,10 @@ namespace stats {
   extern Statistic queryConstructs;
   extern Statistic queryCounterexamples;
   extern Statistic queryTime;
-  
+  extern Statistic subsumptionQueryTime;
+  extern Statistic subsumptionQueryCount;
+  extern Statistic subsumptionQueryFailureCount;
+
 #ifdef DEBUG
   extern Statistic arrayHashTime;
 #endif

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -363,15 +363,6 @@ class SubsumptionTableEntry {
     }
   };
 
-  /// \brief Statistics for actual solver call time in subsumption check
-  static StatTimer actualSolverCallTimer;
-
-  /// \brief The number of solver calls for subsumption checks
-  static unsigned long checkSolverCount;
-
-  /// \brief The number of failed solver calls for subsumption checks
-  static unsigned long checkSolverFailureCount;
-
   ref<Expr> interpolant;
 
   Dependency::ConcreteStore concreteAddressStore;

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -147,3 +147,11 @@ TimingSolver::getRange(const ExecutionState& state, ref<Expr> expr) {
 std::vector< ref<Expr> > TimingSolver::getUnsatCore() {
   return solver->getUnsatCore();
 }
+
+void TimingSolver::startSubsumptionCheck() {
+  return solver->startSubsumptionCheck();
+}
+
+void TimingSolver::endSubsumptionCheck() {
+  return solver->endSubsumptionCheck();
+}

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -66,6 +66,8 @@ namespace klee {
     std::pair< ref<Expr>, ref<Expr> >
     getRange(const ExecutionState&, ref<Expr> query);
     std::vector< ref<Expr> > getUnsatCore();
+    void startSubsumptionCheck();
+    void endSubsumptionCheck();
   };
 
 }

--- a/lib/Solver/CachingSolver.cpp
+++ b/lib/Solver/CachingSolver.cpp
@@ -109,6 +109,8 @@ public:
   char *getConstraintLog(const Query&);
   void setCoreSolverTimeout(double timeout);
   std::vector<ref<Expr> > getUnsatCore() { return unsatCoreToReturn; }
+  void startSubsumptionCheck() { solver->impl->startSubsumptionCheck(); }
+  void endSubsumptionCheck() { solver->impl->endSubsumptionCheck(); }
 };
 
 /** @returns the canonical version of the given query.  The reference

--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -94,6 +94,8 @@ public:
   char *getConstraintLog(const Query& query);
   void setCoreSolverTimeout(double timeout);
   std::vector<ref<Expr> > getUnsatCore() { return unsatCore; }
+  void startSubsumptionCheck() { solver->startSubsumptionCheck(); }
+  void endSubsumptionCheck() { solver->endSubsumptionCheck(); }
 };
 
 ///

--- a/lib/Solver/DummySolver.cpp
+++ b/lib/Solver/DummySolver.cpp
@@ -26,6 +26,8 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   std::vector<ref<Expr> > getUnsatCore();
+  void startSubsumptionCheck() {}
+  void endSubsumptionCheck() {}
 };
 
 DummySolverImpl::DummySolverImpl() {}

--- a/lib/Solver/IndependentSolver.cpp
+++ b/lib/Solver/IndependentSolver.cpp
@@ -409,9 +409,9 @@ public:
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query&);
   void setCoreSolverTimeout(double timeout);
-  std::vector< ref<Expr> > getUnsatCore() {
-    return solver->getUnsatCore();
-  }
+  std::vector<ref<Expr> > getUnsatCore() { return solver->getUnsatCore(); }
+  void startSubsumptionCheck() { return solver->startSubsumptionCheck(); }
+  void endSubsumptionCheck() { return solver->endSubsumptionCheck(); }
 };
   
 bool IndependentSolver::computeValidity(const Query& query,

--- a/lib/Solver/QueryLoggingSolver.h
+++ b/lib/Solver/QueryLoggingSolver.h
@@ -75,6 +75,8 @@ public:
   char *getConstraintLog(const Query &);
   void setCoreSolverTimeout(double timeout);
   std::vector<ref<Expr> > getUnsatCore() { return solver->getUnsatCore(); }
+  void startSubsumptionCheck() { return solver->startSubsumptionCheck(); }
+  void endSubsumptionCheck() { return solver->endSubsumptionCheck(); }
 };
 
 #endif /* KLEE_QUERYLOGGINGSOLVER_H */

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -82,6 +82,8 @@ public:
                             bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   std::vector<ref<Expr> > getUnsatCore();
+  void startSubsumptionCheck() {};
+  void endSubsubmptionCheck() {};
 };
 
 STPSolverImpl::STPSolverImpl(bool _useForkedSTP, bool _optimizeDivides)

--- a/lib/Solver/Solver.cpp
+++ b/lib/Solver/Solver.cpp
@@ -224,6 +224,10 @@ std::vector< ref<Expr> > Solver::getUnsatCore() {
   return impl->getUnsatCore();
 }
 
+void Solver::startSubsumptionCheck() { impl->startSubsumptionCheck(); }
+
+void Solver::endSubsumptionCheck() { impl->endSubsumptionCheck(); }
+
 void Query::dump() const {
   llvm::errs() << "Constraints [\n";
   for (ConstraintManager::const_iterator i = constraints.begin();

--- a/lib/Solver/SolverImpl.cpp
+++ b/lib/Solver/SolverImpl.cpp
@@ -56,3 +56,7 @@ std::vector<ref<Expr> > SolverImpl::getUnsatCore() {
   std::vector<ref<Expr> > localUnsatCore;
   return localUnsatCore;
 }
+
+void SolverImpl::startSubsumptionCheck() {}
+
+void SolverImpl::endSubsumptionCheck() {}

--- a/lib/Solver/SolverStats.cpp
+++ b/lib/Solver/SolverStats.cpp
@@ -23,6 +23,10 @@ Statistic stats::queryConstructTime("QueryConstructTime", "QBtime") ;
 Statistic stats::queryConstructs("QueriesConstructs", "QB");
 Statistic stats::queryCounterexamples("QueriesCEX", "Qcex");
 Statistic stats::queryTime("QueryTime", "Qtime");
+Statistic stats::subsumptionQueryTime("SubsumptionQueryTime", "SQtime");
+Statistic stats::subsumptionQueryCount("SubsumptionQueryCount", "SCcount");
+Statistic stats::subsumptionQueryFailureCount("SubsumptionQueryFailureCount",
+                                              "SFcount");
 
 #ifdef DEBUG
 Statistic stats::arrayHashTime("ArrayHashTime", "AHtime");

--- a/lib/Solver/ValidatingSolver.cpp
+++ b/lib/Solver/ValidatingSolver.cpp
@@ -32,9 +32,9 @@ public:
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query &);
   void setCoreSolverTimeout(double timeout);
-  std::vector< ref<Expr> > getUnsatCore() {
-          return solver->getUnsatCore();
-  }
+  std::vector<ref<Expr> > getUnsatCore() { return solver->getUnsatCore(); }
+  void startSubSumptionCheck() { solver->startSubsumptionCheck(); }
+  void endSubsumptionCheck() { solver->endSubsumptionCheck(); }
 };
 
 bool ValidatingSolver::computeTruth(const Query &query, bool &isValid) {

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -29,6 +29,7 @@ private:
   ::Z3_params solverParameters;
   // Parameter symbols
   ::Z3_symbol timeoutParamStrSymbol;
+  bool subsumptionCheck;
 
   bool internalRunSolver(const Query &,
                          const std::vector<const Array *> *objects,
@@ -73,11 +74,13 @@ public:
                        bool &hasSolution);
   SolverRunStatus getOperationStatusCode();
   std::vector<ref<Expr> > getUnsatCore();
+  void startSubsumptionCheck() { subsumptionCheck = true; }
+  void endSubsumptionCheck() { subsumptionCheck = false; }
 };
 
 Z3SolverImpl::Z3SolverImpl()
     : builder(new Z3Builder(/*autoClearConstructCache=*/false)), timeout(0.0),
-      runStatusCode(SOLVER_RUN_STATUS_FAILURE) {
+      runStatusCode(SOLVER_RUN_STATUS_FAILURE), subsumptionCheck(false) {
   assert(builder && "unable to create Z3Builder");
   solverParameters = Z3_mk_params(builder->ctx);
   Z3_params_inc_ref(builder->ctx, solverParameters);
@@ -185,6 +188,17 @@ bool Z3SolverImpl::computeInitialValues(
 bool Z3SolverImpl::internalRunSolver(
     const Query &query, const std::vector<const Array *> *objects,
     std::vector<std::vector<unsigned char> > *values, bool &hasSolution) {
+  if (subsumptionCheck) {
+    TimerStatIncrementer t(stats::subsumptionQueryTime);
+    ++stats::subsumptionQueryCount;
+    subsumptionCheck = false;
+    bool result = internalRunSolver(query, objects, values, hasSolution);
+    if (!result || hasSolution) {
+      ++stats::subsumptionQueryFailureCount;
+    }
+    subsumptionCheck = true;
+    return result;
+  }
   TimerStatIncrementer t(stats::queryTime);
   // TODO: Does making a new solver for each query have a performance
   // impact vs making one global solver and using push and pop?


### PR DESCRIPTION
Previously, the subsumption check statistics do not reflect the actual call to the core (Z3 backend) solver. They do now.