### PR TITLE
Simplification to memory dependency computation

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -153,12 +153,6 @@ ShadowArray::getShadowExpression(ref<Expr> expr,
 /**/
 
 void MemoryLocation::print(llvm::raw_ostream &stream) const {
-  // Do nothing
-}
-
-/**/
-
-void VersionedLocation::print(llvm::raw_ostream &stream) const {
   stream << "A";
   if (!llvm::isa<ConstantExpr>(this->address.get()))
     stream << "(symbolic)";
@@ -386,7 +380,7 @@ MemoryLocation *Dependency::getSpecificInitialLocation(llvm::Value *loc,
                                                        ref<Expr> address,
                                                        ref<Expr> base,
                                                        ref<Expr> offset) {
-  MemoryLocation *ret = new VersionedLocation(loc, address, base, offset);
+  MemoryLocation *ret = new MemoryLocation(loc, address, base, offset);
   versionedLocationsList.push_back(ret);
   return ret;
 }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -77,8 +77,8 @@ ShadowArray::getShadowExpression(ref<Expr> expr,
     UpdateList newUpdates(
         replacementArray,
         getShadowUpdate(readExpr->updates.head, replacements));
-    ret = ReadExpr::alloc(newUpdates,
-                          getShadowExpression(readExpr->index, replacements));
+    ret = ReadExpr::create(newUpdates,
+                           getShadowExpression(readExpr->index, replacements));
     break;
   }
   case Expr::Constant: {
@@ -86,27 +86,29 @@ ShadowArray::getShadowExpression(ref<Expr> expr,
     break;
   }
   case Expr::Select: {
-    ret = SelectExpr::alloc(getShadowExpression(expr->getKid(0), replacements),
-                            getShadowExpression(expr->getKid(1), replacements),
-                            getShadowExpression(expr->getKid(2), replacements));
+    ret =
+        SelectExpr::create(getShadowExpression(expr->getKid(0), replacements),
+                           getShadowExpression(expr->getKid(1), replacements),
+                           getShadowExpression(expr->getKid(2), replacements));
     break;
   }
   case Expr::Extract: {
     ExtractExpr *extractExpr = llvm::dyn_cast<ExtractExpr>(expr);
-    ret = ExtractExpr::alloc(getShadowExpression(expr->getKid(0), replacements),
-                             extractExpr->offset, extractExpr->width);
+    ret =
+        ExtractExpr::create(getShadowExpression(expr->getKid(0), replacements),
+                            extractExpr->offset, extractExpr->width);
     break;
   }
   case Expr::ZExt: {
     CastExpr *castExpr = llvm::dyn_cast<CastExpr>(expr);
-    ret = ZExtExpr::alloc(getShadowExpression(expr->getKid(0), replacements),
-                          castExpr->getWidth());
+    ret = ZExtExpr::create(getShadowExpression(expr->getKid(0), replacements),
+                           castExpr->getWidth());
     break;
   }
   case Expr::SExt: {
     CastExpr *castExpr = llvm::dyn_cast<CastExpr>(expr);
-    ret = SExtExpr::alloc(getShadowExpression(expr->getKid(0), replacements),
-                          castExpr->getWidth());
+    ret = SExtExpr::create(getShadowExpression(expr->getKid(0), replacements),
+                           castExpr->getWidth());
     break;
   }
   case Expr::Concat:

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -316,6 +316,8 @@ void Dependency::updateStore(ref<MemoryLocation> loc,
 
 void Dependency::addDependency(ref<VersionedValue> source,
                                ref<VersionedValue> target) {
+  ref<MemoryLocation> nullLocation;
+
   if (source.isNull() || target.isNull())
     return;
 
@@ -326,12 +328,14 @@ void Dependency::addDependency(ref<VersionedValue> source,
        it != ie; ++it) {
     target->addLocation(*it);
   }
-  addDependencyViaLocation(source, target, 0);
+  addDependencyViaLocation(source, target, nullLocation);
 }
 
 void Dependency::addDependencyWithOffset(ref<VersionedValue> source,
                                          ref<VersionedValue> target,
                                          ref<Expr> offset) {
+  ref<MemoryLocation> nullLocation;
+
   if (source.isNull() || target.isNull())
     return;
 
@@ -342,7 +346,7 @@ void Dependency::addDependencyWithOffset(ref<VersionedValue> source,
     ref<Expr> expr(target->getExpression());
     target->addLocation(MemoryLocation::create(*it, expr, offset));
   }
-  addDependencyViaLocation(source, target, 0);
+  addDependencyViaLocation(source, target, nullLocation);
 }
 
 void Dependency::addDependencyViaLocation(ref<VersionedValue> source,
@@ -356,8 +360,7 @@ void Dependency::addDependencyViaLocation(ref<VersionedValue> source,
         std::make_pair<ref<VersionedValue>, ref<MemoryLocation> >(source, via));
   } else {
     std::map<ref<VersionedValue>, ref<MemoryLocation> > newMap;
-    newMap.insert(
-        std::make_pair<ref<VersionedValue>, ref<MemoryLocation> >(source, via));
+    newMap[source] = via;
     flowsToMap[target] = newMap;
   }
 }
@@ -685,7 +688,6 @@ void Dependency::execute(llvm::Instruction *instr,
                locIter = locations.begin(),
                locIterEnd = locations.end();
            locIter != locIterEnd; ++locIter) {
-
         ref<VersionedValue> storedValue = _concreteStore[*locIter];
 
         if (storedValue.isNull())

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -208,6 +208,7 @@ Dependency::getStoredExpressions(std::set<const Array *> &replacements,
       ref<Expr> address = it->first->getAddress();
       concreteStore[site][uintAddress] = AddressValuePair(address, expr);
     } else if (it->second->isCore()) {
+      // An address is in the core if it stores a value that is in the core
       ref<Expr> expr = it->second->getExpression();
       llvm::Value *base = it->first->getValue();
       uint64_t uintAddress = it->first->getUIntAddress();
@@ -237,6 +238,7 @@ Dependency::getStoredExpressions(std::set<const Array *> &replacements,
       llvm::Value *base = it->first->getValue();
       symbolicStore[base].push_back(AddressValuePair(address, expr));
     } else if (it->second->isCore()) {
+      // An address is in the core if it stores a value that is in the core
       ref<Expr> expr = it->second->getExpression();
       llvm::Value *base = it->first->getValue();
 #ifdef ENABLE_Z3

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -66,7 +66,7 @@ ShadowArray::getShadowExpression(ref<Expr> expr,
 
   switch (expr->getKind()) {
   case Expr::Read: {
-    ReadExpr *readExpr = static_cast<ReadExpr *>(expr.get());
+    ReadExpr *readExpr = llvm::dyn_cast<ReadExpr>(expr);
     const Array *replacementArray = shadowArray[readExpr->updates.root];
 
     if (std::find(replacements.begin(), replacements.end(), replacementArray) ==
@@ -92,19 +92,19 @@ ShadowArray::getShadowExpression(ref<Expr> expr,
     break;
   }
   case Expr::Extract: {
-    ExtractExpr *extractExpr = static_cast<ExtractExpr *>(expr.get());
+    ExtractExpr *extractExpr = llvm::dyn_cast<ExtractExpr>(expr);
     ret = ExtractExpr::alloc(getShadowExpression(expr->getKid(0), replacements),
                              extractExpr->offset, extractExpr->width);
     break;
   }
   case Expr::ZExt: {
-    CastExpr *castExpr = static_cast<CastExpr *>(expr.get());
+    CastExpr *castExpr = llvm::dyn_cast<CastExpr>(expr);
     ret = ZExtExpr::alloc(getShadowExpression(expr->getKid(0), replacements),
                           castExpr->getWidth());
     break;
   }
   case Expr::SExt: {
-    CastExpr *castExpr = static_cast<CastExpr *>(expr.get());
+    CastExpr *castExpr = llvm::dyn_cast<CastExpr>(expr);
     ret = SExtExpr::alloc(getShadowExpression(expr->getKid(0), replacements),
                           castExpr->getWidth());
     break;
@@ -154,7 +154,7 @@ ShadowArray::getShadowExpression(ref<Expr> expr,
 
 void MemoryLocation::print(llvm::raw_ostream &stream) const {
   stream << "A";
-  if (!llvm::isa<ConstantExpr>(this->address.get()))
+  if (!llvm::isa<ConstantExpr>(this->address))
     stream << "(symbolic)";
   if (core)
     stream << "(I)";

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1197,7 +1197,7 @@ void Dependency::execute(llvm::Instruction *instr,
 
         // We simply propagate the pointer to the current
         addPointerEquality(getNewVersionedValue(instr, address),
-                           getInitialLocation(instr, base));
+                           getInitialLocation(instr, base, offset));
         break;
       }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1127,14 +1127,13 @@ void Dependency::execute(llvm::Instruction *instr,
         // We look up existing locations with the same site as the argument,
         // but with the address given as valueExpr (the value of the
         // getelementptr instruction itself).
-        MemoryLocation *actualLocation =
+        MemoryLocation *loc =
             getLatestLocation(instr->getOperand(0), valueExpr);
-        if (!actualLocation)
-          actualLocation = getInitialLocation(instr->getOperand(0), valueExpr);
+        if (!loc)
+          loc = getInitialLocation(instr->getOperand(0), valueExpr);
 
         // We simply propagate the pointer to the current
-        addPointerEquality(getNewVersionedValue(instr, valueExpr),
-                           actualLocation);
+        addPointerEquality(getNewVersionedValue(instr, valueExpr), loc);
         break;
       }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -157,9 +157,13 @@ void MemoryLocation::print(llvm::raw_ostream &stream) const {
   if (!llvm::isa<ConstantExpr>(this->address))
     stream << "(symbolic)";
   stream << "[";
-  loc->print(stream);
+  value->print(stream);
   stream << ":";
   address->print(stream);
+  stream << ":";
+  base->print(stream);
+  stream << ":";
+  offset->print(stream);
   stream << "]#" << reinterpret_cast<uintptr_t>(this);
 }
 
@@ -322,7 +326,6 @@ void Dependency::addDependency(ref<VersionedValue> source,
     return;
 
   std::set<ref<MemoryLocation> > locations = source->getLocations();
-
   for (std::set<ref<MemoryLocation> >::iterator it = locations.begin(),
                                                 ie = locations.end();
        it != ie; ++it) {
@@ -354,6 +357,13 @@ void Dependency::addDependencyViaLocation(ref<VersionedValue> source,
                                           ref<MemoryLocation> via) {
   if (source.isNull() || target.isNull())
     return;
+
+  std::set<ref<MemoryLocation> > locations = source->getLocations();
+  for (std::set<ref<MemoryLocation> >::iterator it = locations.begin(),
+                                                ie = locations.end();
+       it != ie; ++it) {
+    target->addLocation(*it);
+  }
 
   if (flowsToMap.find(target) != flowsToMap.end()) {
     flowsToMap[target].insert(

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -152,6 +152,21 @@ ShadowArray::getShadowExpression(ref<Expr> expr,
 
 /**/
 
+MemoryLocation::MemoryLocation(MemoryLocation *loc, ref<Expr> &_offset) :
+    core(loc->core), site(loc->site), address(loc->address) {
+  // We create new memory location with different offset
+  ConstantExpr *offsetConst = llvm::dyn_cast<ConstantExpr>(loc->offset.get());
+  ConstantExpr *extraConst = llvm::dyn_cast<ConstantExpr>(_offset.get());
+
+  if (offsetConst != 0 && extraConst != 0) {
+    uint64_t newConst =
+        offsetConst->getZExtValue() + extraConst->getZExtValue();
+    offset = ConstantExpr::create(newConst, Expr::Int64);
+  } else {
+    offset = AddExpr::create(offset, _offset);
+  }
+}
+
 void MemoryLocation::print(llvm::raw_ostream &stream) const {
   // Do nothing
 }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -357,17 +357,16 @@ void LocationGraph::print(llvm::raw_ostream &stream,
 
 /**/
 
-VersionedValue *Dependency::getNewVersionedValue(llvm::Value *value,
-                                                 ref<Expr> valueExpr) {
-  VersionedValue *ret = new VersionedValue(value, valueExpr);
+VersionedValue *Dependency::registerNewVersionedValue(llvm::Value *value,
+                                                      VersionedValue *vvalue) {
   if (valuesMap.find(value) != valuesMap.end()) {
-    valuesMap[value].push_back(ret);
+    valuesMap[value].push_back(vvalue);
   } else {
     std::vector<VersionedValue *> newValueList;
-    newValueList.push_back(ret);
+    newValueList.push_back(vvalue);
     valuesMap[value] = newValueList;
   }
-  return ret;
+  return vvalue;
 }
 
 MemoryLocation *Dependency::getInitialLocation(llvm::Value *loc,

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -183,8 +183,8 @@ void VersionedValue::print(llvm::raw_ostream &stream) const {
 
 bool LocationGraph::isVisited(ref<MemoryLocation> loc) {
   for (std::vector<LocationNode *>::iterator it = allNodes.begin(),
-                                             itEnd = allNodes.end();
-       it != itEnd; ++it) {
+                                             ie = allNodes.end();
+       it != ie; ++it) {
     if ((*it)->getLocation() == loc) {
       return true;
     }
@@ -207,8 +207,8 @@ void LocationGraph::addNewEdge(ref<MemoryLocation> source,
   LocationNode *targetNode = 0;
 
   for (std::vector<LocationNode *>::iterator it = allNodes.begin(),
-                                             itEnd = allNodes.end();
-       it != itEnd; ++it) {
+                                             ie = allNodes.end();
+       it != ie; ++it) {
     if (!targetNode && (*it)->getLocation() == target) {
       targetNode = (*it);
       if (sourceNode)
@@ -258,8 +258,8 @@ void LocationGraph::addNewEdge(ref<MemoryLocation> source,
 void LocationGraph::consumeSinkNode(ref<MemoryLocation> loc) {
   std::vector<LocationNode *>::iterator pos = sinks.end();
   for (std::vector<LocationNode *>::iterator it = sinks.begin(),
-                                             itEnd = sinks.end();
-       it != itEnd; ++it) {
+                                             ie = sinks.end();
+       it != ie; ++it) {
     if ((*it)->getLocation() == loc) {
       pos = it;
       break;
@@ -273,8 +273,8 @@ void LocationGraph::consumeSinkNode(ref<MemoryLocation> loc) {
   sinks.erase(pos);
 
   for (std::vector<LocationNode *>::iterator it = parents.begin(),
-                                             itEnd = parents.end();
-       it != itEnd; ++it) {
+                                             ie = parents.end();
+       it != ie; ++it) {
     if (std::find(sinks.begin(), sinks.end(), (*it)) == sinks.end())
       sinks.push_back(*it);
   }
@@ -284,8 +284,8 @@ std::set<ref<MemoryLocation> > LocationGraph::getSinkLocations() const {
   std::set<ref<MemoryLocation> > sinkLocations;
 
   for (std::vector<LocationNode *>::const_iterator it = sinks.begin(),
-                                                   itEnd = sinks.end();
-       it != itEnd; ++it) {
+                                                   ie = sinks.end();
+       it != ie; ++it) {
     sinkLocations.insert((*it)->getLocation());
   }
 
@@ -297,8 +297,8 @@ std::set<ref<MemoryLocation> > LocationGraph::getSinksWithLocations(
   std::set<ref<MemoryLocation> > sinkLocations;
 
   for (std::vector<LocationNode *>::const_iterator it = sinks.begin(),
-                                                   itEnd = sinks.end();
-       it != itEnd; ++it) {
+                                                   ie = sinks.end();
+       it != ie; ++it) {
     if (std::find(locationsList.begin(), locationsList.end(),
                   (*it)->getLocation()) != locationsList.end())
       sinkLocations.insert((*it)->getLocation());
@@ -315,8 +315,8 @@ void LocationGraph::consumeSinksWithLocations(
     return;
 
   for (std::set<ref<MemoryLocation> >::iterator it = sinkLocs.begin(),
-                                                itEnd = sinkLocs.end();
-       it != itEnd; ++it) {
+                                                ie = sinkLocs.end();
+       it != ie; ++it) {
     consumeSinkNode((*it));
   }
 
@@ -339,8 +339,8 @@ void LocationGraph::print(llvm::raw_ostream &stream,
   std::string tabs = makeTabs(tabNum);
 
   for (std::vector<LocationNode *>::iterator it = nodes.begin(),
-                                             itEnd = nodes.end();
-       it != itEnd; ++it) {
+                                             ie = nodes.end();
+       it != ie; ++it) {
     ref<MemoryLocation> loc = (*it)->getLocation();
     stream << tabs;
     loc->print(stream);
@@ -608,8 +608,8 @@ void Dependency::markFlow(VersionedValue *target) const {
   target->setAsCore();
   std::vector<VersionedValue *> stepSources = directFlowSources(target);
   for (std::vector<VersionedValue *>::iterator it = stepSources.begin(),
-                                               itEnd = stepSources.end();
-       it != itEnd; ++it) {
+                                               ie = stepSources.end();
+       it != ie; ++it) {
     markFlow(*it);
   }
 }
@@ -945,8 +945,8 @@ void Dependency::execute(llvm::Instruction *instr,
       std::set<ref<MemoryLocation> > locations = addressValue->getLocations();
 
       for (std::set<ref<MemoryLocation> >::iterator it = locations.begin(),
-                                                    itEnd = locations.end();
-           it != itEnd; ++it) {
+                                                    ie = locations.end();
+           it != ie; ++it) {
         updateStore(*it, storedValue);
       }
       break;
@@ -1123,8 +1123,8 @@ void Dependency::bindCallArguments(llvm::Instruction *i,
   unsigned index = 0;
   for (llvm::Function::ArgumentListType::iterator
            it = callee->getArgumentList().begin(),
-           itEnd = callee->getArgumentList().end();
-       it != itEnd; ++it) {
+           ie = callee->getArgumentList().end();
+       it != ie; ++it) {
     if (argumentValuesList.back()) {
       addDependency(
           argumentValuesList.back(),
@@ -1243,14 +1243,14 @@ Dependency::directLocationSources(VersionedValue *target) const {
   std::map<VersionedValue *, ref<MemoryLocation> > tmp;
   std::map<VersionedValue *, ref<MemoryLocation> >::iterator nextPos =
                                                                  ret.begin(),
-                                                             itEnd = ret.end();
+                                                             ie = ret.end();
 
   bool elementErased = true;
   while (elementErased) {
     elementErased = false;
     for (std::map<VersionedValue *, ref<MemoryLocation> >::iterator it =
              nextPos;
-         it != itEnd; ++it) {
+         it != ie; ++it) {
       if (it->second.isNull()) {
         std::map<VersionedValue *, ref<MemoryLocation> >::iterator deletionPos =
             it;
@@ -1286,8 +1286,8 @@ void Dependency::recursivelyBuildLocationGraph(
 
   for (std::map<VersionedValue *, ref<MemoryLocation> >::iterator
            it = sourceEdges.begin(),
-           itEnd = sourceEdges.end();
-       it != itEnd; ++it) {
+           ie = sourceEdges.end();
+       it != ie; ++it) {
     // Here we prevent construction of cycle in the graph by checking if the
     // source equals target or included as an ancestor.
     if (it->second != target &&
@@ -1307,8 +1307,8 @@ void Dependency::buildLocationGraph(LocationGraph *g,
 
   for (std::map<VersionedValue *, ref<MemoryLocation> >::iterator
            it = sourceEdges.begin(),
-           itEnd = sourceEdges.end();
-       it != itEnd; ++it) {
+           ie = sourceEdges.end();
+       it != ie; ++it) {
     g->addNewSink(it->second);
     recursivelyBuildLocationGraph(g, it->first, it->second,
                                   std::set<ref<MemoryLocation> >());
@@ -1331,8 +1331,8 @@ void Dependency::print(llvm::raw_ostream &stream,
   stream << tabs << "STORAGE:";
   for (std::map<ref<MemoryLocation>, VersionedValue *>::const_iterator
            it = storesMap.begin(),
-           itEnd = storesMap.end();
-       it != itEnd; ++it) {
+           ie = storesMap.end();
+       it != ie; ++it) {
     if (it != storesMapBegin)
       stream << ",";
     stream << "[";
@@ -1347,8 +1347,8 @@ void Dependency::print(llvm::raw_ostream &stream,
            VersionedValue *,
            std::map<VersionedValue *, ref<MemoryLocation> > >::const_iterator
            it = flowsToMap.begin(),
-           itEnd = flowsToMap.end();
-       it != itEnd; ++it) {
+           ie = flowsToMap.end();
+       it != ie; ++it) {
     if (it != flowsToMapBegin)
       stream << ",";
     std::map<VersionedValue *, ref<MemoryLocation> > sources = (*it).second;
@@ -1384,7 +1384,7 @@ void Dependency::Util::deletePointerMapWithVectorValue(
     std::map<K *, std::vector<T> > &map) {
   typedef typename std::map<K *, std::vector<T> >::iterator IteratorType;
 
-  for (IteratorType it = map.begin(), itEnd = map.end(); it != itEnd; ++it) {
+  for (IteratorType it = map.begin(), ie = map.end(); it != ie; ++it) {
     it->second.clear();
   }
   map.clear();
@@ -1395,7 +1395,7 @@ void Dependency::Util::deletePointerMapWithMapValue(
     std::map<K *, std::map<K *, T> > &map) {
   typedef typename std::map<K *, std::map<K *, T> >::iterator IteratorType;
 
-  for (IteratorType it = map.begin(), itEnd = map.end(); it != itEnd; ++it) {
+  for (IteratorType it = map.begin(), ie = map.end(); it != ie; ++it) {
     it->second.clear();
   }
   map.clear();

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -71,7 +71,7 @@ public:
 
 private:
     /// \brief The location's LLVM value
-    llvm::Value *loc;
+  llvm::Value *value;
 
     /// \brief The absolute address
     ref<Expr> address;
@@ -82,18 +82,18 @@ private:
     /// \brief The offset of the allocation
     ref<Expr> offset;
 
-    MemoryLocation(llvm::Value *_loc, ref<Expr> &_address, ref<Expr> &_base,
+    MemoryLocation(llvm::Value *_value, ref<Expr> &_address, ref<Expr> &_base,
                    ref<Expr> &_offset)
-        : refCount(0), loc(_loc), address(_address), base(_base),
+        : refCount(0), value(_value), address(_address), base(_base),
           offset(_offset) {}
 
   public:
     ~MemoryLocation() {}
 
-    static ref<MemoryLocation> create(llvm::Value *loc, ref<Expr> &address) {
+    static ref<MemoryLocation> create(llvm::Value *value, ref<Expr> &address) {
       ref<Expr> zeroPointer = Expr::createPointer(0);
       ref<MemoryLocation> ret(
-          new MemoryLocation(loc, address, address, zeroPointer));
+          new MemoryLocation(value, address, address, zeroPointer));
       return ret;
     }
 
@@ -116,8 +116,8 @@ private:
     }
 
     int compare(const MemoryLocation other) const {
-      uint64_t l = reinterpret_cast<uint64_t>(loc),
-               r = reinterpret_cast<uint64_t>(other.loc);
+      uint64_t l = reinterpret_cast<uint64_t>(value),
+               r = reinterpret_cast<uint64_t>(other.value);
 
       if (l == r) {
         ConstantExpr *lc = llvm::dyn_cast<ConstantExpr>(address);
@@ -151,7 +151,7 @@ private:
       return llvm::dyn_cast<ConstantExpr>(address)->getZExtValue();
     }
 
-    llvm::Value *getValue() const { return loc; }
+    llvm::Value *getValue() const { return value; }
 
     ref<Expr> getAddress() const { return address; }
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -374,17 +374,6 @@ private:
     class Util {
 
     public:
-      template <typename K, typename T>
-      static void deletePointerMap(std::map<K, T *> &map);
-
-      template <typename K, typename T>
-      static void
-      deletePointerMapWithVectorValue(std::map<K *, std::vector<T> > &map);
-
-      template <typename K, typename T>
-      static void
-      deletePointerMapWithMapValue(std::map<K *, std::map<K *, T> > &map);
-
       /// \brief Tests if a pointer points to a main function's argument
       static bool isMainArgument(llvm::Value *loc);
     };
@@ -396,8 +385,11 @@ private:
     /// \brief Argument values to be passed onto callee
     std::vector<VersionedValue *> argumentValuesList;
 
-    /// \brief The mapping of locations to stored value
-    std::map<ref<MemoryLocation>, VersionedValue *> storesMap;
+    /// \brief The mapping of concrete locations to stored value
+    std::map<ref<MemoryLocation>, VersionedValue *> concreteStoresMap;
+
+    /// \brief The mapping of symbolic locations to stored value
+    std::map<ref<MemoryLocation>, VersionedValue *> symbolicStoresMap;
 
     /// \brief Flow relations of target and its sources with location
     std::map<VersionedValue *,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -105,6 +105,8 @@ private:
 
     ref<Expr> getAddress() const { return address; }
 
+    ref<Expr> getBase() const { return base; }
+
     ref<Expr> getOffset() const { return offset; }
 
     void setAsCore() { core = true; }

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -99,6 +99,15 @@ private:
       return ret;
     }
 
+    static ref<MemoryLocation> createByOffset(ref<MemoryLocation> loc,
+                                              ref<Expr> &address,
+                                              ref<Expr> &offset) {
+      ref<MemoryLocation> ret(
+          new MemoryLocation(loc->getValue(), address, loc->getBase(),
+                             AddExpr::(loc->getOffset(), offset)));
+      return ret;
+    }
+
     bool hasAddress(llvm::Value *__loc, ref<Expr> _address) const {
       return loc == __loc && address == _address;
     }

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -10,8 +10,7 @@
 /// \file
 /// This file contains the declarations for the flow-insensitive dependency
 /// analysis to compute the memory locations upon which the unsatisfiability
-/// core
-/// depends, which is used in computing the interpolant.
+/// core depends, which is used in computing the interpolant.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -265,8 +264,8 @@ private:
 
     ~LocationGraph() {
       for (std::vector<LocationNode *>::iterator it = allNodes.begin(),
-                                                 itEnd = allNodes.end();
-           it != itEnd; ++it) {
+                                                 ie = allNodes.end();
+           it != ie; ++it) {
         delete *it;
       }
       allNodes.clear();

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -81,22 +81,17 @@ class MemoryLocation {
     /// \brief The offset of the allocation
     ref<Expr> offset;
 
+  public:
     MemoryLocation(llvm::Value *_loc, ref<Expr> &_address, ref<Expr> &_base,
                    ref<Expr> &_offset)
         : core(false), loc(_loc), address(_address), base(_base),
           offset(_offset) {}
 
-  public:
-    virtual ~MemoryLocation() {}
+    ~MemoryLocation() {}
 
-    virtual bool hasAddress(llvm::Value *__loc, ref<Expr> &_address) const {
+    bool hasAddress(llvm::Value *__loc, ref<Expr> &_address) const {
       return loc == __loc && address == _address;
     }
-
-    /// \brief Print the content of the object into a stream.
-    ///
-    /// \param The stream to print the data to.
-    virtual void print(llvm::raw_ostream& stream) const;
 
     bool hasConstantAddress() { return llvm::isa<ConstantExpr>(address.get()); }
 
@@ -121,17 +116,6 @@ class MemoryLocation {
       print(llvm::errs());
       llvm::errs() << "\n";
     }
-};
-
-/// \brief A class that represents locations that can be destructively updated
-/// (versioned)
-class VersionedLocation : public MemoryLocation {
-  public:
-    VersionedLocation(llvm::Value *_loc, ref<Expr> &_address, ref<Expr> &_base,
-                      ref<Expr> &_offset)
-        : MemoryLocation(_loc, _address, _base, _offset) {}
-
-    ~VersionedLocation() {}
 
     /// \brief Print the content of the object into a stream.
     ///

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -72,14 +72,19 @@ class MemoryLocation {
     /// \brief The location's LLVM value
     llvm::Value *loc;
 
-    /// \brief The address as provided by KLEE
+    /// \brief The absolute address
     ref<Expr> address;
+
+    /// \brief The base address
+    ref<Expr> base;
 
     /// \brief The offset of the allocation
     ref<Expr> offset;
 
-    MemoryLocation(llvm::Value *_loc, ref<Expr> &_address, ref<Expr> &_offset)
-        : core(false), loc(_loc), address(_address), offset(_offset) {}
+    MemoryLocation(llvm::Value *_loc, ref<Expr> &_address, ref<Expr> &_base,
+                   ref<Expr> &_offset)
+        : core(false), loc(_loc), address(_address), base(_base),
+          offset(_offset) {}
 
   public:
     enum Kind {
@@ -129,9 +134,9 @@ class MemoryLocation {
 /// (versioned)
 class VersionedLocation : public MemoryLocation {
   public:
-    VersionedLocation(llvm::Value *_loc, ref<Expr> &_address,
+    VersionedLocation(llvm::Value *_loc, ref<Expr> &_address, ref<Expr> &_base,
                       ref<Expr> &_offset)
-        : MemoryLocation(_loc, _address, _offset) {}
+        : MemoryLocation(_loc, _address, _base, _offset) {}
 
     ~VersionedLocation() {}
 
@@ -473,10 +478,15 @@ class VersionedLocation : public MemoryLocation {
     VersionedValue *getNewVersionedValue(llvm::Value *value,
                                          ref<Expr> valueExpr);
 
-    /// \brief Create a fresh location object.
-    MemoryLocation *getInitialLocation(llvm::Value *loc, ref<Expr> base,
-                                       ref<Expr> offset =
-                                           Expr::createPointer(0));
+    /// \brief Create a fresh location object. Here the base and offset of the
+    /// location object respectively equals to the address and zero.
+    MemoryLocation *getInitialLocation(llvm::Value *loc, ref<Expr> address);
+
+    /// \brief Create a fresh location object, with specified base and offset
+    MemoryLocation *getSpecificInitialLocation(llvm::Value *loc,
+                                               ref<Expr> address,
+                                               ref<Expr> base,
+                                               ref<Expr> offset);
 
     /// \brief Create a new location object to represent a new version of a
     /// known location.

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -100,7 +100,7 @@ private:
     static ref<MemoryLocation> create(ref<MemoryLocation> loc,
                                       ref<Expr> &address, ref<Expr> &offset) {
       ConstantExpr *c = llvm::dyn_cast<ConstantExpr>(offset);
-      if (c->getZExtValue() == 0) {
+      if (c && c->getZExtValue() == 0) {
         ref<Expr> base = loc->getBase();
         ref<Expr> offset = loc->getOffset();
         ref<MemoryLocation> ret(

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -391,7 +391,7 @@ private:
 
   private:
     /// \brief Previous path condition
-    Dependency *parentDependency;
+    Dependency *parent;
 
     /// \brief Argument values to be passed onto callee
     std::vector<VersionedValue *> argumentValuesList;
@@ -467,10 +467,6 @@ private:
                                   VersionedValue *target,
                                   ref<MemoryLocation> via);
 
-    /// \brief Retrieve the versioned values that are stored in a particular
-    /// location.
-    std::vector<VersionedValue *> stores(ref<MemoryLocation> loc) const;
-
     /// \brief All values that flows to the target in one step
     std::vector<VersionedValue *> directFlowSources(VersionedValue *target) const;
 
@@ -484,7 +480,7 @@ private:
                                std::vector<ref<Expr> > &arguments);
 
   public:
-    Dependency(Dependency *prev);
+    Dependency(Dependency *parent);
 
     ~Dependency();
 
@@ -518,8 +514,7 @@ private:
     /// part
     /// indexed by symbolic expressions.
     std::pair<ConcreteStore, SymbolicStore>
-    getStoredExpressions(std::set<const Array *> &replacements,
-                         bool coreOnly) const;
+    getStoredExpressions(std::set<const Array *> &replacements, bool coreOnly);
 
     /// \brief Record call arguments in a function call
     void bindCallArguments(llvm::Instruction *instr,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -87,13 +87,6 @@ class MemoryLocation {
           offset(_offset) {}
 
   public:
-    enum Kind {
-      Unknown,
-      Versioned
-    };
-
-    virtual Kind getKind() const { return Unknown; }
-
     virtual ~MemoryLocation() {}
 
     virtual bool hasAddress(llvm::Value *__loc, ref<Expr> &_address) const {
@@ -139,14 +132,6 @@ class VersionedLocation : public MemoryLocation {
         : MemoryLocation(_loc, _address, _base, _offset) {}
 
     ~VersionedLocation() {}
-
-    Kind getKind() const { return Versioned; }
-
-    static bool classof(const MemoryLocation *loc) {
-      return loc->getKind() == Versioned;
-    }
-
-    static bool classof(const VersionedLocation *loc) { return true; }
 
     /// \brief Print the content of the object into a stream.
     ///

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -454,11 +454,6 @@ private:
       return registerNewVersionedValue(value, vvalue);
     }
 
-    /// \brief Get all versioned locations for the current node an all of its
-    /// parents
-    std::vector<ref<MemoryLocation> > getAllVersionedLocations(bool coreOnly =
-                                                                   false) const;
-
     /// \brief Gets the latest version of the location, but without checking
     /// for whether the value is constant or not
     ref<VersionedValue> getLatestValueNoConstantCheck(llvm::Value *value);

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -69,12 +69,20 @@ class MemoryLocation {
   protected:
     bool core;
 
+    /// \brief The allocation site
     llvm::Value *site;
 
+    /// \brief The address as provided by KLEE
     ref<Expr> address;
 
+    /// \brief The offset of the allocation
+    ref<Expr> offset;
+
     MemoryLocation(llvm::Value *_site, ref<Expr> &_address)
-        : core(false), site(_site), address(_address) {}
+        : core(false), site(_site), address(_address),
+          offset(ConstantExpr::create(0, Expr::Int64)) {}
+
+    MemoryLocation(MemoryLocation *, ref<Expr> &_offset);
 
   public:
     enum Kind {
@@ -106,6 +114,8 @@ class MemoryLocation {
     llvm::Value *getSite() const { return site; }
 
     ref<Expr> getAddress() const { return address; }
+
+    ref<Expr> getOffset() const { return offset; }
 
     void setAsCore() { core = true; }
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -189,8 +189,12 @@ private:
     /// value.
     bool core;
 
+    /// \brief The id of this object
+    uint64_t id;
+
     VersionedValue(llvm::Value *value, ref<Expr> valueExpr)
-        : refCount(0), value(value), valueExpr(valueExpr), core(false) {}
+        : refCount(0), value(value), valueExpr(valueExpr), core(false),
+          id(reinterpret_cast<uint64_t>(this)) {}
 
   public:
     ~VersionedValue() { locations.clear(); }
@@ -201,12 +205,9 @@ private:
     }
 
     int compare(const VersionedValue other) const {
-      uint64_t l = reinterpret_cast<uint64_t>(this),
-               r = reinterpret_cast<uint64_t>(&other);
-
-      if (l == r)
+      if (id == other.id)
         return 0;
-      if (l < r)
+      if (id < other.id)
         return -1;
       return 1;
     }

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -70,8 +70,6 @@ public:
   unsigned refCount;
 
 private:
-    bool core;
-
     /// \brief The location's LLVM value
     llvm::Value *loc;
 
@@ -86,7 +84,7 @@ private:
 
     MemoryLocation(llvm::Value *_loc, ref<Expr> &_address, ref<Expr> &_base,
                    ref<Expr> &_offset)
-        : refCount(0), core(false), loc(_loc), address(_address), base(_base),
+        : refCount(0), loc(_loc), address(_address), base(_base),
           offset(_offset) {}
 
   public:
@@ -161,10 +159,6 @@ private:
 
     ref<Expr> getOffset() const { return offset; }
 
-    void setAsCore() { core = true; }
-
-    bool isCore() { return core; }
-
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {
       print(llvm::errs());
@@ -225,14 +219,7 @@ private:
 
     ref<Expr> getExpression() const { return valueExpr; }
 
-    void setAsCore() {
-      core = true;
-      for (std::set<ref<MemoryLocation> >::iterator it = locations.begin(),
-                                                    ie = locations.end();
-           it != ie; ++it) {
-        (*it)->setAsCore();
-      }
-    }
+    void setAsCore() { core = true; }
 
     bool isCore() const { return core; }
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -392,10 +392,10 @@ private:
     std::vector<ref<VersionedValue> > argumentValuesList;
 
     /// \brief The mapping of concrete locations to stored value
-    std::map<ref<MemoryLocation>, ref<VersionedValue> > concreteStoresMap;
+    std::map<ref<MemoryLocation>, ref<VersionedValue> > _concreteStore;
 
     /// \brief The mapping of symbolic locations to stored value
-    std::map<ref<MemoryLocation>, ref<VersionedValue> > symbolicStoresMap;
+    std::map<ref<MemoryLocation>, ref<VersionedValue> > _symbolicStore;
 
     /// \brief Flow relations of target and its sources with location
     std::map<ref<VersionedValue>,

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2253,25 +2253,24 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
   case Instruction::GetElementPtr: {
     KGEPInstruction *kgepi = static_cast<KGEPInstruction*>(ki);
     ref<Expr> base = eval(ki, 0, state).value;
-    ref<Expr> oldBase = base;
+    ref<Expr> address(base);
 
     for (std::vector< std::pair<unsigned, uint64_t> >::iterator 
            it = kgepi->indices.begin(), ie = kgepi->indices.end(); 
          it != ie; ++it) {
       uint64_t elementSize = it->second;
       ref<Expr> index = eval(ki, it->first, state).value;
-      base = AddExpr::create(base,
-                             MulExpr::create(Expr::createSExtToPointerWidth(index),
-                                             Expr::createPointer(elementSize)));
+      address = AddExpr::create(
+          address, MulExpr::create(Expr::createSExtToPointerWidth(index),
+                                   Expr::createPointer(elementSize)));
     }
     if (kgepi->offset)
-      base = AddExpr::create(base,
-                             Expr::createPointer(kgepi->offset));
-    bindLocal(ki, state, base);
+      address = AddExpr::create(address, Expr::createPointer(kgepi->offset));
+    bindLocal(ki, state, address);
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->execute(i, base, oldBase);
+      interpTree->execute(i, address, base);
     break;
   }
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3028,14 +3028,13 @@ void Executor::run(ExecutionState &initialState) {
 
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
-
-      //      llvm::errs() << "\nCurrent state:\n";
-      //      processTree->dump();
-      //      interpTree->dump();
-      //      state.itreeNode->dump();
-      //      llvm::errs() << "------------------- Executing New Instruction "
-      //                      "-----------------------\n";
-      //      state.pc->inst->dump();
+      // llvm::errs() << "\nCurrent state:\n";
+      // processTree->dump();
+      // interpTree->dump();
+      // state.itreeNode->dump();
+      // llvm::errs() << "------------------- Executing New Instruction "
+      //                 "-----------------------\n";
+      // state.pc->inst->dump();
     }
 
     if (INTERPOLATION_ENABLED &&

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1849,8 +1849,6 @@ ITree::~ITree() {
 
 bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
                              double timeout) {
-  ++subsumptionCheckCount; // For profiling
-
   assert(state.itreeNode == currentINode);
 
   // Immediately return if the state's instruction is not the
@@ -1861,6 +1859,8 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
   if (!state.itreeNode || reinterpret_cast<uintptr_t>(state.pc->inst) !=
                               state.itreeNode->getNodeId())
     return false;
+
+  ++subsumptionCheckCount; // For profiling
 
   TimerStatIncrementer t(subsumptionCheckTime);
   std::deque<SubsumptionTableEntry *> entryList =

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1672,7 +1672,7 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream) const {
   stream << "\n";
 
   if (!concreteAddressStore.empty()) {
-    stream << "allocations = [";
+    stream << "concrete store = [";
     for (Dependency::ConcreteStore::const_iterator
              it1Begin = concreteAddressStore.begin(),
              it1End = concreteAddressStore.end(), it1 = it1Begin;
@@ -1687,6 +1687,28 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream) const {
         it2->second.first->print(stream);
         stream << ",";
         it2->second.second->print(stream);
+        stream << ")";
+      }
+    }
+    stream << "]\n";
+  }
+
+  if (!symbolicAddressStore.empty()) {
+    stream << "symbolic store = [";
+    for (Dependency::SymbolicStore::const_iterator
+             it1Begin = symbolicAddressStore.begin(),
+             it1End = symbolicAddressStore.end(), it1 = it1Begin;
+         it1 != it1End; ++it1) {
+      for (Dependency::SymbolicStoreMap::const_iterator
+               it2Begin = it1->second.begin(),
+               it2End = it1->second.end(), it2 = it2Begin;
+           it2 != it2End; ++it2) {
+        if (it1 != it1Begin || it2 != it2Begin)
+          stream << ",";
+        stream << "(";
+        it2->first->print(stream);
+        stream << ",";
+        it2->second->print(stream);
         stream << ")";
       }
     }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -501,10 +501,10 @@ std::string SearchTree::PrettyExpressionBuilder::constructActual(ref<Expr> e) {
     std::string existentials;
 
     for (std::set<const Array *>::iterator it = xe->variables.begin(),
-                                           itEnd = xe->variables.end();
-         it != itEnd; ++it) {
+                                           ie = xe->variables.end();
+         it != ie; ++it) {
       existentials += (*it)->name;
-      if (it != itEnd)
+      if (it != ie)
         existentials += ",";
     }
 
@@ -586,8 +586,8 @@ std::string SearchTree::recurseRender(const SearchTree::Node *node) {
          << replacementName << "\\l";
   for (std::map<PathCondition *, std::pair<std::string, bool> >::const_iterator
            it = node->pathConditionTable.begin(),
-           itEnd = node->pathConditionTable.end();
-       it != itEnd; ++it) {
+           ie = node->pathConditionTable.end();
+       it != ie; ++it) {
     stream << it->second.first;
     if (it->second.second)
       stream << " ITP";
@@ -627,8 +627,8 @@ std::string SearchTree::render() {
   std::ostringstream stream;
   for (std::vector<SearchTree::NumberedEdge *>::iterator
            it = subsumptionEdges.begin(),
-           itEnd = subsumptionEdges.end();
-       it != itEnd; ++it) {
+           ie = subsumptionEdges.end();
+       it != ie; ++it) {
     stream << (*it)->render() << "\n";
   }
 
@@ -652,8 +652,8 @@ SearchTree::~SearchTree() {
 
   for (std::vector<SearchTree::NumberedEdge *>::iterator
            it = subsumptionEdges.begin(),
-           itEnd = subsumptionEdges.end();
-       it != itEnd; ++it) {
+           ie = subsumptionEdges.end();
+       it != ie; ++it) {
     delete *it;
   }
   subsumptionEdges.clear();
@@ -852,15 +852,15 @@ SubsumptionTableEntry::SubsumptionTableEntry(ITreeNode *node)
 
   concreteAddressStore = storedExpressions.first;
   for (Dependency::ConcreteStore::iterator it = concreteAddressStore.begin(),
-                                           itEnd = concreteAddressStore.end();
-       it != itEnd; ++it) {
+                                           ie = concreteAddressStore.end();
+       it != ie; ++it) {
     concreteAddressStoreKeys.push_back(it->first);
   }
 
   symbolicAddressStore = storedExpressions.second;
   for (Dependency::SymbolicStore::iterator it = symbolicAddressStore.begin(),
-                                           itEnd = symbolicAddressStore.end();
-       it != itEnd; ++it) {
+                                           ie = symbolicAddressStore.end();
+       it != ie; ++it) {
     symbolicAddressStoreKeys.push_back(it->first);
   }
 
@@ -877,8 +877,8 @@ SubsumptionTableEntry::hasVariableInSet(std::set<const Array *> &existentials,
       ReadExpr *readExpr = llvm::dyn_cast<ReadExpr>(expr.get());
       const Array *array = (readExpr->updates).root;
       for (std::set<const Array *>::iterator it = existentials.begin(),
-                                             itEnd = existentials.end();
-           it != itEnd; ++it) {
+                                             ie = existentials.end();
+           it != ie; ++it) {
         if ((*it) == array)
           return true;
       }
@@ -895,8 +895,8 @@ bool SubsumptionTableEntry::hasVariableNotInSet(
       ReadExpr *readExpr = llvm::dyn_cast<ReadExpr>(expr.get());
       const Array *array = (readExpr->updates).root;
       for (std::set<const Array *>::iterator it = existentials.begin(),
-                                             itEnd = existentials.end();
-           it != itEnd; ++it) {
+                                             ie = existentials.end();
+           it != ie; ++it) {
         if ((*it) == array)
           return false;
       }
@@ -981,8 +981,8 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
   ref<Expr> newInterpolant;
 
   for (std::vector<ref<Expr> >::iterator it = interpolantPack.begin(),
-                                         itEnd = interpolantPack.end();
-       it != itEnd; ++it) {
+                                         ie = interpolantPack.end();
+       it != ie; ++it) {
 
     ref<Expr> interpolantAtom = (*it); // For example C cmp D
 
@@ -1695,11 +1695,11 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream) const {
 
   if (!existentials.empty()) {
     stream << "existentials = [";
-    for (std::set<const Array *>::const_iterator itBegin = existentials.begin(),
-                                                 itEnd = existentials.end(),
-                                                 it = itBegin;
-         it != itEnd; ++it) {
-      if (it != itBegin)
+    for (std::set<const Array *>::const_iterator is = existentials.begin(),
+                                                 ie = existentials.end(),
+                                                 it = is;
+         it != ie; ++it) {
+      if (it != is)
         stream << ", ";
       stream << (*it)->name;
     }
@@ -1801,8 +1801,8 @@ ITree::ITree(ExecutionState *_root) {
 ITree::~ITree() {
   for (std::map<uintptr_t, std::deque<SubsumptionTableEntry *> >::const_iterator
            it = subsumptionTable.begin(),
-           itEnd = subsumptionTable.end();
-       it != itEnd; ++it) {
+           ie = subsumptionTable.end();
+       it != ie; ++it) {
     if (!it->second.empty()) {
       entryNumber += it->second.size();
       ++programPointNumber;
@@ -1811,8 +1811,8 @@ ITree::~ITree() {
 
   for (std::map<uintptr_t, std::deque<SubsumptionTableEntry *> >::iterator
            it = subsumptionTable.begin(),
-           itEnd = subsumptionTable.end();
-       it != itEnd; ++it) {
+           ie = subsumptionTable.end();
+       it != ie; ++it) {
     for (std::deque<SubsumptionTableEntry *>::iterator
              it1 = it->second.begin(),
              it1End = it->second.end();
@@ -1854,8 +1854,8 @@ bool ITree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
   // the successful subsumption mostly happen in the newest entry.
   for (std::deque<SubsumptionTableEntry *>::reverse_iterator
            it = entryList.rbegin(),
-           itEnd = entryList.rend();
-       it != itEnd; ++it) {
+           ie = entryList.rend();
+       it != ie; ++it) {
 
     if ((*it)->subsumed(solver, state, timeout, storedExpressions)) {
       // We mark as subsumed such that the node will not be
@@ -1941,8 +1941,8 @@ void ITree::markPathCondition(ExecutionState &state, TimingSolver *solver) {
 
   if (pc != 0) {
     for (std::vector<ref<Expr> >::iterator it = unsatCore.begin(),
-                                           itEnd = unsatCore.end();
-         it != itEnd; ++it) {
+                                           ie = unsatCore.end();
+         it != ie; ++it) {
       for (; pc != 0; pc = pc->cdr()) {
         if (pc->car().compare(it->get()) == 0) {
           pc->setAsCore(g);
@@ -2043,8 +2043,8 @@ void ITree::print(llvm::raw_ostream &stream) const {
             "-------------------------\n";
   for (std::map<uintptr_t, std::deque<SubsumptionTableEntry *> >::const_iterator
            it = subsumptionTable.begin(),
-           itEnd = subsumptionTable.end();
-       it != itEnd; ++it) {
+           ie = subsumptionTable.end();
+       it != ie; ++it) {
     for (std::deque<SubsumptionTableEntry *>::const_iterator
              it1 = it->second.begin(),
              it1End = it->second.end();
@@ -2112,10 +2112,10 @@ ITreeNode::ITreeNode(ITreeNode *_parent)
 ITreeNode::~ITreeNode() {
   // Only delete the path condition if it's not
   // also the parent's path condition
-  PathCondition *itEnd = parent ? parent->pathCondition : 0;
+  PathCondition *ie = parent ? parent->pathCondition : 0;
 
   PathCondition *it = pathCondition;
-  while (it != itEnd) {
+  while (it != ie) {
     PathCondition *tmp = it;
     it = it->cdr();
     delete tmp;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -410,7 +410,7 @@ class SubsumptionTableEntry {
                                    std::map<ref<Expr>, ref<Expr> > &map);
 
   bool empty() {
-    return !interpolant.get() && concreteAddressStoreKeys.empty();
+    return interpolant.isNull() && concreteAddressStoreKeys.empty();
   }
 
   /// \brief For printing method running time statistics
@@ -436,7 +436,7 @@ public:
   /// \return true if the parameter is either a concatenation or a read,
   ///         otherwise, return false.
   static bool isVariable(ref<Expr> expr) {
-    return llvm::isa<ConcatExpr>(expr.get()) || llvm::isa<ReadExpr>(expr.get());
+    return llvm::isa<ConcatExpr>(expr) || llvm::isa<ReadExpr>(expr);
   }
 
   ref<Expr> getInterpolant() const;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -288,7 +288,7 @@ public:
 
   PathCondition *cdr() const;
 
-  void setAsCore(LocationGraph *g);
+  void setAsCore();
 
   bool isCore() const;
 
@@ -468,7 +468,6 @@ class ITreeNode {
   static Statistic bindReturnValueTime;
   static Statistic getStoredExpressionsTime;
   static Statistic getStoredCoreExpressionsTime;
-  static Statistic computeCoreLocationsTime;
 
 private:
   /// \brief The path condition
@@ -568,9 +567,6 @@ public:
   /// \brief Marking the core constraints on the path condition, and all the
   /// relevant values on the dependency graph, given an unsatistiability core.
   void unsatCoreMarking(std::vector<ref<Expr> > unsatCore);
-
-  /// \brief Compute the allocations that are relevant for the interpolant.
-  void computeCoreLocations(LocationGraph *g);
 
   /// \brief Print the content of the tree node object to the LLVM error stream.
   void dump() const;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -269,7 +269,7 @@ class PathCondition {
   Dependency *dependency;
 
   /// \brief the condition value from which the constraint was generated
-  VersionedValue *condition;
+  ref<VersionedValue> condition;
 
   /// \brief When true, indicates that the constraint should be included in the
   /// interpolant


### PR DESCRIPTION
This PR resolves issue #103 and #85. Now:
1. There are no longer backward searches for memory allocation in for memory access (load/store). 
2. There is no longer backward computation to build memory dependency graph.

Both of the above are results of propagating memory allocation together with pointer value, keeping extra information in case the (LLVM) value is treated as a pointer.

Although the subsumption profile differs for basic examples in tracer-x/klee-examples, the new subsumption profile results in all expected errors reported, with `bubble.c` and `Regexp.c` still demonstrate significant search-space reduction.