### PR TITLE
Fixed reverse iteration of callStack in TxTreeNode::print

### DIFF
--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2929,8 +2929,8 @@ void TxTreeNode::print(llvm::raw_ostream &stream,
   }
   stream << tabsNext << "Stack:\n";
   for (std::vector<llvm::Instruction *>::const_reverse_iterator
-           it = callStack.rend(),
-           ie = callStack.rbegin();
+           it = callStack.rbegin(),
+           ie = callStack.rend();
        it != ie; ++it) {
     stream << tabsNext;
     (*it)->print(stream);


### PR DESCRIPTION
`callStack` should be iterated from `callStack.rbegin()` to `callStack.rend()` instead of the other way around.