### PR TITLE
Stack-indexed table print

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -465,15 +465,18 @@ ref<Expr> StoredValue::getBoundsCheck(ref<StoredValue> stateValue,
   return res;
 }
 
-void StoredValue::print(llvm::raw_ostream &stream) const {
+void StoredValue::print(llvm::raw_ostream &stream) const { print(stream, ""); }
+
+void StoredValue::print(llvm::raw_ostream &stream, std::string prefix) const {
   if (!doNotUseBound && !allocationBounds.empty()) {
-    stream << "BOUNDS:\n";
+    stream << prefix << "BOUNDS:";
     for (std::map<llvm::Value *, std::set<ref<Expr> > >::const_iterator
              it = allocationBounds.begin(),
              ie = allocationBounds.end();
          it != ie; ++it) {
       std::set<ref<Expr> > boundsSet = it->second;
-      stream << "[";
+      stream << "\n";
+      stream << prefix << "[";
       it->first->print(stream);
       stream << "<={";
       for (std::set<ref<Expr> >::const_iterator it1 = it->second.begin(),
@@ -484,17 +487,19 @@ void StoredValue::print(llvm::raw_ostream &stream) const {
           stream << ",";
         (*it1)->print(stream);
       }
-      stream << "}]\n";
+      stream << "}]";
     }
 
     if (!allocationOffsets.empty()) {
-      stream << "OFFSETS:\n";
+      stream << "\n";
+      stream << prefix << "OFFSETS:";
       for (std::map<llvm::Value *, std::set<ref<Expr> > >::const_iterator
                it = allocationOffsets.begin(),
                ie = allocationOffsets.end();
            it != ie; ++it) {
         std::set<ref<Expr> > boundsSet = it->second;
-        stream << "[";
+        stream << "\n";
+        stream << prefix << "[";
         it->first->print(stream);
         stream << "=={";
         for (std::set<ref<Expr> >::const_iterator it1 = it->second.begin(),
@@ -505,11 +510,13 @@ void StoredValue::print(llvm::raw_ostream &stream) const {
             stream << ",";
           (*it1)->print(stream);
         }
-        stream << "}]\n";
+        stream << "}]";
       }
     }
     return;
   }
+  stream << "\n";
+  stream << prefix;
   expr->print(stream);
 }
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -505,6 +505,8 @@ namespace klee {
 
     void print(llvm::raw_ostream &stream) const;
 
+    void print(llvm::raw_ostream &stream, std::string prefix) const;
+
     void dump() const {
       print(llvm::errs());
       llvm::errs() << "\n";

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -332,6 +332,8 @@ class SubsumptionTable {
       void print(llvm::raw_ostream &stream) const;
 
       void print(llvm::raw_ostream &stream, const unsigned paddingAmount) const;
+
+      void print(llvm::raw_ostream &stream, const std::string prefix) const;
     };
 
     Node *root;
@@ -566,6 +568,8 @@ public:
   void print(llvm::raw_ostream &stream) const;
 
   void print(llvm::raw_ostream &stream, const unsigned paddingAmount) const;
+
+  void print(llvm::raw_ostream &stream, const std::string prefix) const;
 };
 
 /// \brief The Tracer-X symbolic execution tree node.

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -336,6 +336,8 @@ class SubsumptionTable {
 
     Node *root;
 
+    void printNode(llvm::raw_ostream &stream, Node *n, std::string edges) const;
+
   public:
     StackIndexedTable() { root = new Node(0); }
 


### PR DESCRIPTION
Added content to the stack-indexed table `StackIndexedTable::print` method: previously this was missing.