### PR TITLE
Corrected pointer dependencies for binary operations

### DIFF
--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -303,10 +303,11 @@ namespace klee {
     }
 
     void addLocation(ref<MemoryLocation> loc) {
-      locations.insert(loc);
+      if (locations.find(loc) == locations.end())
+        locations.insert(loc);
     }
 
-    std::set<ref<MemoryLocation> > getLocations() { return locations; }
+    std::set<ref<MemoryLocation> > getLocations() const { return locations; }
 
     bool hasValue(llvm::Value *value) const { return this->value == value; }
 


### PR DESCRIPTION
This is for when both arguments are pointer arguments.