### PR TITLE
Added -subsumed-test option

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -77,6 +77,8 @@ extern llvm::cl::opt<bool> OutputTree;
 
 extern llvm::cl::opt<bool> InterpolationStat;
 
+extern llvm::cl::opt<bool> SubsumedTest;
+
 extern llvm::cl::opt<bool> NoExistential;
 
 extern llvm::cl::opt<int> MaxFailSubsumption;

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -105,6 +105,11 @@ llvm::cl::opt<bool> InterpolationStat(
     llvm::cl::desc(
         "Displays an execution profile of the interpolation routines."));
 
+llvm::cl::opt<bool>
+SubsumedTest("subsumed-test",
+             llvm::cl::desc("Generates test case of subsumed path."),
+             llvm::cl::init(false));
+
 llvm::cl::opt<bool> NoExistential(
     "no-existential",
     llvm::cl::desc(

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3171,8 +3171,8 @@ void Executor::terminateStateOnSubsumption(ExecutionState &state) {
   interpreterHandler->incTotalInstructionsOnSubsumption(
       state.txTreeNode->getInstructionsDepth());
 
-  if (!OnlyOutputStatesCoveringNew || state.coveredNew ||
-      (AlwaysOutputSeeds && seedMap.count(&state))) {
+  if (SubsumedTest && (!OnlyOutputStatesCoveringNew || state.coveredNew ||
+                       (AlwaysOutputSeeds && seedMap.count(&state)))) {
     interpreterHandler->incSubsumptionTerminationTest();
     interpreterHandler->processTestCase(state, 0, "early");
   }


### PR DESCRIPTION
This makes test/path information generation from subsumed path optional. Resolves issue #200.