### PR TITLE
Limit subsumption test report

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -818,8 +818,13 @@ Dependency::Dependency(Dependency *parent, llvm::DataLayout *_targetData)
     debugSubsumptionLevel = parent->debugSubsumptionLevel;
     debugState = parent->debugState;
   } else {
+#ifdef ENABLE_Z3
     debugSubsumptionLevel = DebugSubsumption;
     debugState = DebugState;
+#else
+    debugSubsumptionLevel = 0;
+    debugState = false;
+#endif
   }
 }
 

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -394,11 +394,19 @@ void ExecutionState::debugSubsumption(uint64_t level) {
 }
 
 void ExecutionState::debugSubsumptionOff() {
+#if ENABLE_Z3
   txTreeNode->dependency->debugSubsumptionLevel = DebugSubsumption;
+#else
+  txTreeNode->dependency->debugSubsumptionLevel = 0;
+#endif
 }
 
 void ExecutionState::debugState() { txTreeNode->dependency->debugState = true; }
 
 void ExecutionState::debugStateOff() {
+#if ENABLE_Z3
   txTreeNode->dependency->debugState = DebugState;
+#else
+  txTreeNode->dependency->debugState = false;
+#endif
 }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3171,11 +3171,13 @@ void Executor::terminateStateOnSubsumption(ExecutionState &state) {
   interpreterHandler->incTotalInstructionsOnSubsumption(
       state.txTreeNode->getInstructionsDepth());
 
+#ifdef ENABLE_Z3
   if (SubsumedTest && (!OnlyOutputStatesCoveringNew || state.coveredNew ||
                        (AlwaysOutputSeeds && seedMap.count(&state)))) {
     interpreterHandler->incSubsumptionTerminationTest();
     interpreterHandler->processTestCase(state, 0, "early");
   }
+#endif
   terminateState(state);
 }
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2071,10 +2071,10 @@ void TxTree::setCurrentINode(ExecutionState &state) {
 }
 
 void TxTree::remove(TxTreeNode *node) {
+#ifdef ENABLE_Z3
   int debugSubsumptionLevel =
       currentTxTreeNode->dependency->debugSubsumptionLevel;
 
-#ifdef ENABLE_Z3
   TimerStatIncrementer t(removeTime);
   assert(!node->left && !node->right);
   do {

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1742,9 +1742,11 @@ int main(int argc, char **argv, char **envp) {
         << handler->getNumTestCases() << ", among which\n";
   stats << "KLEE: done:     early-terminating tests (instruction time limit, solver timeout, max-depth reached) = "
         << handler->getEarlyTerminationTest() << "\n";
-  if (INTERPOLATION_ENABLED)
+#ifdef ENABLE_Z3
+  if (SubsumedTest && INTERPOLATION_ENABLED)
     stats << "KLEE: done:     subsumed tests = "
           << handler->getSubsumptionTerminationTest() << "\n";
+#endif
   stats << "KLEE: done:     error tests = "
         << handler->getErrorTerminationTest() << "\n";
   stats << "KLEE: done:     program exit tests = "


### PR DESCRIPTION
Limit output of subsumed tests statistics only when -subsumed-test option is given. Also removed compilation errors and warnings when ./configure is not run with --with-z3.