### PR TITLE
Dynamic debugging interfaces

### DIFF
--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -192,7 +192,7 @@ public:
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;
-  void setDebugLevel(uint64_t id, uint64_t level);
+  void pushDebugLevel(uint64_t level);
 };
 }
 

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -192,7 +192,7 @@ public:
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;
-  void setDebugSubsumptionLevel(uint64_t level);
+  void setDebugLevel(uint64_t id, uint64_t level);
 };
 }
 

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -192,6 +192,7 @@ public:
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;
+  void setDebugSubsumptionLevel(uint64_t level);
 };
 }
 

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -193,6 +193,7 @@ public:
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;
   void pushDebugLevel(uint64_t level);
+  void popDebugLevel();
 };
 }
 

--- a/include/klee/ExecutionState.h
+++ b/include/klee/ExecutionState.h
@@ -192,8 +192,10 @@ public:
 
   bool merge(const ExecutionState &b);
   void dumpStack(llvm::raw_ostream &out) const;
-  void pushDebugLevel(uint64_t level);
-  void popDebugLevel();
+  void debugSubsumption(uint64_t level);
+  void debugSubsumptionOff();
+  void debugState();
+  void debugStateOff();
 };
 }
 

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -135,6 +135,9 @@ extern "C" {
      constants and that the range lie within a single object. */
   void klee_check_memory_access(const void *address, size_t size);
 
+  /* Set dynamic level of subsumption-related debugging information. */
+  void klee_debug_subsumption(uint64_t level);
+
   /* Enable/disable forking. */
   void klee_set_forking(unsigned enable);
 

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -158,6 +158,8 @@ extern "C" {
   /* Set dynamic level of debugging information. */
   void tracerx_push_debug_level(uint64_t level);
 
+  /* Unset dynamic level of debugging information to previous value */
+  void tracerx_pop_debug_level();
 #ifdef __cplusplus
 }
 #endif

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -135,9 +135,6 @@ extern "C" {
      constants and that the range lie within a single object. */
   void klee_check_memory_access(const void *address, size_t size);
 
-  /* Set dynamic level of subsumption-related debugging information. */
-  void klee_debug_subsumption(uint64_t level);
-
   /* Enable/disable forking. */
   void klee_set_forking(unsigned enable);
 
@@ -157,6 +154,10 @@ extern "C" {
 
   /* Merge current states together if possible */
   void klee_merge();
+
+  /* Set dynamic level of debugging information. */
+  void tracerx_debug_level(uint64_t id, uint64_t level);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -156,7 +156,7 @@ extern "C" {
   void klee_merge();
 
   /* Set dynamic level of debugging information. */
-  void tracerx_debug_level(uint64_t id, uint64_t level);
+  void tracerx_push_debug_level(uint64_t level);
 
 #ifdef __cplusplus
 }

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -155,11 +155,25 @@ extern "C" {
   /* Merge current states together if possible */
   void klee_merge();
 
-  /* Set dynamic level of debugging information. */
+  /* Set dynamic level of subsumption-related debugging information. This
+   * corresponds to -debug-subsumption command-line option, but this API allows
+   * users to specify where in the code to start to output debug information. */
   void tracerx_debug_subsumption(uint64_t level);
 
-  /* Unset dynamic level of debugging information to previous value */
+  /* Reset dynamic level of subsumption-related debugging information to
+   * previous value. This resets the debug level to the value specified via
+   * -debug-subsumption command-line option if exists, otherwise this switches
+   * off subsumption-related debugging. */
   void tracerx_debug_subsumption_off();
+
+  /* Set dynamic level of state-related debugging information. This corresponds
+   * to -debug-state command-line option. */
+  void tracerx_debug_state();
+
+  /* Reset dynamic level of state-related debugging information. This resets the
+   * state debug flag to the value specified via -debug-state command-line
+   * option, otherwise, it switches off state debugging. */
+  void tracerx_debug_state_off();
 #ifdef __cplusplus
 }
 #endif

--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -156,10 +156,10 @@ extern "C" {
   void klee_merge();
 
   /* Set dynamic level of debugging information. */
-  void tracerx_push_debug_level(uint64_t level);
+  void tracerx_debug_subsumption(uint64_t level);
 
   /* Unset dynamic level of debugging information to previous value */
-  void tracerx_pop_debug_level();
+  void tracerx_debug_subsumption_off();
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -45,8 +45,7 @@ namespace klee {
 
 void StoredValue::init(ref<VersionedValue> vvalue,
                        std::set<const Array *> &replacements,
-                       std::vector<std::string> &_coreReasons, int _debugLevel,
-                       bool shadowing) {
+                       std::vector<std::string> &_coreReasons, bool shadowing) {
   std::set<ref<MemoryLocation> > locations = vvalue->getLocations();
 
   refCount = 0;
@@ -127,12 +126,11 @@ void StoredValue::init(ref<VersionedValue> vvalue,
       }
     }
   }
-
-  debugLevel = _debugLevel;
 }
 
 ref<Expr> StoredValue::getBoundsCheck(ref<StoredValue> stateValue,
-                                      std::set<ref<Expr> > &bounds) const {
+                                      std::set<ref<Expr> > &bounds,
+                                      int debugLevel) const {
   ref<Expr> res;
 #ifdef ENABLE_Z3
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -45,8 +45,8 @@ namespace klee {
 
 void StoredValue::init(ref<VersionedValue> vvalue,
                        std::set<const Array *> &replacements,
-                       std::vector<std::string> &_coreReasons,
-                       int _debugSubsumptionLevel, bool shadowing) {
+                       std::vector<std::string> &_coreReasons, int _debugLevel,
+                       bool shadowing) {
   std::set<ref<MemoryLocation> > locations = vvalue->getLocations();
 
   refCount = 0;
@@ -128,7 +128,7 @@ void StoredValue::init(ref<VersionedValue> vvalue,
     }
   }
 
-  debugSubsumptionLevel = _debugSubsumptionLevel;
+  debugLevel = _debugLevel;
 }
 
 ref<Expr> StoredValue::getBoundsCheck(ref<StoredValue> stateValue,
@@ -161,7 +161,7 @@ ref<Expr> StoredValue::getBoundsCheck(ref<StoredValue> stateValue,
     assert(!tabledBounds.empty() && "tabled bounds empty");
 
     if (stateOffsets.empty()) {
-      if (debugSubsumptionLevel >= 3) {
+      if (debugLevel >= 3) {
         std::string msg;
         llvm::raw_string_ostream stream(msg);
         it->first->print(stream);
@@ -183,9 +183,7 @@ ref<Expr> StoredValue::getBoundsCheck(ref<StoredValue> stateValue,
             if (tabledBoundInt > 0) {
               uint64_t stateOffsetInt = stateOffset->getZExtValue();
               if (stateOffsetInt >= tabledBoundInt) {
-                if ((DebugSubsumption > debugSubsumptionLevel
-                         ? DebugSubsumption
-                         : debugSubsumptionLevel) >= 3) {
+                if (debugLevel >= 3) {
                   std::string msg;
                   llvm::raw_string_ostream stream(msg);
                   it->first->print(stream);
@@ -343,18 +341,18 @@ Dependency::getStoredExpressions(const std::vector<llvm::Instruction *> &stack,
     if (!coreOnly) {
       llvm::Value *base = it->first->getValue();
       concreteStore[base][it->first] =
-          StoredValue::create(it->second.second, debugSubsumptionLevel);
+          StoredValue::create(it->second.second, debugLevel);
     } else if (it->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
       llvm::Value *base = it->first->getValue();
 #ifdef ENABLE_Z3
       if (!NoExistential) {
-        concreteStore[base][it->first] = StoredValue::create(
-            it->second.second, replacements, debugSubsumptionLevel);
+        concreteStore[base][it->first] =
+            StoredValue::create(it->second.second, replacements, debugLevel);
       } else
 #endif
         concreteStore[base][it->first] =
-            StoredValue::create(it->second.second, debugSubsumptionLevel);
+            StoredValue::create(it->second.second, debugLevel);
     }
   }
 
@@ -372,8 +370,7 @@ Dependency::getStoredExpressions(const std::vector<llvm::Instruction *> &stack,
     if (!coreOnly) {
       llvm::Value *base = it->first->getValue();
       symbolicStore[base].push_back(AddressValuePair(
-          it->first,
-          StoredValue::create(it->second.second, debugSubsumptionLevel)));
+          it->first, StoredValue::create(it->second.second, debugLevel)));
     } else if (it->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
       llvm::Value *base = it->first->getValue();
@@ -381,13 +378,11 @@ Dependency::getStoredExpressions(const std::vector<llvm::Instruction *> &stack,
       if (!NoExistential) {
         symbolicStore[base].push_back(AddressValuePair(
             MemoryLocation::create(it->first, replacements),
-            StoredValue::create(it->second.second, replacements,
-                                debugSubsumptionLevel)));
+            StoredValue::create(it->second.second, replacements, debugLevel)));
       } else
 #endif
         symbolicStore[base].push_back(AddressValuePair(
-            it->first,
-            StoredValue::create(it->second.second, debugSubsumptionLevel)));
+            it->first, StoredValue::create(it->second.second, debugLevel)));
       }
   }
 
@@ -676,10 +671,6 @@ void Dependency::addDependencyViaExternalFunction(
   if (source.isNull() || target.isNull())
     return;
 
-  int debugLevel = debugSubsumptionLevel;
-  if (DebugSubsumption > debugLevel)
-    debugLevel = DebugSubsumption;
-
 #ifdef ENABLE_Z3
   if (!NoBoundInterpolation) {
     std::set<ref<MemoryLocation> > locations = source->getLocations();
@@ -824,21 +815,14 @@ std::vector<ref<VersionedValue> > Dependency::populateArgumentValuesList(
   return argumentValuesList;
 }
 
-Dependency::Dependency(Dependency *parent, llvm::DataLayout *_targetData,
-                       int _debugSubsumptionLevel)
+Dependency::Dependency(Dependency *parent, llvm::DataLayout *_targetData)
     : parent(parent), targetData(_targetData) {
-  int debugLevel = DebugSubsumption;
-  if (_debugSubsumptionLevel > DebugSubsumption)
-    debugLevel = _debugSubsumptionLevel;
+  debugLevel = DebugSubsumption;
 
   if (parent) {
     concretelyAddressedStore = parent->concretelyAddressedStore;
     symbolicallyAddressedStore = parent->symbolicallyAddressedStore;
-    debugSubsumptionLevel = (parent->debugSubsumptionLevel > debugLevel
-                                 ? parent->debugSubsumptionLevel
-                                 : debugLevel);
-  } else {
-    debugSubsumptionLevel = debugLevel;
+    debugLevel = parent->debugLevel;
   }
 }
 
@@ -1024,9 +1008,7 @@ void Dependency::execute(llvm::Instruction *instr,
       if (binst && binst->isConditional()) {
         ref<Expr> unknownExpression;
         std::string reason = "";
-        if ((DebugSubsumption > debugSubsumptionLevel
-                 ? DebugSubsumption
-                 : debugSubsumptionLevel) >= 1) {
+        if (debugLevel >= 1) {
           llvm::raw_string_ostream stream(reason);
           stream << "branch instruction [";
           if (binst->getParent()->getParent()) {
@@ -1473,9 +1455,7 @@ void Dependency::executeMemoryOperation(
                     llvm::dyn_cast<llvm::ConstantExpr>((*it)->getValue())) {
               if (llvm::isa<llvm::GetElementPtrInst>(ce->getAsInstruction())) {
                 std::string reason = "";
-                if ((DebugSubsumption > debugSubsumptionLevel
-                         ? DebugSubsumption
-                         : debugSubsumptionLevel) >= 1) {
+                if (debugLevel >= 1) {
                   llvm::raw_string_ostream stream(reason);
                   stream << "pointer use [";
                   if (instr->getParent()->getParent()) {
@@ -1502,9 +1482,7 @@ void Dependency::executeMemoryOperation(
       }
     } else {
       std::string reason = "";
-      if ((DebugSubsumption > debugSubsumptionLevel
-               ? DebugSubsumption
-               : debugSubsumptionLevel) >= 1) {
+      if (debugLevel >= 1) {
         llvm::raw_string_ostream stream(reason);
         stream << "pointer use [";
         if (instr->getParent()->getParent()) {

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -817,8 +817,10 @@ Dependency::Dependency(Dependency *parent, llvm::DataLayout *_targetData)
     concretelyAddressedStore = parent->concretelyAddressedStore;
     symbolicallyAddressedStore = parent->symbolicallyAddressedStore;
     debugSubsumptionLevel = parent->debugSubsumptionLevel;
+    debugState = parent->debugState;
   } else {
     debugSubsumptionLevel = DebugSubsumption;
+    debugState = DebugState;
   }
 }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -338,19 +338,17 @@ Dependency::getStoredExpressions(const std::vector<llvm::Instruction *> &stack,
 
     if (!coreOnly) {
       llvm::Value *base = it->first->getValue();
-      concreteStore[base][it->first] =
-          StoredValue::create(it->second.second, debugSubsumptionLevel.top());
+      concreteStore[base][it->first] = StoredValue::create(it->second.second);
     } else if (it->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
       llvm::Value *base = it->first->getValue();
 #ifdef ENABLE_Z3
       if (!NoExistential) {
-        concreteStore[base][it->first] = StoredValue::create(
-            it->second.second, replacements, debugSubsumptionLevel.top());
+        concreteStore[base][it->first] =
+            StoredValue::create(it->second.second, replacements);
       } else
 #endif
-        concreteStore[base][it->first] =
-            StoredValue::create(it->second.second, debugSubsumptionLevel.top());
+        concreteStore[base][it->first] = StoredValue::create(it->second.second);
     }
   }
 
@@ -367,8 +365,8 @@ Dependency::getStoredExpressions(const std::vector<llvm::Instruction *> &stack,
 
     if (!coreOnly) {
       llvm::Value *base = it->first->getValue();
-      symbolicStore[base].push_back(AddressValuePair(
-          it->first, StoredValue::create(it->second.second, debugSubsumptionLevel.top())));
+      symbolicStore[base].push_back(
+          AddressValuePair(it->first, StoredValue::create(it->second.second)));
     } else if (it->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
       llvm::Value *base = it->first->getValue();
@@ -376,13 +374,11 @@ Dependency::getStoredExpressions(const std::vector<llvm::Instruction *> &stack,
       if (!NoExistential) {
         symbolicStore[base].push_back(AddressValuePair(
             MemoryLocation::create(it->first, replacements),
-            StoredValue::create(it->second.second, replacements,
-                                debugSubsumptionLevel.top())));
+            StoredValue::create(it->second.second, replacements)));
       } else
 #endif
-        symbolicStore[base].push_back(
-            AddressValuePair(it->first, StoredValue::create(it->second.second,
-                                                            debugSubsumptionLevel.top())));
+        symbolicStore[base].push_back(AddressValuePair(
+            it->first, StoredValue::create(it->second.second)));
       }
   }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -672,7 +672,7 @@ void Dependency::addDependencyViaExternalFunction(
     std::set<ref<MemoryLocation> > locations = source->getLocations();
     if (!locations.empty()) {
       std::string reason = "";
-      if (debugSubsumptionLevel.top() >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         llvm::raw_string_ostream stream(reason);
         stream << "parameter [";
         source->getValue()->print(stream);
@@ -818,7 +818,7 @@ Dependency::Dependency(Dependency *parent, llvm::DataLayout *_targetData)
     symbolicallyAddressedStore = parent->symbolicallyAddressedStore;
     debugSubsumptionLevel = parent->debugSubsumptionLevel;
   } else {
-    debugSubsumptionLevel.push(DebugSubsumption);
+    debugSubsumptionLevel = DebugSubsumption;
   }
 }
 
@@ -1004,7 +1004,7 @@ void Dependency::execute(llvm::Instruction *instr,
       if (binst && binst->isConditional()) {
         ref<Expr> unknownExpression;
         std::string reason = "";
-        if (debugSubsumptionLevel.top() >= 1) {
+        if (debugSubsumptionLevel >= 1) {
           llvm::raw_string_ostream stream(reason);
           stream << "branch instruction [";
           if (binst->getParent()->getParent()) {
@@ -1451,7 +1451,7 @@ void Dependency::executeMemoryOperation(
                     llvm::dyn_cast<llvm::ConstantExpr>((*it)->getValue())) {
               if (llvm::isa<llvm::GetElementPtrInst>(ce->getAsInstruction())) {
                 std::string reason = "";
-                if (debugSubsumptionLevel.top() >= 1) {
+                if (debugSubsumptionLevel >= 1) {
                   llvm::raw_string_ostream stream(reason);
                   stream << "pointer use [";
                   if (instr->getParent()->getParent()) {
@@ -1478,7 +1478,7 @@ void Dependency::executeMemoryOperation(
       }
     } else {
       std::string reason = "";
-      if (debugSubsumptionLevel.top() >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         llvm::raw_string_ostream stream(reason);
         stream << "pointer use [";
         if (instr->getParent()->getParent()) {

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -417,7 +417,7 @@ namespace klee {
 
   public:
     /// \brief This is for dynamic setting up of debug messages.
-    int debugLevel;
+    std::stack<int> debugLevel;
 
     Dependency(Dependency *parent, llvm::DataLayout *_targetData);
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -82,24 +82,24 @@ namespace klee {
     }
 
     StoredValue(ref<VersionedValue> vvalue,
-                std::vector<std::string> &coreReasons, int _debugLevel) {
+                std::vector<std::string> &coreReasons, int _debugSubsumptionLevel) {
       std::set<const Array *> dummyReplacements;
-      init(vvalue, dummyReplacements, coreReasons, _debugLevel);
+      init(vvalue, dummyReplacements, coreReasons, _debugSubsumptionLevel);
     }
 
   public:
     static ref<StoredValue> create(ref<VersionedValue> vvalue,
                                    std::set<const Array *> &replacements,
-                                   int _debugLevel) {
+                                   int _debugSubsumptionLevel) {
       ref<StoredValue> sv(
           new StoredValue(vvalue, replacements, vvalue->getReasons()));
       return sv;
     }
 
     static ref<StoredValue> create(ref<VersionedValue> vvalue,
-                                   int _debugLevel) {
+                                   int _debugSubsumptionLevel) {
       ref<StoredValue> sv(
-          new StoredValue(vvalue, vvalue->getReasons(), _debugLevel));
+          new StoredValue(vvalue, vvalue->getReasons(), _debugSubsumptionLevel));
       return sv;
     }
 
@@ -119,7 +119,7 @@ namespace klee {
 
     ref<Expr> getBoundsCheck(ref<StoredValue> svalue,
                              std::set<ref<Expr> > &bounds,
-                             int debugLevel) const;
+                             int debugSubsumptionLevel) const;
 
     ref<Expr> getExpression() const { return expr; }
 
@@ -417,7 +417,7 @@ namespace klee {
 
   public:
     /// \brief This is for dynamic setting up of debug messages.
-    std::stack<int> debugLevel;
+    std::stack<int> debugSubsumptionLevel;
 
     Dependency(Dependency *parent, llvm::DataLayout *_targetData);
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -72,17 +72,13 @@ namespace klee {
     /// \brief Reason this was stored as needed value
     std::vector<std::string> coreReasons;
 
-    /// \brief This is for dynamic setting up of debug messages.
-    int debugLevel;
-
     void init(ref<VersionedValue> vvalue, std::set<const Array *> &replacements,
-              std::vector<std::string> &coreReasons, int debugLevel,
-              bool shadowing = false);
+              std::vector<std::string> &coreReasons, bool shadowing = false);
 
     StoredValue(ref<VersionedValue> vvalue,
                 std::set<const Array *> &replacements,
-                std::vector<std::string> &coreReasons, int _debugLevel) {
-      init(vvalue, replacements, coreReasons, _debugLevel, true);
+                std::vector<std::string> &coreReasons) {
+      init(vvalue, replacements, coreReasons, true);
     }
 
     StoredValue(ref<VersionedValue> vvalue,
@@ -95,8 +91,8 @@ namespace klee {
     static ref<StoredValue> create(ref<VersionedValue> vvalue,
                                    std::set<const Array *> &replacements,
                                    int _debugLevel) {
-      ref<StoredValue> sv(new StoredValue(vvalue, replacements,
-                                          vvalue->getReasons(), _debugLevel));
+      ref<StoredValue> sv(
+          new StoredValue(vvalue, replacements, vvalue->getReasons()));
       return sv;
     }
 
@@ -122,7 +118,8 @@ namespace klee {
     bool isPointer() const { return !allocationBounds.empty(); }
 
     ref<Expr> getBoundsCheck(ref<StoredValue> svalue,
-                             std::set<ref<Expr> > &bounds) const;
+                             std::set<ref<Expr> > &bounds,
+                             int debugLevel) const;
 
     ref<Expr> getExpression() const { return expr; }
 
@@ -298,10 +295,6 @@ namespace klee {
     /// \brief The data layout of the analysis target program
     llvm::DataLayout *targetData;
 
-    /// \brief This is for dynamic setting up of subsumption-related debug
-    /// messages.
-    int debugLevel;
-
     /// \brief Tests if a pointer points to a main function's argument
     static bool isMainArgument(llvm::Value *loc);
 
@@ -423,6 +416,9 @@ namespace klee {
                                std::vector<ref<Expr> > &arguments);
 
   public:
+    /// \brief This is for dynamic setting up of debug messages.
+    int debugLevel;
+
     Dependency(Dependency *parent, llvm::DataLayout *_targetData);
 
     ~Dependency();

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -72,41 +72,38 @@ namespace klee {
     /// \brief Reason this was stored as needed value
     std::vector<std::string> coreReasons;
 
-    /// \brief This is for dynamic setting up of subsumption-related debug
-    /// messages.
-    int debugSubsumptionLevel;
+    /// \brief This is for dynamic setting up of debug messages.
+    int debugLevel;
 
     void init(ref<VersionedValue> vvalue, std::set<const Array *> &replacements,
-              std::vector<std::string> &coreReasons, int debugSubsumptionLevel,
+              std::vector<std::string> &coreReasons, int debugLevel,
               bool shadowing = false);
 
     StoredValue(ref<VersionedValue> vvalue,
                 std::set<const Array *> &replacements,
-                std::vector<std::string> &coreReasons,
-                int _debugSubsumptionLevel) {
-      init(vvalue, replacements, coreReasons, _debugSubsumptionLevel, true);
+                std::vector<std::string> &coreReasons, int _debugLevel) {
+      init(vvalue, replacements, coreReasons, _debugLevel, true);
     }
 
     StoredValue(ref<VersionedValue> vvalue,
-                std::vector<std::string> &coreReasons,
-                int _debugSubsumptionLevel) {
+                std::vector<std::string> &coreReasons, int _debugLevel) {
       std::set<const Array *> dummyReplacements;
-      init(vvalue, dummyReplacements, coreReasons, _debugSubsumptionLevel);
+      init(vvalue, dummyReplacements, coreReasons, _debugLevel);
     }
 
   public:
     static ref<StoredValue> create(ref<VersionedValue> vvalue,
                                    std::set<const Array *> &replacements,
-                                   int _debugSubsumptionLevel) {
-      ref<StoredValue> sv(new StoredValue(
-          vvalue, replacements, vvalue->getReasons(), _debugSubsumptionLevel));
+                                   int _debugLevel) {
+      ref<StoredValue> sv(new StoredValue(vvalue, replacements,
+                                          vvalue->getReasons(), _debugLevel));
       return sv;
     }
 
     static ref<StoredValue> create(ref<VersionedValue> vvalue,
-                                   int _debugSubsumptionLevel) {
-      ref<StoredValue> sv(new StoredValue(vvalue, vvalue->getReasons(),
-                                          _debugSubsumptionLevel));
+                                   int _debugLevel) {
+      ref<StoredValue> sv(
+          new StoredValue(vvalue, vvalue->getReasons(), _debugLevel));
       return sv;
     }
 
@@ -303,7 +300,7 @@ namespace klee {
 
     /// \brief This is for dynamic setting up of subsumption-related debug
     /// messages.
-    int debugSubsumptionLevel;
+    int debugLevel;
 
     /// \brief Tests if a pointer points to a main function's argument
     static bool isMainArgument(llvm::Value *loc);
@@ -426,8 +423,7 @@ namespace klee {
                                std::vector<ref<Expr> > &arguments);
 
   public:
-    Dependency(Dependency *parent, llvm::DataLayout *_targetData,
-               int debugSubsumptionLevel);
+    Dependency(Dependency *parent, llvm::DataLayout *_targetData);
 
     ~Dependency();
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -72,31 +72,41 @@ namespace klee {
     /// \brief Reason this was stored as needed value
     std::vector<std::string> coreReasons;
 
+    /// \brief This is for dynamic setting up of subsumption-related debug
+    /// messages.
+    int debugSubsumptionLevel;
+
     void init(ref<VersionedValue> vvalue, std::set<const Array *> &replacements,
-              std::vector<std::string> &coreReasons, bool shadowing = false);
+              std::vector<std::string> &coreReasons, int debugSubsumptionLevel,
+              bool shadowing = false);
 
     StoredValue(ref<VersionedValue> vvalue,
                 std::set<const Array *> &replacements,
-                std::vector<std::string> &coreReasons) {
-      init(vvalue, replacements, coreReasons, true);
+                std::vector<std::string> &coreReasons,
+                int _debugSubsumptionLevel) {
+      init(vvalue, replacements, coreReasons, _debugSubsumptionLevel, true);
     }
 
     StoredValue(ref<VersionedValue> vvalue,
-                std::vector<std::string> &coreReasons) {
+                std::vector<std::string> &coreReasons,
+                int _debugSubsumptionLevel) {
       std::set<const Array *> dummyReplacements;
-      init(vvalue, dummyReplacements, coreReasons);
+      init(vvalue, dummyReplacements, coreReasons, _debugSubsumptionLevel);
     }
 
   public:
     static ref<StoredValue> create(ref<VersionedValue> vvalue,
-                                   std::set<const Array *> &replacements) {
-      ref<StoredValue> sv(
-          new StoredValue(vvalue, replacements, vvalue->getReasons()));
+                                   std::set<const Array *> &replacements,
+                                   int _debugSubsumptionLevel) {
+      ref<StoredValue> sv(new StoredValue(
+          vvalue, replacements, vvalue->getReasons(), _debugSubsumptionLevel));
       return sv;
     }
 
-    static ref<StoredValue> create(ref<VersionedValue> vvalue) {
-      ref<StoredValue> sv(new StoredValue(vvalue, vvalue->getReasons()));
+    static ref<StoredValue> create(ref<VersionedValue> vvalue,
+                                   int _debugSubsumptionLevel) {
+      ref<StoredValue> sv(new StoredValue(vvalue, vvalue->getReasons(),
+                                          _debugSubsumptionLevel));
       return sv;
     }
 
@@ -291,6 +301,10 @@ namespace klee {
     /// \brief The data layout of the analysis target program
     llvm::DataLayout *targetData;
 
+    /// \brief This is for dynamic setting up of subsumption-related debug
+    /// messages.
+    int debugSubsumptionLevel;
+
     /// \brief Tests if a pointer points to a main function's argument
     static bool isMainArgument(llvm::Value *loc);
 
@@ -412,7 +426,8 @@ namespace klee {
                                std::vector<ref<Expr> > &arguments);
 
   public:
-    Dependency(Dependency *parent, llvm::DataLayout *_targetData);
+    Dependency(Dependency *parent, llvm::DataLayout *_targetData,
+               int debugSubsumptionLevel);
 
     ~Dependency();
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -414,7 +414,7 @@ namespace klee {
 
   public:
     /// \brief This is for dynamic setting up of debug messages.
-    std::stack<int> debugSubsumptionLevel;
+    int debugSubsumptionLevel;
 
     Dependency(Dependency *parent, llvm::DataLayout *_targetData);
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -82,24 +82,21 @@ namespace klee {
     }
 
     StoredValue(ref<VersionedValue> vvalue,
-                std::vector<std::string> &coreReasons, int _debugSubsumptionLevel) {
+                std::vector<std::string> &coreReasons) {
       std::set<const Array *> dummyReplacements;
-      init(vvalue, dummyReplacements, coreReasons, _debugSubsumptionLevel);
+      init(vvalue, dummyReplacements, coreReasons);
     }
 
   public:
     static ref<StoredValue> create(ref<VersionedValue> vvalue,
-                                   std::set<const Array *> &replacements,
-                                   int _debugSubsumptionLevel) {
+                                   std::set<const Array *> &replacements) {
       ref<StoredValue> sv(
           new StoredValue(vvalue, replacements, vvalue->getReasons()));
       return sv;
     }
 
-    static ref<StoredValue> create(ref<VersionedValue> vvalue,
-                                   int _debugSubsumptionLevel) {
-      ref<StoredValue> sv(
-          new StoredValue(vvalue, vvalue->getReasons(), _debugSubsumptionLevel));
+    static ref<StoredValue> create(ref<VersionedValue> vvalue) {
+      ref<StoredValue> sv(new StoredValue(vvalue, vvalue->getReasons()));
       return sv;
     }
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -416,6 +416,9 @@ namespace klee {
     /// \brief This is for dynamic setting up of debug messages.
     int debugSubsumptionLevel;
 
+    /// \brief Flag to display debug information on the state.
+    bool debugState;
+
     Dependency(Dependency *parent, llvm::DataLayout *_targetData);
 
     ~Dependency();

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -390,10 +390,10 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
 }
 
 void ExecutionState::pushDebugLevel(uint64_t level) {
-  txTreeNode->dependency->debugLevel.push(level);
+  txTreeNode->dependency->debugSubsumptionLevel.push(level);
 }
 
 void ExecutionState::popDebugLevel() {
-  if (txTreeNode->dependency->debugLevel.size() > 1)
-    txTreeNode->dependency->debugLevel.pop();
+  if (txTreeNode->dependency->debugSubsumptionLevel.size() > 1)
+    txTreeNode->dependency->debugSubsumptionLevel.pop();
 }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -392,3 +392,8 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
 void ExecutionState::pushDebugLevel(uint64_t level) {
   txTreeNode->dependency->debugLevel.push(level);
 }
+
+void ExecutionState::popDebugLevel() {
+  if (txTreeNode->dependency->debugLevel.size() > 1)
+    txTreeNode->dependency->debugLevel.pop();
+}

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -390,10 +390,9 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
 }
 
 void ExecutionState::pushDebugLevel(uint64_t level) {
-  txTreeNode->dependency->debugSubsumptionLevel.push(level);
+  txTreeNode->dependency->debugSubsumptionLevel = level;
 }
 
 void ExecutionState::popDebugLevel() {
-  if (txTreeNode->dependency->debugSubsumptionLevel.size() > 1)
-    txTreeNode->dependency->debugSubsumptionLevel.pop();
+  txTreeNode->dependency->debugSubsumptionLevel = DebugSubsumption;
 }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -390,5 +390,5 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
 }
 
 void ExecutionState::setDebugLevel(uint64_t id, uint64_t level) {
-  txTreeNode->debugLevel = level;
+  txTreeNode->dependency->debugLevel = level;
 }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -389,10 +389,16 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
   }
 }
 
-void ExecutionState::pushDebugLevel(uint64_t level) {
+void ExecutionState::debugSubsumption(uint64_t level) {
   txTreeNode->dependency->debugSubsumptionLevel = level;
 }
 
-void ExecutionState::popDebugLevel() {
+void ExecutionState::debugSubsumptionOff() {
   txTreeNode->dependency->debugSubsumptionLevel = DebugSubsumption;
+}
+
+void ExecutionState::debugState() { txTreeNode->dependency->debugState = true; }
+
+void ExecutionState::debugStateOff() {
+  txTreeNode->dependency->debugState = DebugState;
 }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -389,6 +389,6 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
   }
 }
 
-void ExecutionState::setDebugLevel(uint64_t id, uint64_t level) {
-  txTreeNode->dependency->debugLevel = level;
+void ExecutionState::pushDebugLevel(uint64_t level) {
+  txTreeNode->dependency->debugLevel.push(level);
 }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -390,5 +390,5 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
 }
 
 void ExecutionState::setDebugLevel(uint64_t id, uint64_t level) {
-  txTreeNode->debugSubsumptionLevel = level;
+  txTreeNode->debugLevel = level;
 }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -388,3 +388,7 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
     target = sf.caller;
   }
 }
+
+void ExecutionState::setDebugSubsumptionLevel(uint64_t level) {
+  txTreeNode->debugSubsumptionLevel = level;
+}

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -389,6 +389,6 @@ void ExecutionState::dumpStack(llvm::raw_ostream &out) const {
   }
 }
 
-void ExecutionState::setDebugSubsumptionLevel(uint64_t level) {
+void ExecutionState::setDebugLevel(uint64_t id, uint64_t level) {
   txTreeNode->debugSubsumptionLevel = level;
 }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3031,7 +3031,7 @@ void Executor::run(ExecutionState &initialState) {
       // in the node.
       txTree->setCurrentINode(state);
 
-      if (DebugState) {
+      if (txTree->getDebugState()) {
         std::string debugMessage;
         llvm::raw_string_ostream stream(debugMessage);
         stream << "\nCurrent state:\n";

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -140,7 +140,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("__ubsan_handle_divrem_overflow", handleDivRemOverflow, false),
 
   // change debug information
-  add("tracerx_debug_level", handleDebugLevel, false),
+  add("tracerx_push_debug_level", handlePushDebugLevel, false),
 
 #undef addDNR
 #undef add
@@ -653,12 +653,11 @@ void SpecialFunctionHandler::handleCheckMemoryAccess(ExecutionState &state,
   }
 }
 
-void
-SpecialFunctionHandler::handleDebugLevel(ExecutionState &state,
-                                         KInstruction *target,
-                                         std::vector<ref<Expr> > &arguments) {
-  assert(arguments.size() == 2 &&
-         "invalid number of arguments to tracerx_debug_level");
+void SpecialFunctionHandler::handlePushDebugLevel(
+    ExecutionState &state, KInstruction *target,
+    std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 1 &&
+         "invalid number of arguments to tracerx_push_debug_level");
 
   ref<Expr> id = executor.toUnique(state, arguments[0]);
   ref<Expr> level = executor.toUnique(state, arguments[1]);
@@ -670,7 +669,7 @@ SpecialFunctionHandler::handleDebugLevel(ExecutionState &state,
   }
 
   executor.terminateStateOnError(
-      state, "debug_level requires constant arguments", Executor::User);
+      state, "push_debug_level requires constant arguments", Executor::User);
 }
 
 void SpecialFunctionHandler::handleGetValue(ExecutionState &state,

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -140,7 +140,8 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("__ubsan_handle_divrem_overflow", handleDivRemOverflow, false),
 
   // change debug information
-  add("tracerx_push_debug_level", handlePushDebugLevel, false),
+  add("tracerx_debug_subsumption", handlePushDebugLevel, false),
+  add("tracerx_debug_subsumption_off", handlePushDebugLevel, false),
 
 #undef addDNR
 #undef add
@@ -657,7 +658,7 @@ void SpecialFunctionHandler::handlePushDebugLevel(
     ExecutionState &state, KInstruction *target,
     std::vector<ref<Expr> > &arguments) {
   assert(arguments.size() == 1 &&
-         "invalid number of arguments to tracerx_push_debug_level");
+         "invalid number of arguments to tracerx_debug_subsumption");
 
   ref<Expr> level = executor.toUnique(state, arguments[0]);
   if (ConstantExpr *cLevel = llvm::dyn_cast<ConstantExpr>(level)) {
@@ -673,7 +674,7 @@ void SpecialFunctionHandler::handlePopDebugLevel(
     ExecutionState &state, KInstruction *target,
     std::vector<ref<Expr> > &arguments) {
   assert(arguments.size() == 0 &&
-         "invalid number of arguments to tracerx_pop_debug_level");
+         "invalid number of arguments to tracerx_debug_subsumption_off");
   state.popDebugLevel();
 }
 

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -85,13 +85,13 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   addDNR("_exit", handleExit),
   { "exit", &SpecialFunctionHandler::handleExit, true, false, true },
   addDNR("klee_abort", handleAbort),
-  addDNR("klee_silent_exit", handleSilentExit),  
+  addDNR("klee_silent_exit", handleSilentExit),
   addDNR("klee_report_error", handleReportError),
-
   add("calloc", handleCalloc, true),
   add("free", handleFree, false),
   add("klee_assume", handleAssume, false),
   add("klee_check_memory_access", handleCheckMemoryAccess, false),
+  add("klee_debug_subsumption", handleDebugSubsumption, false),
   add("klee_get_valuef", handleGetValue, true),
   add("klee_get_valued", handleGetValue, true),
   add("klee_get_valuel", handleGetValue, true),
@@ -141,7 +141,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("__ubsan_handle_divrem_overflow", handleDivRemOverflow, false),
 
 #undef addDNR
-#undef add  
+#undef add
 };
 
 SpecialFunctionHandler::const_iterator SpecialFunctionHandler::begin() {
@@ -649,6 +649,22 @@ void SpecialFunctionHandler::handleCheckMemoryAccess(ExecutionState &state,
       }
     }
   }
+}
+
+void SpecialFunctionHandler::handleDebugSubsumption(
+    ExecutionState &state, KInstruction *target,
+    std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 1 &&
+         "invalid number of arguments to klee_debug_subsumption");
+
+  ref<Expr> level = executor.toUnique(state, arguments[0]);
+  if (ConstantExpr *ce = llvm::dyn_cast<ConstantExpr>(level)) {
+    state.setDebugSubsumptionLevel(ce->getZExtValue());
+    return;
+  }
+
+  executor.terminateStateOnError(
+      state, "debug_subsumption requires constant argument", Executor::User);
 }
 
 void SpecialFunctionHandler::handleGetValue(ExecutionState &state,

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -659,13 +659,10 @@ void SpecialFunctionHandler::handlePushDebugLevel(
   assert(arguments.size() == 1 &&
          "invalid number of arguments to tracerx_push_debug_level");
 
-  ref<Expr> id = executor.toUnique(state, arguments[0]);
-  ref<Expr> level = executor.toUnique(state, arguments[1]);
-  if (ConstantExpr *cid = llvm::dyn_cast<ConstantExpr>(id)) {
-    if (ConstantExpr *cLevel = llvm::dyn_cast<ConstantExpr>(level)) {
-      state.setDebugLevel(cid->getZExtValue(), cLevel->getZExtValue());
+  ref<Expr> level = executor.toUnique(state, arguments[0]);
+  if (ConstantExpr *cLevel = llvm::dyn_cast<ConstantExpr>(level)) {
+    state.pushDebugLevel(cLevel->getZExtValue());
       return;
-    }
   }
 
   executor.terminateStateOnError(

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -140,8 +140,10 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
   add("__ubsan_handle_divrem_overflow", handleDivRemOverflow, false),
 
   // change debug information
-  add("tracerx_debug_subsumption", handlePushDebugLevel, false),
-  add("tracerx_debug_subsumption_off", handlePushDebugLevel, false),
+  add("tracerx_debug_subsumption", handleDebugSubsumption, false),
+  add("tracerx_debug_subsumption_off", handleDebugSubsumption, false),
+  add("tracerx_debug_state", handleDebugState, false),
+  add("tracerx_debug_state_off", handleDebugStateOff, false),
 
 #undef addDNR
 #undef add
@@ -654,7 +656,7 @@ void SpecialFunctionHandler::handleCheckMemoryAccess(ExecutionState &state,
   }
 }
 
-void SpecialFunctionHandler::handlePushDebugLevel(
+void SpecialFunctionHandler::handleDebugSubsumption(
     ExecutionState &state, KInstruction *target,
     std::vector<ref<Expr> > &arguments) {
   assert(arguments.size() == 1 &&
@@ -662,20 +664,37 @@ void SpecialFunctionHandler::handlePushDebugLevel(
 
   ref<Expr> level = executor.toUnique(state, arguments[0]);
   if (ConstantExpr *cLevel = llvm::dyn_cast<ConstantExpr>(level)) {
-    state.pushDebugLevel(cLevel->getZExtValue());
-      return;
+    state.debugSubsumption(cLevel->getZExtValue());
+    return;
   }
 
   executor.terminateStateOnError(
       state, "push_debug_level requires constant arguments", Executor::User);
 }
 
-void SpecialFunctionHandler::handlePopDebugLevel(
+void SpecialFunctionHandler::handleDebugSubsumptionOff(
     ExecutionState &state, KInstruction *target,
     std::vector<ref<Expr> > &arguments) {
   assert(arguments.size() == 0 &&
          "invalid number of arguments to tracerx_debug_subsumption_off");
-  state.popDebugLevel();
+  state.debugSubsumptionOff();
+}
+
+void
+SpecialFunctionHandler::handleDebugState(ExecutionState &state,
+                                         KInstruction *target,
+                                         std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 0 &&
+         "invalid number of arguments to tracerx_debug_state");
+  state.debugState();
+}
+
+void SpecialFunctionHandler::handleDebugStateOff(
+    ExecutionState &state, KInstruction *target,
+    std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 0 &&
+         "invalid number of arguments to tracerx_debug_state_off");
+  state.debugStateOff();
 }
 
 void SpecialFunctionHandler::handleGetValue(ExecutionState &state,

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -669,6 +669,14 @@ void SpecialFunctionHandler::handlePushDebugLevel(
       state, "push_debug_level requires constant arguments", Executor::User);
 }
 
+void SpecialFunctionHandler::handlePopDebugLevel(
+    ExecutionState &state, KInstruction *target,
+    std::vector<ref<Expr> > &arguments) {
+  assert(arguments.size() == 0 &&
+         "invalid number of arguments to tracerx_pop_debug_level");
+  state.popDebugLevel();
+}
+
 void SpecialFunctionHandler::handleGetValue(ExecutionState &state,
                                             KInstruction *target,
                                             std::vector<ref<Expr> > &arguments) {

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -103,6 +103,7 @@ namespace klee {
     HANDLER(handleAssume);
     HANDLER(handleCalloc);
     HANDLER(handleCheckMemoryAccess);
+    HANDLER(handleDebugSubsumption);
     HANDLER(handleDefineFixedObject);
     HANDLER(handleDelete);    
     HANDLER(handleDeleteArray);

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -120,6 +120,7 @@ namespace klee {
     HANDLER(handleNew);
     HANDLER(handleNewArray);
     HANDLER(handlePreferCex);
+    HANDLER(handlePopDebugLevel);
     HANDLER(handlePosixPreferCex);
     HANDLER(handlePrintExpr);
     HANDLER(handlePrintRange);

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -103,6 +103,10 @@ namespace klee {
     HANDLER(handleAssume);
     HANDLER(handleCalloc);
     HANDLER(handleCheckMemoryAccess);
+    HANDLER(handleDebugState);
+    HANDLER(handleDebugStateOff);
+    HANDLER(handleDebugSubsumption);
+    HANDLER(handleDebugSubsumptionOff);
     HANDLER(handleDefineFixedObject);
     HANDLER(handleDelete);    
     HANDLER(handleDeleteArray);
@@ -120,11 +124,9 @@ namespace klee {
     HANDLER(handleNew);
     HANDLER(handleNewArray);
     HANDLER(handlePreferCex);
-    HANDLER(handlePopDebugLevel);
     HANDLER(handlePosixPreferCex);
     HANDLER(handlePrintExpr);
     HANDLER(handlePrintRange);
-    HANDLER(handlePushDebugLevel);
     HANDLER(handleRange);
     HANDLER(handleRealloc);
     HANDLER(handleReportError);

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -103,7 +103,6 @@ namespace klee {
     HANDLER(handleAssume);
     HANDLER(handleCalloc);
     HANDLER(handleCheckMemoryAccess);
-    HANDLER(handleDebugLevel);
     HANDLER(handleDefineFixedObject);
     HANDLER(handleDelete);    
     HANDLER(handleDeleteArray);
@@ -124,6 +123,7 @@ namespace klee {
     HANDLER(handlePosixPreferCex);
     HANDLER(handlePrintExpr);
     HANDLER(handlePrintRange);
+    HANDLER(handlePushDebugLevel);
     HANDLER(handleRange);
     HANDLER(handleRealloc);
     HANDLER(handleReportError);

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -103,7 +103,7 @@ namespace klee {
     HANDLER(handleAssume);
     HANDLER(handleCalloc);
     HANDLER(handleCheckMemoryAccess);
-    HANDLER(handleDebugSubsumption);
+    HANDLER(handleDebugLevel);
     HANDLER(handleDefineFixedObject);
     HANDLER(handleDelete);    
     HANDLER(handleDeleteArray);

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -328,9 +328,10 @@ void TxTreeGraph::save(std::string dotFileName) {
 PathCondition::PathCondition(ref<Expr> &constraint, Dependency *dependency,
                              llvm::Value *_condition,
                              const std::vector<llvm::Instruction *> &stack,
-                             PathCondition *prev)
+                             PathCondition *prev, int _debugSubsumptionLevel)
     : constraint(constraint), shadowConstraint(constraint), shadowed(false),
-      dependency(dependency), core(false), tail(prev) {
+      dependency(dependency), core(false), tail(prev),
+      debugSubsumptionLevel(_debugSubsumptionLevel) {
   ref<VersionedValue> emptyCondition;
   if (dependency) {
     condition = dependency->getLatestValue(_condition, stack, constraint, true);
@@ -349,7 +350,8 @@ PathCondition *PathCondition::cdr() const { return tail; }
 void PathCondition::setAsCore() {
   // We mark all values to which this constraint depends
   std::string reason = "";
-  if (DebugSubsumption >= 1) {
+  if ((debugSubsumptionLevel > DebugSubsumption ? debugSubsumptionLevel
+                                                : DebugSubsumption) >= 1) {
     llvm::raw_string_ostream stream(reason);
     stream << "path condition [";
     constraint->print(stream);
@@ -958,7 +960,11 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
 bool SubsumptionTableEntry::subsumed(
     TimingSolver *solver, ExecutionState &state, double timeout,
     const std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
-        storedExpressions) {
+        storedExpressions, int debugSubsumptionLevel) {
+
+  if (DebugSubsumption > debugSubsumptionLevel)
+    debugSubsumptionLevel = DebugSubsumption;
+
 #ifdef ENABLE_Z3
   // Tell the solver implementation that we are checking for subsumption for
   // collecting statistics of solver calls.
@@ -966,7 +972,7 @@ bool SubsumptionTableEntry::subsumed(
 
   // Quick check for subsumption in case the interpolant is empty
   if (empty()) {
-    if (DebugSubsumption >= 1) {
+    if (debugSubsumptionLevel >= 1) {
       klee_message("#%lu=>#%lu: Check success due to empty table entry",
                    state.txTreeNode->getNodeSequenceNumber(),
                    nodeSequenceNumber);
@@ -1004,7 +1010,7 @@ bool SubsumptionTableEntry::subsumed(
       // If the current state does not constrain the same base, subsumption
       // fails.
       if (stateConcreteMap.empty() && stateSymbolicMap.empty()) {
-        if (DebugSubsumption >= 1) {
+        if (debugSubsumptionLevel >= 1) {
           klee_message("#%lu=>#%lu: Check failure due to empty state concrete "
                        "and symbolic maps",
                        state.txTreeNode->getNodeSequenceNumber(),
@@ -1022,7 +1028,7 @@ bool SubsumptionTableEntry::subsumed(
         // the current state is incomparable to the stored interpolant,
         // and we therefore fail the subsumption.
         if (!stateConcreteMap.count(it2->first)) {
-          if (DebugSubsumption >= 1) {
+          if (debugSubsumptionLevel >= 1) {
             klee_message("#%lu=>#%lu: Check failure as memory region in the "
                          "table does not "
                          "exist in the state",
@@ -1042,7 +1048,7 @@ bool SubsumptionTableEntry::subsumed(
               stateValue->getExpression()->getWidth()) {
             // We conservatively fail the subsumption in case the sizes do not
             // match.
-            if (DebugSubsumption >= 1) {
+            if (debugSubsumptionLevel >= 1) {
               klee_message("#%lu=>#%lu: Check failure as sizes of stored "
                            "values do not match",
                            state.txTreeNode->getNodeSequenceNumber(),
@@ -1056,7 +1062,7 @@ bool SubsumptionTableEntry::subsumed(
             ref<Expr> boundsCheck =
                 tabledValue->getBoundsCheck(stateValue, bounds);
             if (boundsCheck->isFalse()) {
-              if (DebugSubsumption >= 1) {
+              if (debugSubsumptionLevel >= 1) {
                 klee_message("#%lu=>#%lu: Check failure due to failure in "
                              "memory bounds check",
                              state.txTreeNode->getNodeSequenceNumber(),
@@ -1073,7 +1079,7 @@ bool SubsumptionTableEntry::subsumed(
             res = EqExpr::create(tabledValue->getExpression(),
                                  stateValue->getExpression());
             if (res->isFalse()) {
-              if (DebugSubsumption >= 1) {
+              if (debugSubsumptionLevel >= 1) {
                 std::string msg;
                 llvm::raw_string_ostream stream(msg);
                 tabledValue->getExpression()->print(stream);
@@ -1371,7 +1377,7 @@ bool SubsumptionTableEntry::subsumed(
     } else {
       // Here both the interpolant constraints and state equality
       // constraints are empty, therefore everything gets subsumed
-      if (DebugSubsumption >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message("#%lu=>#%lu: Check success as interpolant is empty",
                      state.txTreeNode->getNodeSequenceNumber(),
                      nodeSequenceNumber);
@@ -1379,7 +1385,7 @@ bool SubsumptionTableEntry::subsumed(
 
       // We build memory bounds interpolants from pointer values
       std::string reason = "";
-      if (DebugSubsumption >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         llvm::raw_string_ostream stream(reason);
         llvm::Instruction *instr = state.pc->inst;
         stream << "interpolating memory bound for subsumption at ";
@@ -1412,7 +1418,7 @@ bool SubsumptionTableEntry::subsumed(
 
     if (!existentials.empty()) {
       ref<Expr> existsExpr = ExistsExpr::create(existentials, query);
-      if (DebugSubsumption >= 2) {
+      if (debugSubsumptionLevel >= 2) {
         klee_message("Before simplification:\n%s",
                      PrettyExpressionBuilder::constructQuery(
                          state.constraints, existsExpr).c_str());
@@ -1423,7 +1429,7 @@ bool SubsumptionTableEntry::subsumed(
     // If query simplification result was false, we quickly fail without calling
     // the solver
     if (query->isFalse()) {
-      if (DebugSubsumption >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message("#%lu=>#%lu: Check failure as consequent is unsatisfiable",
                      state.txTreeNode->getNodeSequenceNumber(),
                      nodeSequenceNumber);
@@ -1434,7 +1440,7 @@ bool SubsumptionTableEntry::subsumed(
     bool success = false;
 
     if (!detectConflictPrimitives(state, query)) {
-      if (DebugSubsumption >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message(
             "#%lu=>#%lu: Check failure as contradictory equalities detected",
             state.txTreeNode->getNodeSequenceNumber(), nodeSequenceNumber);
@@ -1449,7 +1455,7 @@ bool SubsumptionTableEntry::subsumed(
     // method.
     if (!llvm::isa<ConstantExpr>(query)) {
       if (!existentials.empty() && llvm::isa<ExistsExpr>(query)) {
-        if (DebugSubsumption >= 2) {
+        if (debugSubsumptionLevel >= 2) {
           klee_message("Existentials not empty");
         }
 
@@ -1474,7 +1480,7 @@ bool SubsumptionTableEntry::subsumed(
           constraints.addConstraint(
               EqExpr::create(falseExpr, query->getKid(0)));
 
-          if (DebugSubsumption >= 2) {
+          if (debugSubsumptionLevel >= 2) {
             klee_message("Querying for satisfiability check:\n%s",
                          PrettyExpressionBuilder::constructQuery(
                              constraints, falseExpr).c_str());
@@ -1483,7 +1489,7 @@ bool SubsumptionTableEntry::subsumed(
           success = z3solver->getValue(Query(constraints, falseExpr), tmpExpr);
           result = success ? Solver::True : Solver::Unknown;
         } else {
-          if (DebugSubsumption >= 2) {
+          if (debugSubsumptionLevel >= 2) {
             klee_message("Querying for subsumption check:\n%s",
                          PrettyExpressionBuilder::constructQuery(
                              state.constraints, query).c_str());
@@ -1496,7 +1502,7 @@ bool SubsumptionTableEntry::subsumed(
         z3solver->setCoreSolverTimeout(0);
 
       } else {
-        if (DebugSubsumption >= 2) {
+        if (debugSubsumptionLevel >= 2) {
           klee_message("Querying for subsumption check:\n%s",
                        PrettyExpressionBuilder::constructQuery(
                            state.constraints, query).c_str());
@@ -1510,7 +1516,7 @@ bool SubsumptionTableEntry::subsumed(
     } else {
       // query is a constant expression
       if (query->isTrue()) {
-        if (DebugSubsumption >= 1) {
+        if (debugSubsumptionLevel >= 1) {
           klee_message("#%lu=>#%lu: Check success as query is true",
                        state.txTreeNode->getNodeSequenceNumber(),
                        nodeSequenceNumber);
@@ -1519,7 +1525,7 @@ bool SubsumptionTableEntry::subsumed(
         if (!NoBoundInterpolation && !ExactAddressInterpolant) {
           // We build memory bounds interpolants from pointer values
           std::string reason = "";
-          if (DebugSubsumption >= 1) {
+          if (debugSubsumptionLevel >= 1) {
             llvm::raw_string_ostream stream(reason);
             llvm::Instruction *instr = state.pc->inst;
             stream << "interpolating memory bound for subsumption at ";
@@ -1548,7 +1554,7 @@ bool SubsumptionTableEntry::subsumed(
         }
         return true;
       }
-      if (DebugSubsumption >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message("#%lu=>#%lu: Check failure as query is non-true",
                      state.txTreeNode->getNodeSequenceNumber(),
                      nodeSequenceNumber);
@@ -1562,7 +1568,7 @@ bool SubsumptionTableEntry::subsumed(
 
       // State subsumed, we mark needed constraints on the
       // path condition.
-      if (DebugSubsumption >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message("#%lu=>#%lu: Check success as solver decided validity",
                      state.txTreeNode->getNodeSequenceNumber(),
                      nodeSequenceNumber);
@@ -1574,7 +1580,7 @@ bool SubsumptionTableEntry::subsumed(
       if (!NoBoundInterpolation && !ExactAddressInterpolant) {
         // We build memory bounds interpolants from pointer values
         std::string reason = "";
-        if (DebugSubsumption >= 1) {
+        if (debugSubsumptionLevel >= 1) {
           llvm::raw_string_ostream stream(reason);
           llvm::Instruction *instr = state.pc->inst;
           stream << "interpolating memory bound for subsumption at ";
@@ -1613,7 +1619,7 @@ bool SubsumptionTableEntry::subsumed(
     if (z3solver)
       delete z3solver;
 
-    if (DebugSubsumption >= 1) {
+    if (debugSubsumptionLevel >= 1) {
       klee_message(
           "#%lu=>#%lu: Check failure as solver did not decide validity",
           state.txTreeNode->getNodeSequenceNumber(), nodeSequenceNumber);
@@ -1902,14 +1908,17 @@ void SubsumptionTable::insert(uintptr_t id,
 }
 
 bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
-                             double timeout) {
+                             double timeout, int debugSubsumptionLevel) {
   StackIndexedTable *subTable = 0;
   TxTreeNode *txTreeNode = state.txTreeNode;
+
+  if (DebugSubsumption > debugSubsumptionLevel)
+    debugSubsumptionLevel = DebugSubsumption;
 
   std::map<uintptr_t, StackIndexedTable *>::iterator it =
       instance.find(state.txTreeNode->getProgramPoint());
   if (it == instance.end()) {
-    if (DebugSubsumption >= 1) {
+    if (debugSubsumptionLevel >= 1) {
       klee_message(
           "#%lu: Check failure due to control point not found in table",
           state.txTreeNode->getNodeSequenceNumber());
@@ -1922,7 +1931,7 @@ bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
   std::pair<EntryIterator, EntryIterator> iterPair =
       subTable->find(txTreeNode->entryCallStack, found);
   if (!found) {
-    if (DebugSubsumption >= 1) {
+    if (debugSubsumptionLevel >= 1) {
       klee_message("#%lu: Check failure due to entry not found",
                    state.txTreeNode->getNodeSequenceNumber());
     }
@@ -1939,7 +1948,8 @@ bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
     // the successful subsumption mostly happen in the newest entry.
     for (EntryIterator it = iterPair.first, ie = iterPair.second; it != ie;
          ++it) {
-      if ((*it)->subsumed(solver, state, timeout, storedExpressions)) {
+      if ((*it)->subsumed(solver, state, timeout, storedExpressions,
+                          debugSubsumptionLevel)) {
         // We mark as subsumed such that the node will not be
         // stored into table (the table already contains a more
         // general entry).
@@ -2067,11 +2077,15 @@ bool TxTree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
                                state.txTreeNode->getProgramPoint())
     return false;
 
-  if (DebugSubsumption >= 2) {
+  int debugLevel = currentINode->debugSubsumptionLevel;
+  if (DebugSubsumption > debugLevel)
+    debugLevel = DebugSubsumption;
+
+  if (debugLevel >= 2) {
     klee_message("Subsumption check for Node #%lu, Program Point %lu",
                  state.txTreeNode->getNodeSequenceNumber(),
                  state.txTreeNode->getProgramPoint());
-  } else if (DebugSubsumption >= 1) {
+  } else if (debugLevel >= 1) {
     klee_message("Subsumption check for Node #%lu",
                  state.txTreeNode->getNodeSequenceNumber());
   }
@@ -2080,7 +2094,7 @@ bool TxTree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
 
   TimerStatIncrementer t(subsumptionCheckTime);
 
-  return SubsumptionTable::check(solver, state, timeout);
+  return SubsumptionTable::check(solver, state, timeout, debugLevel);
 #endif
   return false;
 }
@@ -2093,6 +2107,11 @@ void TxTree::setCurrentINode(ExecutionState &state) {
 }
 
 void TxTree::remove(TxTreeNode *node) {
+  int debugLevel = node->debugSubsumptionLevel;
+
+  if (DebugSubsumption > debugLevel)
+    debugLevel = DebugSubsumption;
+
 #ifdef ENABLE_Z3
   TimerStatIncrementer t(removeTime);
   assert(!node->left && !node->right);
@@ -2102,10 +2121,10 @@ void TxTree::remove(TxTreeNode *node) {
     // As the node is about to be deleted, it must have been completely
     // traversed, hence the correct time to table the interpolant.
     if (!node->isSubsumed && node->storable) {
-      if (DebugSubsumption >= 2) {
+      if (debugLevel >= 2) {
         klee_message("Storing entry for Node #%lu, Program Point %lu",
                      node->getNodeSequenceNumber(), node->getProgramPoint());
-      } else if (DebugSubsumption >= 1) {
+      } else if (debugLevel >= 1) {
         klee_message("Storing entry for Node #%lu",
                      node->getNodeSequenceNumber());
       }
@@ -2117,7 +2136,7 @@ void TxTree::remove(TxTreeNode *node) {
 
       TxTreeGraph::addTableEntryMapping(node, entry);
 
-      if (DebugSubsumption >= 2) {
+      if (debugLevel >= 2) {
         std::string msg;
         llvm::raw_string_ostream out(msg);
         entry->print(out);
@@ -2153,12 +2172,16 @@ void TxTree::markPathCondition(ExecutionState &state, TimingSolver *solver) {
   TimerStatIncrementer t(markPathConditionTime);
   const std::vector<ref<Expr> > &unsatCore = solver->getUnsatCore();
 
+  int debugLevel = state.txTreeNode->debugSubsumptionLevel;
+  if (DebugSubsumption > debugLevel)
+    debugLevel = DebugSubsumption;
+
   llvm::BranchInst *binst =
       llvm::dyn_cast<llvm::BranchInst>(state.prevPC->inst);
   if (binst) {
     ref<Expr> unknownExpression;
     std::string reason = "";
-    if (DebugSubsumption >= 1) {
+    if (debugLevel >= 1) {
       llvm::raw_string_ostream stream(reason);
       stream << "branch infeasibility [";
       if (binst->getParent()->getParent()) {
@@ -2325,7 +2348,8 @@ TxTreeNode::TxTreeNode(TxTreeNode *_parent, llvm::DataLayout *_targetData)
       nodeSequenceNumber(nextNodeSequenceNumber++), storable(true),
       graph(_parent ? _parent->graph : 0),
       instructionsDepth(_parent ? _parent->instructionsDepth : 0),
-      targetData(_targetData), isSubsumed(false) {
+      targetData(_targetData), isSubsumed(false),
+      debugSubsumptionLevel(_parent ? _parent->debugSubsumptionLevel : 0) {
 
   pathCondition = 0;
   if (_parent) {
@@ -2335,7 +2359,8 @@ TxTreeNode::TxTreeNode(TxTreeNode *_parent, llvm::DataLayout *_targetData)
   }
 
   // Inherit the abstract dependency or NULL
-  dependency = new Dependency(_parent ? _parent->dependency : 0, _targetData);
+  dependency = new Dependency(_parent ? _parent->dependency : 0, _targetData,
+                              _parent ? _parent->debugSubsumptionLevel : 0);
 }
 
 TxTreeNode::~TxTreeNode() {
@@ -2363,8 +2388,9 @@ TxTreeNode::getInterpolant(std::set<const Array *> &replacements) const {
 
 void TxTreeNode::addConstraint(ref<Expr> &constraint, llvm::Value *condition) {
   TimerStatIncrementer t(addConstraintTime);
-  pathCondition = new PathCondition(constraint, dependency, condition,
-                                    callStack, pathCondition);
+  pathCondition =
+      new PathCondition(constraint, dependency, condition, callStack,
+                        pathCondition, debugSubsumptionLevel);
   graph->addPathCondition(this, pathCondition, constraint);
 }
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2068,7 +2068,7 @@ bool TxTree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
                                state.txTreeNode->getProgramPoint())
     return false;
 
-  int debugLevel = currentINode->dependency->debugLevel;
+  int debugLevel = currentINode->dependency->debugLevel.top();
 
   if (debugLevel >= 2) {
     klee_message("Subsumption check for Node #%lu, Program Point %lu",
@@ -2096,7 +2096,7 @@ void TxTree::setCurrentINode(ExecutionState &state) {
 }
 
 void TxTree::remove(TxTreeNode *node) {
-  int debugLevel = currentINode->dependency->debugLevel;
+  int debugLevel = currentINode->dependency->debugLevel.top();
 
 #ifdef ENABLE_Z3
   TimerStatIncrementer t(removeTime);
@@ -2158,7 +2158,7 @@ void TxTree::markPathCondition(ExecutionState &state, TimingSolver *solver) {
   TimerStatIncrementer t(markPathConditionTime);
   const std::vector<ref<Expr> > &unsatCore = solver->getUnsatCore();
 
-  int debugLevel = currentINode->dependency->debugLevel;
+  int debugLevel = currentINode->dependency->debugLevel.top();
 
   llvm::BranchInst *binst =
       llvm::dyn_cast<llvm::BranchInst>(state.prevPC->inst);
@@ -2462,7 +2462,7 @@ TxTreeNode::unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore) {
     // because constraints are not properly added at state merge.
     PathCondition *cond = markerMap[it1->get()];
     if (cond)
-      cond->setAsCore(dependency->debugLevel);
+      cond->setAsCore(dependency->debugLevel.top());
   }
 }
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -346,10 +346,10 @@ ref<Expr> PathCondition::car() const { return constraint; }
 
 PathCondition *PathCondition::cdr() const { return tail; }
 
-void PathCondition::setAsCore(int debugLevel) {
+void PathCondition::setAsCore(int debugSubsumptionLevel) {
   // We mark all values to which this constraint depends
   std::string reason = "";
-  if (debugLevel >= 1) {
+  if (debugSubsumptionLevel >= 1) {
     llvm::raw_string_ostream stream(reason);
     stream << "path condition [";
     constraint->print(stream);
@@ -958,7 +958,7 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
 bool SubsumptionTableEntry::subsumed(
     TimingSolver *solver, ExecutionState &state, double timeout,
     const std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore>
-        storedExpressions, int debugLevel) {
+        storedExpressions, int debugSubsumptionLevel) {
 #ifdef ENABLE_Z3
   // Tell the solver implementation that we are checking for subsumption for
   // collecting statistics of solver calls.
@@ -966,7 +966,7 @@ bool SubsumptionTableEntry::subsumed(
 
   // Quick check for subsumption in case the interpolant is empty
   if (empty()) {
-    if (debugLevel >= 1) {
+    if (debugSubsumptionLevel >= 1) {
       klee_message("#%lu=>#%lu: Check success due to empty table entry",
                    state.txTreeNode->getNodeSequenceNumber(),
                    nodeSequenceNumber);
@@ -1004,7 +1004,7 @@ bool SubsumptionTableEntry::subsumed(
       // If the current state does not constrain the same base, subsumption
       // fails.
       if (stateConcreteMap.empty() && stateSymbolicMap.empty()) {
-        if (debugLevel >= 1) {
+        if (debugSubsumptionLevel >= 1) {
           klee_message("#%lu=>#%lu: Check failure due to empty state concrete "
                        "and symbolic maps",
                        state.txTreeNode->getNodeSequenceNumber(),
@@ -1022,7 +1022,7 @@ bool SubsumptionTableEntry::subsumed(
         // the current state is incomparable to the stored interpolant,
         // and we therefore fail the subsumption.
         if (!stateConcreteMap.count(it2->first)) {
-          if (debugLevel >= 1) {
+          if (debugSubsumptionLevel >= 1) {
             klee_message("#%lu=>#%lu: Check failure as memory region in the "
                          "table does not "
                          "exist in the state",
@@ -1042,7 +1042,7 @@ bool SubsumptionTableEntry::subsumed(
               stateValue->getExpression()->getWidth()) {
             // We conservatively fail the subsumption in case the sizes do not
             // match.
-            if (debugLevel >= 1) {
+            if (debugSubsumptionLevel >= 1) {
               klee_message("#%lu=>#%lu: Check failure as sizes of stored "
                            "values do not match",
                            state.txTreeNode->getNodeSequenceNumber(),
@@ -1054,9 +1054,9 @@ bool SubsumptionTableEntry::subsumed(
                      tabledValue->useBound()) {
             std::set<ref<Expr> > bounds;
             ref<Expr> boundsCheck =
-                tabledValue->getBoundsCheck(stateValue, bounds, debugLevel);
+                tabledValue->getBoundsCheck(stateValue, bounds, debugSubsumptionLevel);
             if (boundsCheck->isFalse()) {
-              if (debugLevel >= 1) {
+              if (debugSubsumptionLevel >= 1) {
                 klee_message("#%lu=>#%lu: Check failure due to failure in "
                              "memory bounds check",
                              state.txTreeNode->getNodeSequenceNumber(),
@@ -1073,7 +1073,7 @@ bool SubsumptionTableEntry::subsumed(
             res = EqExpr::create(tabledValue->getExpression(),
                                  stateValue->getExpression());
             if (res->isFalse()) {
-              if (debugLevel >= 1) {
+              if (debugSubsumptionLevel >= 1) {
                 std::string msg;
                 llvm::raw_string_ostream stream(msg);
                 tabledValue->getExpression()->print(stream);
@@ -1123,7 +1123,7 @@ bool SubsumptionTableEntry::subsumed(
                        tabledValue->useBound()) {
               std::set<ref<Expr> > bounds;
               ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
-                  stateSymbolicValue, bounds, debugLevel);
+                  stateSymbolicValue, bounds, debugSubsumptionLevel);
 
               if (!boundsCheck->isTrue()) {
                 newTerm = EqExpr::create(
@@ -1240,7 +1240,7 @@ bool SubsumptionTableEntry::subsumed(
                      tabledValue->useBound()) {
             std::set<ref<Expr> > bounds;
             ref<Expr> boundsCheck =
-                tabledValue->getBoundsCheck(stateValue, bounds, debugLevel);
+                tabledValue->getBoundsCheck(stateValue, bounds, debugSubsumptionLevel);
 
             if (!boundsCheck->isTrue()) {
               newTerm = EqExpr::create(
@@ -1303,7 +1303,7 @@ bool SubsumptionTableEntry::subsumed(
                      tabledValue->useBound()) {
             std::set<ref<Expr> > bounds;
             ref<Expr> boundsCheck =
-                tabledValue->getBoundsCheck(stateValue, bounds, debugLevel);
+                tabledValue->getBoundsCheck(stateValue, bounds, debugSubsumptionLevel);
 
             if (!boundsCheck->isTrue()) {
               newTerm = EqExpr::create(
@@ -1371,7 +1371,7 @@ bool SubsumptionTableEntry::subsumed(
     } else {
       // Here both the interpolant constraints and state equality
       // constraints are empty, therefore everything gets subsumed
-      if (debugLevel >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message("#%lu=>#%lu: Check success as interpolant is empty",
                      state.txTreeNode->getNodeSequenceNumber(),
                      nodeSequenceNumber);
@@ -1379,7 +1379,7 @@ bool SubsumptionTableEntry::subsumed(
 
       // We build memory bounds interpolants from pointer values
       std::string reason = "";
-      if (debugLevel >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         llvm::raw_string_ostream stream(reason);
         llvm::Instruction *instr = state.pc->inst;
         stream << "interpolating memory bound for subsumption at ";
@@ -1412,7 +1412,7 @@ bool SubsumptionTableEntry::subsumed(
 
     if (!existentials.empty()) {
       ref<Expr> existsExpr = ExistsExpr::create(existentials, query);
-      if (debugLevel >= 2) {
+      if (debugSubsumptionLevel >= 2) {
         klee_message("Before simplification:\n%s",
                      PrettyExpressionBuilder::constructQuery(
                          state.constraints, existsExpr).c_str());
@@ -1423,7 +1423,7 @@ bool SubsumptionTableEntry::subsumed(
     // If query simplification result was false, we quickly fail without calling
     // the solver
     if (query->isFalse()) {
-      if (debugLevel >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message("#%lu=>#%lu: Check failure as consequent is unsatisfiable",
                      state.txTreeNode->getNodeSequenceNumber(),
                      nodeSequenceNumber);
@@ -1434,7 +1434,7 @@ bool SubsumptionTableEntry::subsumed(
     bool success = false;
 
     if (!detectConflictPrimitives(state, query)) {
-      if (debugLevel >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message(
             "#%lu=>#%lu: Check failure as contradictory equalities detected",
             state.txTreeNode->getNodeSequenceNumber(), nodeSequenceNumber);
@@ -1449,7 +1449,7 @@ bool SubsumptionTableEntry::subsumed(
     // method.
     if (!llvm::isa<ConstantExpr>(query)) {
       if (!existentials.empty() && llvm::isa<ExistsExpr>(query)) {
-        if (debugLevel >= 2) {
+        if (debugSubsumptionLevel >= 2) {
           klee_message("Existentials not empty");
         }
 
@@ -1474,7 +1474,7 @@ bool SubsumptionTableEntry::subsumed(
           constraints.addConstraint(
               EqExpr::create(falseExpr, query->getKid(0)));
 
-          if (debugLevel >= 2) {
+          if (debugSubsumptionLevel >= 2) {
             klee_message("Querying for satisfiability check:\n%s",
                          PrettyExpressionBuilder::constructQuery(
                              constraints, falseExpr).c_str());
@@ -1483,7 +1483,7 @@ bool SubsumptionTableEntry::subsumed(
           success = z3solver->getValue(Query(constraints, falseExpr), tmpExpr);
           result = success ? Solver::True : Solver::Unknown;
         } else {
-          if (debugLevel >= 2) {
+          if (debugSubsumptionLevel >= 2) {
             klee_message("Querying for subsumption check:\n%s",
                          PrettyExpressionBuilder::constructQuery(
                              state.constraints, query).c_str());
@@ -1496,7 +1496,7 @@ bool SubsumptionTableEntry::subsumed(
         z3solver->setCoreSolverTimeout(0);
 
       } else {
-        if (debugLevel >= 2) {
+        if (debugSubsumptionLevel >= 2) {
           klee_message("Querying for subsumption check:\n%s",
                        PrettyExpressionBuilder::constructQuery(
                            state.constraints, query).c_str());
@@ -1510,7 +1510,7 @@ bool SubsumptionTableEntry::subsumed(
     } else {
       // query is a constant expression
       if (query->isTrue()) {
-        if (debugLevel >= 1) {
+        if (debugSubsumptionLevel >= 1) {
           klee_message("#%lu=>#%lu: Check success as query is true",
                        state.txTreeNode->getNodeSequenceNumber(),
                        nodeSequenceNumber);
@@ -1519,7 +1519,7 @@ bool SubsumptionTableEntry::subsumed(
         if (!NoBoundInterpolation && !ExactAddressInterpolant) {
           // We build memory bounds interpolants from pointer values
           std::string reason = "";
-          if (debugLevel >= 1) {
+          if (debugSubsumptionLevel >= 1) {
             llvm::raw_string_ostream stream(reason);
             llvm::Instruction *instr = state.pc->inst;
             stream << "interpolating memory bound for subsumption at ";
@@ -1548,7 +1548,7 @@ bool SubsumptionTableEntry::subsumed(
         }
         return true;
       }
-      if (debugLevel >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message("#%lu=>#%lu: Check failure as query is non-true",
                      state.txTreeNode->getNodeSequenceNumber(),
                      nodeSequenceNumber);
@@ -1562,7 +1562,7 @@ bool SubsumptionTableEntry::subsumed(
 
       // State subsumed, we mark needed constraints on the
       // path condition.
-      if (debugLevel >= 1) {
+      if (debugSubsumptionLevel >= 1) {
         klee_message("#%lu=>#%lu: Check success as solver decided validity",
                      state.txTreeNode->getNodeSequenceNumber(),
                      nodeSequenceNumber);
@@ -1574,7 +1574,7 @@ bool SubsumptionTableEntry::subsumed(
       if (!NoBoundInterpolation && !ExactAddressInterpolant) {
         // We build memory bounds interpolants from pointer values
         std::string reason = "";
-        if (debugLevel >= 1) {
+        if (debugSubsumptionLevel >= 1) {
           llvm::raw_string_ostream stream(reason);
           llvm::Instruction *instr = state.pc->inst;
           stream << "interpolating memory bound for subsumption at ";
@@ -1613,7 +1613,7 @@ bool SubsumptionTableEntry::subsumed(
     if (z3solver)
       delete z3solver;
 
-    if (debugLevel >= 1) {
+    if (debugSubsumptionLevel >= 1) {
       klee_message(
           "#%lu=>#%lu: Check failure as solver did not decide validity",
           state.txTreeNode->getNodeSequenceNumber(), nodeSequenceNumber);
@@ -1902,14 +1902,14 @@ void SubsumptionTable::insert(uintptr_t id,
 }
 
 bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
-                             double timeout, int debugLevel) {
+                             double timeout, int debugSubsumptionLevel) {
   StackIndexedTable *subTable = 0;
   TxTreeNode *txTreeNode = state.txTreeNode;
 
   std::map<uintptr_t, StackIndexedTable *>::iterator it =
       instance.find(state.txTreeNode->getProgramPoint());
   if (it == instance.end()) {
-    if (debugLevel >= 1) {
+    if (debugSubsumptionLevel >= 1) {
       klee_message(
           "#%lu: Check failure due to control point not found in table",
           state.txTreeNode->getNodeSequenceNumber());
@@ -1922,7 +1922,7 @@ bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
   std::pair<EntryIterator, EntryIterator> iterPair =
       subTable->find(txTreeNode->entryCallStack, found);
   if (!found) {
-    if (debugLevel >= 1) {
+    if (debugSubsumptionLevel >= 1) {
       klee_message("#%lu: Check failure due to entry not found",
                    state.txTreeNode->getNodeSequenceNumber());
     }
@@ -1940,7 +1940,7 @@ bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
     for (EntryIterator it = iterPair.first, ie = iterPair.second; it != ie;
          ++it) {
       if ((*it)->subsumed(solver, state, timeout, storedExpressions,
-                          debugLevel)) {
+                          debugSubsumptionLevel)) {
         // We mark as subsumed such that the node will not be
         // stored into table (the table already contains a more
         // general entry).
@@ -2068,13 +2068,13 @@ bool TxTree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
                                state.txTreeNode->getProgramPoint())
     return false;
 
-  int debugLevel = currentINode->dependency->debugLevel.top();
+  int debugSubsumptionLevel = currentINode->dependency->debugSubsumptionLevel.top();
 
-  if (debugLevel >= 2) {
+  if (debugSubsumptionLevel >= 2) {
     klee_message("Subsumption check for Node #%lu, Program Point %lu",
                  state.txTreeNode->getNodeSequenceNumber(),
                  state.txTreeNode->getProgramPoint());
-  } else if (debugLevel >= 1) {
+  } else if (debugSubsumptionLevel >= 1) {
     klee_message("Subsumption check for Node #%lu",
                  state.txTreeNode->getNodeSequenceNumber());
   }
@@ -2083,7 +2083,7 @@ bool TxTree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
 
   TimerStatIncrementer t(subsumptionCheckTime);
 
-  return SubsumptionTable::check(solver, state, timeout, debugLevel);
+  return SubsumptionTable::check(solver, state, timeout, debugSubsumptionLevel);
 #endif
   return false;
 }
@@ -2096,7 +2096,7 @@ void TxTree::setCurrentINode(ExecutionState &state) {
 }
 
 void TxTree::remove(TxTreeNode *node) {
-  int debugLevel = currentINode->dependency->debugLevel.top();
+  int debugSubsumptionLevel = currentINode->dependency->debugSubsumptionLevel.top();
 
 #ifdef ENABLE_Z3
   TimerStatIncrementer t(removeTime);
@@ -2107,10 +2107,10 @@ void TxTree::remove(TxTreeNode *node) {
     // As the node is about to be deleted, it must have been completely
     // traversed, hence the correct time to table the interpolant.
     if (!node->isSubsumed && node->storable) {
-      if (debugLevel >= 2) {
+      if (debugSubsumptionLevel >= 2) {
         klee_message("Storing entry for Node #%lu, Program Point %lu",
                      node->getNodeSequenceNumber(), node->getProgramPoint());
-      } else if (debugLevel >= 1) {
+      } else if (debugSubsumptionLevel >= 1) {
         klee_message("Storing entry for Node #%lu",
                      node->getNodeSequenceNumber());
       }
@@ -2122,7 +2122,7 @@ void TxTree::remove(TxTreeNode *node) {
 
       TxTreeGraph::addTableEntryMapping(node, entry);
 
-      if (debugLevel >= 2) {
+      if (debugSubsumptionLevel >= 2) {
         std::string msg;
         llvm::raw_string_ostream out(msg);
         entry->print(out);
@@ -2158,14 +2158,14 @@ void TxTree::markPathCondition(ExecutionState &state, TimingSolver *solver) {
   TimerStatIncrementer t(markPathConditionTime);
   const std::vector<ref<Expr> > &unsatCore = solver->getUnsatCore();
 
-  int debugLevel = currentINode->dependency->debugLevel.top();
+  int debugSubsumptionLevel = currentINode->dependency->debugSubsumptionLevel.top();
 
   llvm::BranchInst *binst =
       llvm::dyn_cast<llvm::BranchInst>(state.prevPC->inst);
   if (binst) {
     ref<Expr> unknownExpression;
     std::string reason = "";
-    if (debugLevel >= 1) {
+    if (debugSubsumptionLevel >= 1) {
       llvm::raw_string_ostream stream(reason);
       stream << "branch infeasibility [";
       if (binst->getParent()->getParent()) {
@@ -2192,7 +2192,7 @@ void TxTree::markPathCondition(ExecutionState &state, TimingSolver *solver) {
          it != ie; ++it) {
       for (; pc != 0; pc = pc->cdr()) {
         if (pc->car().compare(it->get()) == 0) {
-          pc->setAsCore(debugLevel);
+          pc->setAsCore(debugSubsumptionLevel);
           pc = pc->cdr();
           break;
         }
@@ -2462,7 +2462,7 @@ TxTreeNode::unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore) {
     // because constraints are not properly added at state merge.
     PathCondition *cond = markerMap[it1->get()];
     if (cond)
-      cond->setAsCore(dependency->debugLevel.top());
+      cond->setAsCore(dependency->debugSubsumptionLevel.top());
   }
 }
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2068,7 +2068,7 @@ bool TxTree::subsumptionCheck(TimingSolver *solver, ExecutionState &state,
                                state.txTreeNode->getProgramPoint())
     return false;
 
-  int debugSubsumptionLevel = currentINode->dependency->debugSubsumptionLevel.top();
+  int debugSubsumptionLevel = currentINode->dependency->debugSubsumptionLevel;
 
   if (debugSubsumptionLevel >= 2) {
     klee_message("Subsumption check for Node #%lu, Program Point %lu",
@@ -2096,7 +2096,7 @@ void TxTree::setCurrentINode(ExecutionState &state) {
 }
 
 void TxTree::remove(TxTreeNode *node) {
-  int debugSubsumptionLevel = currentINode->dependency->debugSubsumptionLevel.top();
+  int debugSubsumptionLevel = currentINode->dependency->debugSubsumptionLevel;
 
 #ifdef ENABLE_Z3
   TimerStatIncrementer t(removeTime);
@@ -2158,7 +2158,7 @@ void TxTree::markPathCondition(ExecutionState &state, TimingSolver *solver) {
   TimerStatIncrementer t(markPathConditionTime);
   const std::vector<ref<Expr> > &unsatCore = solver->getUnsatCore();
 
-  int debugSubsumptionLevel = currentINode->dependency->debugSubsumptionLevel.top();
+  int debugSubsumptionLevel = currentINode->dependency->debugSubsumptionLevel;
 
   llvm::BranchInst *binst =
       llvm::dyn_cast<llvm::BranchInst>(state.prevPC->inst);
@@ -2462,7 +2462,7 @@ TxTreeNode::unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore) {
     // because constraints are not properly added at state merge.
     PathCondition *cond = markerMap[it1->get()];
     if (cond)
-      cond->setAsCore(dependency->debugSubsumptionLevel.top());
+      cond->setAsCore(dependency->debugSubsumptionLevel);
   }
 }
 

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -926,6 +926,9 @@ public:
 
   /// \brief Retrieve subsumption statistics result in std::string format
   static std::string getInterpolationStat();
+
+  /// \brief Get the current debug state flag
+  bool getDebugState() { return currentINode->dependency->debugState; }
 };
 }
 #endif /* TXTREE_H_ */

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -201,11 +201,15 @@ class PathCondition {
   /// \brief Previous path condition
   PathCondition *tail;
 
+  /// \brief This is for dynamic setting up of subsumption-related debug
+  /// messages.
+  int debugSubsumptionLevel;
+
 public:
   PathCondition(ref<Expr> &constraint, Dependency *dependency,
                 llvm::Value *condition,
                 const std::vector<llvm::Instruction *> &stack,
-                PathCondition *prev);
+                PathCondition *prev, int _debugSubsumptionLevel);
 
   ~PathCondition();
 
@@ -284,8 +288,8 @@ public:
                      const std::vector<llvm::Instruction *> &stack,
                      SubsumptionTableEntry *entry);
 
-  static bool check(TimingSolver *solver, ExecutionState &state,
-                    double timeout);
+  static bool check(TimingSolver *solver, ExecutionState &state, double timeout,
+                    int debugSubsumptionLevel);
 
   static void clear();
 
@@ -459,9 +463,10 @@ public:
 
   ~SubsumptionTableEntry();
 
-  bool subsumed(
-      TimingSolver *solver, ExecutionState &state, double timeout,
-      std::pair<Dependency::ConcreteStore, Dependency::SymbolicStore> const);
+  bool subsumed(TimingSolver *solver, ExecutionState &state, double timeout,
+                const std::pair<Dependency::ConcreteStore,
+                                Dependency::SymbolicStore> storedExpressions,
+                int debugSubsumptionLevel);
 
   /// Tests if the argument is a variable. A variable here is defined to be
   /// either a symbolic concatenation or a symbolic read. A concatenation in
@@ -562,6 +567,10 @@ public:
 
   /// \brief The current call stack
   std::vector<llvm::Instruction *> callStack;
+
+  /// \brief This is for dynamic setting up of subsumption-related debug
+  /// messages.
+  int debugSubsumptionLevel;
 
 private:
   void setProgramPoint(llvm::Instruction *instr) {

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -213,7 +213,7 @@ public:
 
   PathCondition *cdr() const;
 
-  void setAsCore(int debugLevel);
+  void setAsCore(int debugSubsumptionLevel);
 
   bool isCore() const;
 
@@ -285,7 +285,7 @@ public:
                      SubsumptionTableEntry *entry);
 
   static bool check(TimingSolver *solver, ExecutionState &state, double timeout,
-                    int debugLevel);
+                    int debugSubsumptionLevel);
 
   static void clear();
 
@@ -462,7 +462,7 @@ public:
   bool subsumed(TimingSolver *solver, ExecutionState &state, double timeout,
                 const std::pair<Dependency::ConcreteStore,
                                 Dependency::SymbolicStore> storedExpressions,
-                int debugLevel);
+                int debugSubsumptionLevel);
 
   /// Tests if the argument is a variable. A variable here is defined to be
   /// either a symbolic concatenation or a symbolic read. A concatenation in

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -201,15 +201,14 @@ class PathCondition {
   /// \brief Previous path condition
   PathCondition *tail;
 
-  /// \brief This is for dynamic setting up of subsumption-related debug
-  /// messages.
-  int debugSubsumptionLevel;
+  /// \brief This is for dynamic setting up of debug messages.
+  int debugLevel;
 
 public:
   PathCondition(ref<Expr> &constraint, Dependency *dependency,
                 llvm::Value *condition,
                 const std::vector<llvm::Instruction *> &stack,
-                PathCondition *prev, int _debugSubsumptionLevel);
+                PathCondition *prev, int _debugLevel);
 
   ~PathCondition();
 
@@ -289,7 +288,7 @@ public:
                      SubsumptionTableEntry *entry);
 
   static bool check(TimingSolver *solver, ExecutionState &state, double timeout,
-                    int debugSubsumptionLevel);
+                    int debugLevel);
 
   static void clear();
 
@@ -466,7 +465,7 @@ public:
   bool subsumed(TimingSolver *solver, ExecutionState &state, double timeout,
                 const std::pair<Dependency::ConcreteStore,
                                 Dependency::SymbolicStore> storedExpressions,
-                int debugSubsumptionLevel);
+                int debugLevel);
 
   /// Tests if the argument is a variable. A variable here is defined to be
   /// either a symbolic concatenation or a symbolic read. A concatenation in
@@ -568,9 +567,8 @@ public:
   /// \brief The current call stack
   std::vector<llvm::Instruction *> callStack;
 
-  /// \brief This is for dynamic setting up of subsumption-related debug
-  /// messages.
-  int debugSubsumptionLevel;
+  /// \brief This is for dynamic setting up of debug messages.
+  int debugLevel;
 
 private:
   void setProgramPoint(llvm::Instruction *instr) {

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -201,14 +201,11 @@ class PathCondition {
   /// \brief Previous path condition
   PathCondition *tail;
 
-  /// \brief This is for dynamic setting up of debug messages.
-  int debugLevel;
-
 public:
   PathCondition(ref<Expr> &constraint, Dependency *dependency,
                 llvm::Value *condition,
                 const std::vector<llvm::Instruction *> &stack,
-                PathCondition *prev, int _debugLevel);
+                PathCondition *prev);
 
   ~PathCondition();
 
@@ -216,7 +213,7 @@ public:
 
   PathCondition *cdr() const;
 
-  void setAsCore();
+  void setAsCore(int debugLevel);
 
   bool isCore() const;
 
@@ -566,9 +563,6 @@ public:
 
   /// \brief The current call stack
   std::vector<llvm::Instruction *> callStack;
-
-  /// \brief This is for dynamic setting up of debug messages.
-  int debugLevel;
 
 private:
   void setProgramPoint(llvm::Instruction *instr) {

--- a/runtime/Runtest/intrinsics.c
+++ b/runtime/Runtest/intrinsics.c
@@ -145,7 +145,7 @@ void klee_print_expr(const char *msg, ...) { }
 void klee_set_forking(unsigned enable) { }
 
 /* Change debug level */
-void tracerx_push_debug_level(uint64_t level) {}
+void tracerx_debug_subsumption(uint64_t level) {}
 
 /* Reset debug level to previous value */
-void tracerx_pop_debug_level() {}
+void tracerx_debug_subsumption_off() {}

--- a/runtime/Runtest/intrinsics.c
+++ b/runtime/Runtest/intrinsics.c
@@ -144,8 +144,14 @@ void klee_print_expr(const char *msg, ...) { }
 
 void klee_set_forking(unsigned enable) { }
 
-/* Change debug level */
+/* Change subsumption-related debug level */
 void tracerx_debug_subsumption(uint64_t level) {}
 
-/* Reset debug level to previous value */
+/* Reset subsumption-related debug level to its original value */
 void tracerx_debug_subsumption_off() {}
+
+/* Switch on state debug */
+void tracerx_debug_state() {}
+
+/* Reset state debug to its original value */
+void tracerx_debug_state_off() {}

--- a/runtime/Runtest/intrinsics.c
+++ b/runtime/Runtest/intrinsics.c
@@ -143,3 +143,5 @@ int klee_range(int begin, int end, const char* name) {
 void klee_print_expr(const char *msg, ...) { }
 
 void klee_set_forking(unsigned enable) { }
+
+void klee_debug_subsumption(uint64_t level) {}

--- a/runtime/Runtest/intrinsics.c
+++ b/runtime/Runtest/intrinsics.c
@@ -144,4 +144,5 @@ void klee_print_expr(const char *msg, ...) { }
 
 void klee_set_forking(unsigned enable) { }
 
-void klee_debug_subsumption(uint64_t level) {}
+/* Change debug level */
+void tracerx_debug_level(uint64_t id, uint64_t level) {}

--- a/runtime/Runtest/intrinsics.c
+++ b/runtime/Runtest/intrinsics.c
@@ -146,3 +146,6 @@ void klee_set_forking(unsigned enable) { }
 
 /* Change debug level */
 void tracerx_push_debug_level(uint64_t level) {}
+
+/* Reset debug level to previous value */
+void tracerx_pop_debug_level() {}

--- a/runtime/Runtest/intrinsics.c
+++ b/runtime/Runtest/intrinsics.c
@@ -145,4 +145,4 @@ void klee_print_expr(const char *msg, ...) { }
 void klee_set_forking(unsigned enable) { }
 
 /* Change debug level */
-void tracerx_debug_level(uint64_t id, uint64_t level) {}
+void tracerx_push_debug_level(uint64_t level) {}

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -486,6 +486,8 @@ void klee_mark_global(void *object) {
 
 void tracerx_push_debug_level(uint64_t level) { ; }
 
+void tracerx_pop_debug_level() {}
+
 /*** HELPER FUNCTIONS ***/
 
 static void __emit_error(const char *msg) {

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -484,7 +484,7 @@ void klee_mark_global(void *object) {
   ;
 }
 
-void tracerx_debug(uint64_t id, uint64_t level) { ; }
+void tracerx_push_debug_level(uint64_t level) { ; }
 
 /*** HELPER FUNCTIONS ***/
 

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -484,6 +484,8 @@ void klee_mark_global(void *object) {
   ;
 }
 
+void klee_debug_subsumption(uint64_t level) { ; }
+
 /*** HELPER FUNCTIONS ***/
 
 static void __emit_error(const char *msg) {

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -484,7 +484,7 @@ void klee_mark_global(void *object) {
   ;
 }
 
-void klee_debug_subsumption(uint64_t level) { ; }
+void tracerx_debug(uint64_t id, uint64_t level) { ; }
 
 /*** HELPER FUNCTIONS ***/
 

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -486,7 +486,11 @@ void klee_mark_global(void *object) {
 
 void tracerx_debug_subsumption(uint64_t level) { ; }
 
-void tracerx_debug_subsumption_off() {}
+void tracerx_debug_subsumption_off() { ; }
+
+void tracerx_debug_state() { ; }
+
+void tracerx_debug_state_off() { ; }
 
 /*** HELPER FUNCTIONS ***/
 

--- a/tools/klee-replay/klee-replay.c
+++ b/tools/klee-replay/klee-replay.c
@@ -484,9 +484,9 @@ void klee_mark_global(void *object) {
   ;
 }
 
-void tracerx_push_debug_level(uint64_t level) { ; }
+void tracerx_debug_subsumption(uint64_t level) { ; }
 
-void tracerx_pop_debug_level() {}
+void tracerx_debug_subsumption_off() {}
 
 /*** HELPER FUNCTIONS ***/
 

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -913,6 +913,8 @@ static const char *modelledExternals[] = {
   "__ubsan_handle_divrem_overflow",
   "tracerx_debug_subsumption",
   "tracerx_debug_subsumption_off"
+  "tracerx_debug_state",
+  "tracerx_debug_state_off"
 };
 // Symbols we aren't going to warn about
 static const char *dontCareExternals[] = {

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -911,6 +911,8 @@ static const char *modelledExternals[] = {
   "__ubsan_handle_sub_overflow",
   "__ubsan_handle_mul_overflow",
   "__ubsan_handle_divrem_overflow",
+  "tracerx_push_debug_level",
+  "tracerx_pop_debug_level"
 };
 // Symbols we aren't going to warn about
 static const char *dontCareExternals[] = {

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -911,8 +911,8 @@ static const char *modelledExternals[] = {
   "__ubsan_handle_sub_overflow",
   "__ubsan_handle_mul_overflow",
   "__ubsan_handle_divrem_overflow",
-  "tracerx_push_debug_level",
-  "tracerx_pop_debug_level"
+  "tracerx_debug_subsumption",
+  "tracerx_debug_subsumption_off"
 };
 // Symbols we aren't going to warn about
 static const char *dontCareExternals[] = {


### PR DESCRIPTION
Added `tracerx_debug_subsumption` and `tracerx_debug_subsumption_off` API pair and `tracerx_debug_state` and `tracerx_debug_state` API pair for dynamically within the program setting the debugging output. For more information on these APIs, consult `include/klee/klee.h`. 