### PR TITLE
Option to limit memory bound interpolation to within tracerx_check function only

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -96,6 +96,8 @@ extern llvm::cl::opt<SubsumptionDebugType> DebugSubsumption;
 extern llvm::cl::opt<bool> NoBoundInterpolation;
 
 extern llvm::cl::opt<bool> ExactAddressInterpolant;
+
+extern llvm::cl::opt<bool> SpecialFunctionBoundCheck;
 #endif
 
 #ifdef ENABLE_METASMT

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -162,6 +162,12 @@ llvm::cl::opt<bool> ExactAddressInterpolant(
                    "default memory offset bound. It has no effect when "
                    "-no-bound-interpolation is specified."));
 
+llvm::cl::opt<bool> SpecialFunctionBoundCheck(
+    "special-function-bound-check",
+    llvm::cl::desc("Perform memory bound interpolation only within function "
+                   "named tracerx_check."),
+    llvm::cl::init(false));
+
 #endif // ENABLE_Z3
 
 #ifdef ENABLE_METASMT

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1637,10 +1637,27 @@ void Dependency::executeMemoryOperation(
       }
     }
 
-    if (ExactAddressInterpolant) {
-      markAllValues(addressOperand, address);
-    } else {
-      markAllPointerValues(addressOperand, address);
+    ref<VersionedValue> val(getLatestValueForMarking(addressOperand, address));
+    if (llvm::isa<llvm::LoadInst>(instr) && !val->getLocations().empty()) {
+      if (instr->getParent()->getParent()->getName().str() == "tracerx_check") {
+        std::set<ref<MemoryLocation> > locations(val->getLocations());
+        for (std::set<ref<MemoryLocation> >::iterator it = locations.begin(),
+                                                      ie = locations.end();
+             it != ie; ++it) {
+          if (llvm::ConstantExpr *ce =
+                  llvm::dyn_cast<llvm::ConstantExpr>((*it)->getValue())) {
+            if (llvm::isa<llvm::GetElementPtrInst>(ce->getAsInstruction())) {
+              (*it)->dump();
+              if (ExactAddressInterpolant) {
+                markAllValues(addressOperand, address);
+              } else {
+                markAllPointerValues(addressOperand, address);
+              }
+              break;
+            }
+          }
+        }
+      }
     }
   }
 #endif

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1637,26 +1637,37 @@ void Dependency::executeMemoryOperation(
       }
     }
 
-    ref<VersionedValue> val(getLatestValueForMarking(addressOperand, address));
-    if (llvm::isa<llvm::LoadInst>(instr) && !val->getLocations().empty()) {
-      if (instr->getParent()->getParent()->getName().str() == "tracerx_check") {
-        std::set<ref<MemoryLocation> > locations(val->getLocations());
-        for (std::set<ref<MemoryLocation> >::iterator it = locations.begin(),
-                                                      ie = locations.end();
-             it != ie; ++it) {
-          if (llvm::ConstantExpr *ce =
-                  llvm::dyn_cast<llvm::ConstantExpr>((*it)->getValue())) {
-            if (llvm::isa<llvm::GetElementPtrInst>(ce->getAsInstruction())) {
-              (*it)->dump();
-              if (ExactAddressInterpolant) {
-                markAllValues(addressOperand, address);
-              } else {
-                markAllPointerValues(addressOperand, address);
+    if (SpecialFunctionBoundCheck) {
+      // Limit interpolation to only within function tracerx_check
+      ref<VersionedValue> val(
+          getLatestValueForMarking(addressOperand, address));
+      if (llvm::isa<llvm::LoadInst>(instr) && !val->getLocations().empty()) {
+        if (instr->getParent()->getParent()->getName().str() ==
+            "tracerx_check") {
+          std::set<ref<MemoryLocation> > locations(val->getLocations());
+          for (std::set<ref<MemoryLocation> >::iterator it = locations.begin(),
+                                                        ie = locations.end();
+               it != ie; ++it) {
+            if (llvm::ConstantExpr *ce =
+                    llvm::dyn_cast<llvm::ConstantExpr>((*it)->getValue())) {
+              if (llvm::isa<llvm::GetElementPtrInst>(ce->getAsInstruction())) {
+                (*it)->dump();
+                if (ExactAddressInterpolant) {
+                  markAllValues(addressOperand, address);
+                } else {
+                  markAllPointerValues(addressOperand, address);
+                }
+                break;
               }
-              break;
             }
           }
         }
+      }
+    } else {
+      if (ExactAddressInterpolant) {
+        markAllValues(addressOperand, address);
+      } else {
+        markAllPointerValues(addressOperand, address);
       }
     }
   }


### PR DESCRIPTION
Added `-special-function-bound-check` to limit memory bound interpolation to within `tracerx_check` function only. This option does not disable memory bound checks.