### PR TITLE
Use set instead of vector to store reasons of inclusion of values in …

### DIFF
--- a/include/klee/Internal/Module/VersionedValue.h
+++ b/include/klee/Internal/Module/VersionedValue.h
@@ -301,7 +301,7 @@ private:
   ref<VersionedValue> storeAddress;
 
   /// \brief Reasons for this value to be in the core
-  std::vector<std::string> coreReasons;
+  std::set<std::string> coreReasons;
 
   VersionedValue(llvm::Value *value,
                  const std::vector<llvm::Instruction *> &_stack,
@@ -385,7 +385,7 @@ public:
   void setAsCore(std::string reason) {
     core = true;
     if (!reason.empty())
-      coreReasons.push_back(reason);
+      coreReasons.insert(reason);
   }
 
   bool isCore() const { return core; }
@@ -394,7 +394,7 @@ public:
 
   std::vector<llvm::Instruction *> &getStack() { return stack; }
 
-  std::vector<std::string> &getReasons() { return coreReasons; }
+  std::set<std::string> &getReasons() { return coreReasons; }
 
   /// \brief Print the content of the object into a stream.
   ///

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -45,7 +45,7 @@ namespace klee {
 
 void StoredValue::init(ref<VersionedValue> vvalue,
                        std::set<const Array *> &replacements,
-                       std::vector<std::string> &_coreReasons, bool shadowing) {
+                       std::set<std::string> &_coreReasons, bool shadowing) {
   std::set<ref<MemoryLocation> > locations = vvalue->getLocations();
 
   refCount = 0;
@@ -287,9 +287,8 @@ void StoredValue::print(llvm::raw_ostream &stream,
   if (!coreReasons.empty()) {
     stream << "\n";
     stream << prefix << "reason(s) for storage:\n";
-    for (std::vector<std::string>::const_iterator is = coreReasons.begin(),
-                                                  ie = coreReasons.end(),
-                                                  it = is;
+    for (std::set<std::string>::const_iterator is = coreReasons.begin(),
+                                               ie = coreReasons.end(), it = is;
          it != ie; ++it) {
       if (it != is)
         stream << "\n";

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -70,19 +70,19 @@ namespace klee {
     bool doNotUseBound;
 
     /// \brief Reason this was stored as needed value
-    std::vector<std::string> coreReasons;
+    std::set<std::string> coreReasons;
 
     void init(ref<VersionedValue> vvalue, std::set<const Array *> &replacements,
-              std::vector<std::string> &coreReasons, bool shadowing = false);
+              std::set<std::string> &coreReasons, bool shadowing = false);
 
     StoredValue(ref<VersionedValue> vvalue,
                 std::set<const Array *> &replacements,
-                std::vector<std::string> &coreReasons) {
+                std::set<std::string> &coreReasons) {
       init(vvalue, replacements, coreReasons, true);
     }
 
     StoredValue(ref<VersionedValue> vvalue,
-                std::vector<std::string> &coreReasons) {
+                std::set<std::string> &coreReasons) {
       std::set<const Array *> dummyReplacements;
       init(vvalue, dummyReplacements, coreReasons);
     }

--- a/lib/Core/VersionedValue.cpp
+++ b/lib/Core/VersionedValue.cpp
@@ -172,8 +172,8 @@ void VersionedValue::printNoDependency(llvm::raw_ostream &stream,
       stream << prefix << "an interpolant value\n";
     }
     if (!coreReasons.empty()) {
-      for (std::vector<std::string>::const_iterator it = coreReasons.begin(),
-                                                    ie = coreReasons.end();
+      for (std::set<std::string>::const_iterator it = coreReasons.begin(),
+                                                 ie = coreReasons.end();
            it != ie; ++it) {
         stream << tabsNext << *it << "\n";
       }


### PR DESCRIPTION
…a subsumption table entry. This is because we don't need to store repeating strings.