### PR TITLE
Various Fixes for Stability

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1384,8 +1384,16 @@ void Dependency::execute(llvm::Instruction *instr,
 
       if (!op1.isNull() || !op2.isNull()) {
         newValue = getNewVersionedValue(instr, result);
-        addDependency(op1, newValue);
-        addDependency(op2, newValue);
+        if (instr->getOpcode() == llvm::Instruction::ICmp ||
+            instr->getOpcode() == llvm::Instruction::FCmp) {
+          // addDependencyViaExternalFunction cuts off
+          // dependency to pointer arguments
+          addDependencyViaExternalFunction(op1, newValue);
+          addDependencyViaExternalFunction(op2, newValue);
+        } else {
+          addDependency(op1, newValue);
+          addDependency(op2, newValue);
+        }
       }
       break;
     }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -770,9 +770,9 @@ void Dependency::addDependencyWithOffset(ref<VersionedValue> source,
     return;
 
   std::set<ref<MemoryLocation> > locations = source->getLocations();
-  ref<Expr> expr(target->getExpression());
+  ref<Expr> targetExpr(target->getExpression());
 
-  ConstantExpr *ce = llvm::dyn_cast<ConstantExpr>(expr);
+  ConstantExpr *ce = llvm::dyn_cast<ConstantExpr>(targetExpr);
   uint64_t a = ce ? ce->getZExtValue() : 0;
 
   ConstantExpr *oe = llvm::dyn_cast<ConstantExpr>(offset);
@@ -797,7 +797,7 @@ void Dependency::addDependencyWithOffset(ref<VersionedValue> source,
       if (o != (a - b) && (locationAdded || i < nLocations))
         continue;
     }
-    target->addLocation(MemoryLocation::create(*it, expr, offset));
+    target->addLocation(MemoryLocation::create(*it, targetExpr, offset));
     locationAdded = true;
   }
   target->addDependency(source, nullLocation);

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -748,11 +748,12 @@ void Dependency::addDependencyIntToPtr(ref<VersionedValue> source,
     return;
 
   std::set<ref<MemoryLocation> > locations = source->getLocations();
+  ref<Expr> targetExpr(target->getExpression());
+
   for (std::set<ref<MemoryLocation> >::iterator it = locations.begin(),
                                                 ie = locations.end();
        it != ie; ++it) {
     ref<Expr> sourceBase((*it)->getBase());
-    ref<Expr> targetExpr(target->getExpression());
     ref<Expr> offsetDelta(SubExpr::create(
         SubExpr::create(targetExpr, sourceBase), (*it)->getOffset()));
     target->addLocation(MemoryLocation::create(*it, targetExpr, offsetDelta));

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -301,7 +301,10 @@ namespace klee {
       return 1;
     }
 
-    void addLocation(ref<MemoryLocation> loc) { locations.insert(loc); }
+    void addLocation(ref<MemoryLocation> loc) {
+      assert(locations.empty());
+      locations.insert(loc);
+    }
 
     std::set<ref<MemoryLocation> > getLocations() { return locations; }
 
@@ -644,6 +647,16 @@ namespace klee {
     void addDependencyViaLocation(ref<VersionedValue> source,
                                   ref<VersionedValue> target,
                                   ref<MemoryLocation> via);
+
+    /// \brief Add a flow dependency from a pointer value to a non-pointer
+    /// value,
+    /// typically for an external function call.
+    ///
+    /// Here the target is not a pointer, and we assume that the source is
+    /// is checked for memory access validity at the current index, meaning that
+    /// we assumed all memory access within the external function is valid.
+    void addDependencyViaExternalFunction(ref<VersionedValue> source,
+                                          ref<VersionedValue> target);
 
     /// \brief All values that flows to the target in one step
     std::vector<ref<VersionedValue> >

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -157,8 +157,9 @@ namespace klee {
     }
 
     static ref<MemoryLocation> create(ref<MemoryLocation> loc,
-                                      ref<Expr> &address, ref<Expr> &offset) {
-      ConstantExpr *c = llvm::dyn_cast<ConstantExpr>(offset);
+                                      ref<Expr> &address,
+                                      ref<Expr> &offsetDelta) {
+      ConstantExpr *c = llvm::dyn_cast<ConstantExpr>(offsetDelta);
       if (c && c->getZExtValue() == 0) {
         ref<Expr> base = loc->base;
         ref<Expr> offset = loc->offset;
@@ -168,7 +169,7 @@ namespace klee {
       }
 
       ref<Expr> base = loc->base;
-      ref<Expr> newOffset = AddExpr::create(loc->offset, offset);
+      ref<Expr> newOffset = AddExpr::create(loc->offset, offsetDelta);
       ref<MemoryLocation> ret(
           new MemoryLocation(loc->value, address, base, newOffset, loc->size));
       return ret;
@@ -640,7 +641,8 @@ namespace klee {
     /// \brief Add flow dependency between source and target pointers, offset by
     /// some amount
     void addDependencyWithOffset(ref<VersionedValue> source,
-                                 ref<VersionedValue> target, ref<Expr> offset);
+                                 ref<VersionedValue> target,
+                                 ref<Expr> offsetDelta);
 
     /// \brief Add flow dependency between source and target value, as the
     /// result of store/load via a memory location.

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -302,7 +302,6 @@ namespace klee {
     }
 
     void addLocation(ref<MemoryLocation> loc) {
-      assert(locations.empty());
       locations.insert(loc);
     }
 
@@ -631,7 +630,8 @@ namespace klee {
     void updateStore(ref<MemoryLocation> loc, ref<VersionedValue> value);
 
     /// \brief Add flow dependency between source and target value
-    void addDependency(ref<VersionedValue> source, ref<VersionedValue> target);
+    void addDependency(ref<VersionedValue> source, ref<VersionedValue> target,
+                       bool multiLocationsCheck = true);
 
     /// \brief Add flow dependency between source and target value
     void addDependencyIntToPtr(ref<VersionedValue> source,
@@ -649,14 +649,18 @@ namespace klee {
                                   ref<MemoryLocation> via);
 
     /// \brief Add a flow dependency from a pointer value to a non-pointer
-    /// value,
-    /// typically for an external function call.
+    /// value, for an external function call.
     ///
     /// Here the target is not a pointer, and we assume that the source is
     /// is checked for memory access validity at the current index, meaning that
     /// we assumed all memory access within the external function is valid.
     void addDependencyViaExternalFunction(ref<VersionedValue> source,
                                           ref<VersionedValue> target);
+
+    /// \brief Add a flow dependency from a pointer value to a non-pointer
+    /// value.
+    void addDependencyToNonPointer(ref<VersionedValue> source,
+                                   ref<VersionedValue> target);
 
     /// \brief All values that flows to the target in one step
     std::vector<ref<VersionedValue> >


### PR DESCRIPTION
The fixes are intended for eliminating assertion failures in the memory bounds interpolation.