### PR TITLE
Additional comment for `Dependency`

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -240,6 +240,7 @@ void VersionedValue::printNoDependency(llvm::raw_ostream &stream) const {
   valueExpr->print(stream);
   stream << "]#" << reinterpret_cast<uintptr_t>(this);
 }
+
 /**/
 
 void StoredValue::init(ref<VersionedValue> vvalue,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -496,6 +496,24 @@ namespace klee {
   /// with modified offsets according to the offset argument of the
   /// instruction.
   ///
+  /// <b>Notes on why stacks are not used</b>
+  ///
+  /// Here we are not using stacks to implement the shadow memory
+  /// for dependency information. The reason is that when a function
+  /// is called and then it returned, its local allocations can not
+  /// normally be removed from consideration as the function may
+  /// contain unexplored branches. So therefore, it is in principle the
+  /// case that subsequently allocated memory regions are disjoint from
+  /// whatever local memories that have ever been allocated throughout
+  /// the execution anyway. This, however, conflicts with the notion
+  /// of the latest value of a variable, where there is a potential
+  /// for confusion where, given a recursive function, the latest
+  /// value of a local variable is considered to be the one allocated
+  /// in its recursive call that has been exited (because the local
+  /// variable in the recursive call is allocated lated). But for this,
+  /// we add another check to ensure that the stored value match
+  /// (in Dependency#getLatestValue).
+  ///
   /// \see ITree
   /// \see ITreeNode
   /// \see VersionedValue

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -299,6 +299,31 @@ public:
 };
 
 /// \brief The class that implements an entry (record) in the subsumption table.
+///
+/// The subsumption table records the generalization of state such that
+/// starting from this generalization, all symbolic execution will reach
+/// the same conclusion (falsity of branch or successful memory bounds check).
+/// Such generalization is a form of Craig interpolation. It is used to
+/// subsume other symbolic execution paths encountered later, as any
+/// extension of a subsumed path would only reach infeasibility or
+/// the same conclusion that has already been seen.
+///
+/// This class implements an entry in the subsumption table. It is
+/// instantiated when the a traversal of a symbolic execution subtree has
+/// finished in the ITree#remove method. This class basically stores a
+/// subset of the path condition (the SubsumptionTableEntry#interpolant
+/// field), plus the fragment of memory (allocations). They are components
+/// that are needed to ensure the previously-seen conclusions. The memory
+/// fragments are stored in either SubsumptionTableEntry#concreteAddressStore
+/// or SubsumptionTableEntry#symbolicAddressStore, depending on whether
+/// the memory fragment is concretely addressed or symbolically addressed.
+/// Both fields are multi-level maps that are first indexed by the LLVM
+/// value that represents the allocation (e.g., the call to <b>malloc</b>,
+/// the <b>alloca</b> instruction, etc.).
+///
+/// \see ITree
+/// \see ITreeNode
+/// \see Dependency
 class SubsumptionTableEntry {
   friend class ITree;
 
@@ -475,6 +500,7 @@ public:
 ///
 /// \see ITree
 /// \see Dependency
+/// \see SubsumptionTableEntry
 /// \see PathCondition
 class ITreeNode {
   friend class ITree;


### PR DESCRIPTION
Added comment to explain why stack in the dependency shadow memory is not used. Also added comment for `SubsumptionTableEntry`.