### PR TITLE
Fix to memory bound interpolation in subsumption checking

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -579,7 +579,7 @@ Dependency::getStoredExpressions(std::set<const Array *> &replacements,
 ref<VersionedValue> Dependency::getLatestValue(llvm::Value *value,
                                                ref<Expr> valueExpr,
                                                bool constraint) {
-  assert(value && "value cannot be null");
+  assert(value && !valueExpr.isNull() && "value cannot be null");
   if (llvm::isa<llvm::ConstantExpr>(value)) {
     llvm::Instruction *asInstruction =
         llvm::dyn_cast<llvm::ConstantExpr>(value)->getAsInstruction();
@@ -630,7 +630,6 @@ ref<VersionedValue> Dependency::getLatestValue(llvm::Value *value,
   if (llvm::isa<llvm::Constant>(value) && !llvm::isa<llvm::GlobalValue>(value))
     return getNewVersionedValue(value, valueExpr);
 
-  ref<VersionedValue> ret = 0;
   if (valuesMap.find(value) != valuesMap.end()) {
     // Slight complication here that the latest version of an LLVM
     // value may not be at the end of the vector; it is possible other
@@ -656,6 +655,7 @@ ref<VersionedValue> Dependency::getLatestValue(llvm::Value *value,
     }
   }
 
+  ref<VersionedValue> ret = 0;
   if (parent)
     ret = parent->getLatestValue(value, valueExpr, constraint);
 
@@ -689,25 +689,41 @@ ref<VersionedValue> Dependency::getLatestValue(llvm::Value *value,
 }
 
 ref<VersionedValue>
-Dependency::getLatestValueNoConstantCheck(llvm::Value *value) {
+Dependency::getLatestValueNoConstantCheck(llvm::Value *value,
+                                          ref<Expr> valueExpr) {
   assert(value && "value cannot be null");
 
   if (valuesMap.find(value) != valuesMap.end()) {
-    // We assume this method is only used for marking constraints, so here we do
-    // not check for the equivalence of the expressions as in getLatestValue
-    // method. We assume that in condition, we have the latest value
-    // of the condition at the end of the vector.
-    return valuesMap[value].back();
+    if (!valueExpr.isNull()) {
+      // Slight complication here that the latest version of an LLVM
+      // value may not be at the end of the vector; it is possible other
+      // values in a call stack has been appended to the vector, before
+      // the function returned, so the end part of the vector contains
+      // local values in a call already returned. To resolve this issue,
+      // here we naively search for values with equivalent expression.
+      std::vector<ref<VersionedValue> > allValues = valuesMap[value];
+
+      for (std::vector<ref<VersionedValue> >::iterator it = allValues.begin(),
+                                                       ie = allValues.end();
+           it != ie; ++it) {
+        ref<Expr> e = (*it)->getExpression();
+        if (e == valueExpr)
+          return *it;
+      }
+    } else {
+      return valuesMap[value].back();
+    }
   }
 
   if (parent)
-    return parent->getLatestValueNoConstantCheck(value);
+    return parent->getLatestValueNoConstantCheck(value, valueExpr);
 
   return 0;
 }
 
-ref<VersionedValue> Dependency::getLatestValueForMarking(llvm::Value *val) {
-  ref<VersionedValue> value = getLatestValueNoConstantCheck(val);
+ref<VersionedValue> Dependency::getLatestValueForMarking(llvm::Value *val,
+                                                         ref<Expr> expr) {
+  ref<VersionedValue> value = getLatestValueNoConstantCheck(val, expr);
 
   // Right now we simply ignore the __dso_handle values. They are due
   // to library / linking errors caused by missing options (-shared) in the
@@ -899,6 +915,7 @@ void Dependency::markFlow(ref<VersionedValue> target) const {
 void Dependency::markPointerFlow(ref<VersionedValue> target,
                                  ref<VersionedValue> checkedAddress,
                                  std::set<ref<Expr> > &bounds) const {
+  //  checkedAddress->dump();
   std::set<ref<MemoryLocation> > locations = target->getLocations();
   for (std::set<ref<MemoryLocation> >::iterator it = locations.begin(),
                                                 ie = locations.end();
@@ -1120,7 +1137,8 @@ void Dependency::execute(llvm::Instruction *instr,
     case llvm::Instruction::Br: {
       llvm::BranchInst *binst = llvm::dyn_cast<llvm::BranchInst>(instr);
       if (binst && binst->isConditional()) {
-        markAllValues(binst->getCondition());
+        ref<Expr> unknownExpression;
+        markAllValues(binst->getCondition(), unknownExpression);
       }
       break;
     }
@@ -1504,6 +1522,7 @@ void Dependency::executeMemoryOperation(llvm::Instruction *instr,
     // operation, but we ignored it here as this method is only called when load
     // / store instruction is processed.
     llvm::Value *addressOperand;
+    ref<Expr> address(args.at(1));
     switch (instr->getOpcode()) {
     case llvm::Instruction::Load: {
       addressOperand = instr->getOperand(0);
@@ -1538,9 +1557,9 @@ void Dependency::executeMemoryOperation(llvm::Instruction *instr,
     }
 
     if (ExactAddressInterpolant) {
-      markAllValues(addressOperand);
+      markAllValues(addressOperand, address);
     } else {
-      markAllPointerValues(addressOperand);
+      markAllPointerValues(addressOperand, address);
     }
   }
 #endif
@@ -1592,8 +1611,8 @@ void Dependency::bindReturnValue(llvm::CallInst *site, llvm::Instruction *i,
 
 void Dependency::markAllValues(ref<VersionedValue> value) { markFlow(value); }
 
-void Dependency::markAllValues(llvm::Value *val) {
-  ref<VersionedValue> value = getLatestValueForMarking(val);
+void Dependency::markAllValues(llvm::Value *val, ref<Expr> expr) {
+  ref<VersionedValue> value = getLatestValueForMarking(val, expr);
 
   if (value.isNull())
     return;
@@ -1601,9 +1620,9 @@ void Dependency::markAllValues(llvm::Value *val) {
   markFlow(value);
 }
 
-void Dependency::markAllPointerValues(llvm::Value *val,
+void Dependency::markAllPointerValues(llvm::Value *val, ref<Expr> address,
                                       std::set<ref<Expr> > &bounds) {
-  ref<VersionedValue> value = getLatestValueForMarking(val);
+  ref<VersionedValue> value = getLatestValueForMarking(val, address);
 
   if (value.isNull())
     return;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -625,10 +625,12 @@ namespace klee {
 
     /// \brief Gets the latest version of the location, but without checking
     /// for whether the value is constant or not.
-    ref<VersionedValue> getLatestValueNoConstantCheck(llvm::Value *value);
+    ref<VersionedValue> getLatestValueNoConstantCheck(llvm::Value *value,
+                                                      ref<Expr> expr);
 
     /// \brief Gets the latest pointer value for marking
-    ref<VersionedValue> getLatestValueForMarking(llvm::Value *val);
+    ref<VersionedValue> getLatestValueForMarking(llvm::Value *val,
+                                                 ref<Expr> expr);
 
     /// \brief Newly relate an location with its stored value
     void updateStore(ref<MemoryLocation> loc, ref<VersionedValue> value);
@@ -748,18 +750,19 @@ namespace klee {
 
     /// \brief Given an LLVM value, retrieve all its sources and mark them as in
     /// the core.
-    void markAllValues(llvm::Value *value);
+    void markAllValues(llvm::Value *value, ref<Expr> expr);
 
     /// \brief Given an LLVM value which is used as an address, retrieve all its
     /// sources and mark them as in the core.
-    void markAllPointerValues(llvm::Value *val) {
+    void markAllPointerValues(llvm::Value *val, ref<Expr> address) {
       std::set<ref<Expr> > bounds;
-      markAllPointerValues(val, bounds);
+      markAllPointerValues(val, address, bounds);
     }
 
     /// \brief Given an LLVM value which is used as an address, retrieve all its
     /// sources and mark them as in the core.
-    void markAllPointerValues(llvm::Value *value, std::set<ref<Expr> > &bounds);
+    void markAllPointerValues(llvm::Value *val, ref<Expr> address,
+                              std::set<ref<Expr> > &bounds);
 
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -206,7 +206,8 @@ namespace klee {
     }
 
     /// \brief Adjust the offset bound for interpolation (a.k.a. slackening)
-    void adjustOffsetBound(ref<VersionedValue> checkedAddress);
+    void adjustOffsetBound(ref<VersionedValue> checkedAddress,
+                           std::set<ref<Expr> > &bounds);
 
     bool hasConstantAddress() const { return llvm::isa<ConstantExpr>(address); }
 
@@ -395,7 +396,8 @@ namespace klee {
 
     bool isPointer() const { return !allocationBounds.empty(); }
 
-    ref<Expr> getBoundsCheck(ref<StoredValue> svalue) const;
+    ref<Expr> getBoundsCheck(ref<StoredValue> svalue,
+                             std::set<ref<Expr> > &bounds) const;
 
     ref<Expr> getExpression() const { return expr; }
 
@@ -677,7 +679,17 @@ namespace klee {
     /// and adjust its offset bound for memory bounds interpolation (a.k.a.
     /// slackening)
     void markPointerFlow(ref<VersionedValue> target,
-                         ref<VersionedValue> checkedOffset) const;
+                         ref<VersionedValue> checkedOffset) const {
+      std::set<ref<Expr> > bounds;
+      markPointerFlow(target, checkedOffset, bounds);
+    }
+
+    /// \brief Mark as core all the pointer values and that flows to the target;
+    /// and adjust its offset bound for memory bounds interpolation (a.k.a.
+    /// slackening)
+    void markPointerFlow(ref<VersionedValue> target,
+                         ref<VersionedValue> checkedOffset,
+                         std::set<ref<Expr> > &bounds) const;
 
     /// \brief Record the expressions of a call's arguments
     std::vector<ref<VersionedValue> >
@@ -740,7 +752,14 @@ namespace klee {
 
     /// \brief Given an LLVM value which is used as an address, retrieve all its
     /// sources and mark them as in the core.
-    void markAllPointerValues(llvm::Value *value);
+    void markAllPointerValues(llvm::Value *val) {
+      std::set<ref<Expr> > bounds;
+      markAllPointerValues(val, bounds);
+    }
+
+    /// \brief Given an LLVM value which is used as an address, retrieve all its
+    /// sources and mark them as in the core.
+    void markAllPointerValues(llvm::Value *value, std::set<ref<Expr> > &bounds);
 
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1439,7 +1439,10 @@ bool SubsumptionTableEntry::subsumed(
 
   ref<Expr> stateEqualityConstraints;
 
-  std::set<llvm::Value *> corePointerValues; // Pointer values in the core for
+  std::map<llvm::Value *, std::set<ref<Expr> > > corePointerValues; // Pointer
+                                                                    // values in
+                                                                    // the core
+                                                                    // for
                                              // memory bounds interpolation
 
   {
@@ -1503,7 +1506,9 @@ bool SubsumptionTableEntry::subsumed(
             return false;
           } else if (!NoBoundInterpolation && !ExactAddressInterpolant &&
                      tabledValue->isPointer() && stateValue->isPointer()) {
-            ref<Expr> boundsCheck = tabledValue->getBoundsCheck(stateValue);
+            std::set<ref<Expr> > bounds;
+            ref<Expr> boundsCheck =
+                tabledValue->getBoundsCheck(stateValue, bounds);
             if (boundsCheck->isFalse()) {
               if (DebugInterpolation == ITP_DEBUG_ALL ||
                   DebugInterpolation == ITP_DEBUG_SUBSUMPTION) {
@@ -1516,7 +1521,7 @@ bool SubsumptionTableEntry::subsumed(
               res = boundsCheck;
 
             // We record the LLVM value of the pointer
-            corePointerValues.insert(stateValue->getValue());
+            corePointerValues[stateValue->getValue()] = bounds;
           } else {
             res = EqExpr::create(tabledValue->getExpression(),
                                  stateValue->getExpression());
@@ -1547,8 +1552,9 @@ bool SubsumptionTableEntry::subsumed(
             } else if (!NoBoundInterpolation && !ExactAddressInterpolant &&
                        tabledValue->isPointer() &&
                        stateSymbolicValue->isPointer()) {
+              std::set<ref<Expr> > bounds;
               ref<Expr> boundsCheck =
-                  tabledValue->getBoundsCheck(stateSymbolicValue);
+                  tabledValue->getBoundsCheck(stateSymbolicValue, bounds);
 
               if (!boundsCheck->isTrue()) {
                 newTerm = EqExpr::create(ConstantExpr::create(0, Expr::Bool),
@@ -1564,7 +1570,7 @@ bool SubsumptionTableEntry::subsumed(
               }
 
               // We record the LLVM value of the pointer
-              corePointerValues.insert(stateValue->getValue());
+              corePointerValues[stateValue->getValue()] = bounds;
             } else {
               // Implication: if tabledConcreteAddress == stateSymbolicAddress,
               // then tabledValue->getExpression() ==
@@ -1654,7 +1660,9 @@ bool SubsumptionTableEntry::subsumed(
                 EqExpr::create(tabledSymbolicAddress, stateConcreteAddress));
           } else if (!NoBoundInterpolation && !ExactAddressInterpolant &&
                      tabledValue->isPointer() && stateValue->isPointer()) {
-            ref<Expr> boundsCheck = tabledValue->getBoundsCheck(stateValue);
+            std::set<ref<Expr> > bounds;
+            ref<Expr> boundsCheck =
+                tabledValue->getBoundsCheck(stateValue, bounds);
 
             if (!boundsCheck->isTrue()) {
               newTerm = EqExpr::create(
@@ -1669,7 +1677,7 @@ bool SubsumptionTableEntry::subsumed(
             }
 
             // We record the LLVM value of the pointer
-            corePointerValues.insert(stateValue->getValue());
+            corePointerValues[stateValue->getValue()] = bounds;
           } else {
             // Implication: if tabledSymbolicAddress == stateConcreteAddress,
             // then tabledValue == stateValue
@@ -1707,7 +1715,9 @@ bool SubsumptionTableEntry::subsumed(
                 EqExpr::create(tabledSymbolicAddress, stateSymbolicAddress));
           } else if (!NoBoundInterpolation && !ExactAddressInterpolant &&
                      tabledValue->isPointer() && stateValue->isPointer()) {
-            ref<Expr> boundsCheck = tabledValue->getBoundsCheck(stateValue);
+            std::set<ref<Expr> > bounds;
+            ref<Expr> boundsCheck =
+                tabledValue->getBoundsCheck(stateValue, bounds);
 
             if (!boundsCheck->isTrue()) {
               newTerm = EqExpr::create(
@@ -1722,7 +1732,7 @@ bool SubsumptionTableEntry::subsumed(
             }
 
             // We record the LLVM value of the pointer
-            corePointerValues.insert(stateValue->getValue());
+            corePointerValues[stateValue->getValue()] = bounds;
           } else {
             // Implication: if tabledSymbolicAddress == stateSymbolicAddress
             // then tabledValue == stateValue
@@ -1799,10 +1809,11 @@ bool SubsumptionTableEntry::subsumed(
                        msg.c_str());
         }
       }
-      for (std::set<llvm::Value *>::iterator it = corePointerValues.begin(),
-                                             ie = corePointerValues.end();
+      for (std::map<llvm::Value *, std::set<ref<Expr> > >::iterator
+               it = corePointerValues.begin(),
+               ie = corePointerValues.end();
            it != ie; ++it) {
-        state.itreeNode->pointerValuesInterpolation(*it);
+        state.itreeNode->pointerValuesInterpolation(it->first, it->second);
       }
       return true;
     }
@@ -1930,10 +1941,11 @@ bool SubsumptionTableEntry::subsumed(
 
         if (!NoBoundInterpolation && !ExactAddressInterpolant) {
           // We build memory bounds interpolants from pointer values
-          for (std::set<llvm::Value *>::iterator it = corePointerValues.begin(),
-                                                 ie = corePointerValues.end();
+          for (std::map<llvm::Value *, std::set<ref<Expr> > >::iterator
+                   it = corePointerValues.begin(),
+                   ie = corePointerValues.end();
                it != ie; ++it) {
-            state.itreeNode->pointerValuesInterpolation(*it);
+            state.itreeNode->pointerValuesInterpolation(it->first, it->second);
           }
         }
 
@@ -1967,10 +1979,11 @@ bool SubsumptionTableEntry::subsumed(
 
       if (!NoBoundInterpolation && !ExactAddressInterpolant) {
         // We build memory bounds interpolants from pointer values
-        for (std::set<llvm::Value *>::iterator it = corePointerValues.begin(),
-                                               ie = corePointerValues.end();
+        for (std::map<llvm::Value *, std::set<ref<Expr> > >::iterator
+                 it = corePointerValues.begin(),
+                 ie = corePointerValues.end();
              it != ie; ++it) {
-          state.itreeNode->pointerValuesInterpolation(*it);
+          state.itreeNode->pointerValuesInterpolation(it->first, it->second);
         }
       }
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -632,9 +632,9 @@ public:
   void unsatCoreInterpolation(std::vector<ref<Expr> > unsatCore);
 
   /// \brief Memory bounds interpolation from a target address
-  void pointerValuesInterpolation(llvm::Value *address,
+  void pointerValuesInterpolation(llvm::Value *value, ref<Expr> address,
                                   std::set<ref<Expr> > &bounds) {
-    dependency->markAllPointerValues(address, bounds);
+    dependency->markAllPointerValues(value, address, bounds);
   }
 
   /// \brief Print the content of the tree node object to the LLVM error stream.

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -632,8 +632,9 @@ public:
   void unsatCoreInterpolation(std::vector<ref<Expr> > unsatCore);
 
   /// \brief Memory bounds interpolation from a target address
-  void pointerValuesInterpolation(llvm::Value *address) {
-    dependency->markAllPointerValues(address);
+  void pointerValuesInterpolation(llvm::Value *address,
+                                  std::set<ref<Expr> > &bounds) {
+    dependency->markAllPointerValues(address, bounds);
   }
 
   /// \brief Print the content of the tree node object to the LLVM error stream.


### PR DESCRIPTION
Allocation size is correct to be used in computing interpolant when checking memory validity, but incorrect for when generating interpolant from subsumption check. In that case, pointer values should be bounded by the bounds in the subsuming state instead of the allocation size.