### PR TITLE
Corrected subsumption table indexing

### DIFF
--- a/include/klee/Internal/Module/VersionedValue.h
+++ b/include/klee/Internal/Module/VersionedValue.h
@@ -159,6 +159,8 @@ public:
   int compareContext(llvm::Value *otherValue,
                      const std::vector<llvm::Instruction *> &_stack) const {
     if (value == otherValue) {
+      // Please note the use of reverse iterator here, which improves
+      // performance.
       for (std::vector<llvm::Instruction *>::const_reverse_iterator
                it1 = stack.rbegin(),
                ie1 = stack.rend(), it2 = _stack.rbegin(), ie2 = _stack.rend();
@@ -187,11 +189,16 @@ public:
     return 3;
   }
 
-  bool contextIsPrefixOf(const std::vector<llvm::Instruction *> &stack) const {
-    int res = compareContext(value, stack);
-    if (res == 0 || res == -1)
-      return true;
-    return false;
+  bool contextIsPrefixOf(const std::vector<llvm::Instruction *> &_stack) const {
+    for (std::vector<llvm::Instruction *>::const_iterator
+             it1 = stack.begin(),
+             ie1 = stack.end(), it2 = _stack.begin(), ie2 = _stack.end();
+         it1 != ie1; ++it1, ++it2) {
+      if (it2 == ie2 || (*it1) != (*it2)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   int compare(const MemoryLocation &other) const {

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1024,8 +1024,7 @@ bool SubsumptionTableEntry::subsumed(
         if (!stateConcreteMap.count(it2->first)) {
           if (debugSubsumptionLevel >= 1) {
             klee_message("#%lu=>#%lu: Check failure as memory region in the "
-                         "table does not "
-                         "exist in the state",
+                         "table does not exist in the state",
                          state.txTreeNode->getNodeSequenceNumber(),
                          nodeSequenceNumber);
           }

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1754,18 +1754,11 @@ void SubsumptionTable::StackIndexedTable::Node::print(
     (*it)->print(stream, tabsNext);
     stream << "\n";
   }
-  stream << tabsNext << "Left:\n";
-  if (!left) {
-    stream << tabsNext << "NULL\n";
-  } else {
-    left->print(stream, appendTab(prefix));
-    stream << "\n";
-  }
-  stream << tabsNext << "Right:\n";
-  if (!right) {
-    stream << tabsNext << "NULL\n";
-  } else {
-    right->print(stream, appendTab(prefix));
+  for (std::map<llvm::Instruction *, Node *>::const_iterator it = next.begin(),
+                                                             ie = next.end();
+       it != ie; ++it) {
+    stream << tabsNext << "Next call:\n";
+    it->second->print(stream, appendTab(prefix));
     stream << "\n";
   }
 }
@@ -1773,12 +1766,12 @@ void SubsumptionTable::StackIndexedTable::Node::print(
 /**/
 
 void SubsumptionTable::StackIndexedTable::clearTree(Node *node) {
-  if (node->left)
-    clearTree(node->left);
-  if (node->right)
-    clearTree(node->right);
-  delete node->left;
-  delete node->right;
+  for (std::map<llvm::Instruction *, Node *>::iterator it = node->next.begin(),
+                                                       ie = node->next.end();
+       it != ie; ++it) {
+    clearTree(it->second);
+    delete it->second;
+  }
 
   for (std::deque<SubsumptionTableEntry *>::iterator
            it = node->entryList.begin(),
@@ -1797,20 +1790,15 @@ void SubsumptionTable::StackIndexedTable::insert(
                                                         ie = stack.end();
        it != ie; ++it) {
     llvm::Instruction *call = *it;
-    if (call < current->id) {
-      if (!current->left) {
-        current->left = new Node(call);
-      }
-      current = current->left;
-      continue;
-    } else if (call > current->id) {
-      if (!current->right) {
-        current->right = new Node(call);
-      }
-      current = current->right;
-      continue;
+    std::map<llvm::Instruction *, Node *>::const_iterator it1 =
+        current->next.find(call);
+    if (it1 == current->next.end()) {
+      Node *newNode = new Node(call);
+      current->next[*it] = newNode;
+      current = newNode;
+    } else {
+      current = it1->second;
     }
-    break;
   }
   current->entryList.push_back(entry);
 }
@@ -1825,22 +1813,13 @@ SubsumptionTable::StackIndexedTable::find(
                                                         ie = stack.end();
        it != ie; ++it) {
     llvm::Instruction *call = *it;
-    if (call < current->id) {
-      if (!current->left) {
-        found = false;
-        return ret;
-      }
-      current = current->left;
-      continue;
-    } else if (call > current->id) {
-      if (!current->right) {
-        found = false;
-        return ret;
-      }
-      current = current->right;
-      continue;
+    std::map<llvm::Instruction *, Node *>::const_iterator it1 =
+        current->next.find(call);
+    if (it1 == current->next.end()) {
+      found = false;
+      return ret;
     }
-    break;
+    current = it1->second;
   }
   found = true;
   return std::pair<EntryIterator, EntryIterator>(current->entryList.rbegin(),
@@ -1850,23 +1829,14 @@ SubsumptionTable::StackIndexedTable::find(
 void SubsumptionTable::StackIndexedTable::printNode(llvm::raw_ostream &stream,
                                                     Node *n,
                                                     std::string edges) const {
-  if (n->left != 0) {
+  for (std::map<llvm::Instruction *, Node *>::const_iterator
+           it = n->next.begin(),
+           ie = n->next.end();
+       it != ie; ++it) {
     stream << "\n";
-    stream << edges << "+-- L:";
-    n->left->print(stream, edges + "    ");
+    it->second->print(stream, edges + "    ");
     stream << "\n";
-    if (n->right != 0) {
-      printNode(stream, n->left, edges + "|   ");
-    } else {
-      printNode(stream, n->left, edges + "    ");
-    }
-  }
-  if (n->right != 0) {
-    stream << "\n";
-    stream << edges << "+-- R:";
-    n->right->print(stream, edges + "    ");
-    stream << "\n";
-    printNode(stream, n->right, edges + "    ");
+    printNode(stream, it->second, edges + "    ");
   }
 }
 

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -236,9 +236,9 @@ class SubsumptionTable {
 
       std::deque<SubsumptionTableEntry *> entryList;
 
-      Node *left, *right;
+      std::map<llvm::Instruction *, Node *> next;
 
-      Node(llvm::Instruction *_id) : id(_id) { left = right = 0; }
+      Node(llvm::Instruction *_id) : id(_id) {}
 
       void dump() const {
         this->print(llvm::errs());


### PR DESCRIPTION
In this new indexing for subsumption table, instead of lumping everything into binary tree which results in entries retrieved not matching the subsumption control location, we use n-ary tree indexing, which is the program's call graph, with unrolled recursive calls.