### PR TITLE
Added -loaded-value-check option

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -92,6 +92,9 @@ extern llvm::cl::opt<bool> NoBoundInterpolation;
 extern llvm::cl::opt<bool> ExactAddressInterpolant;
 
 extern llvm::cl::opt<bool> SpecialFunctionBoundInterpolation;
+
+extern llvm::cl::opt<bool> LoadedValueCheck;
+
 #endif
 
 #ifdef ENABLE_METASMT

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -162,6 +162,12 @@ llvm::cl::opt<bool> SpecialFunctionBoundInterpolation(
                    "named tracerx_check."),
     llvm::cl::init(false));
 
+llvm::cl::opt<bool> LoadedValueCheck(
+    "loaded-value-check",
+    llvm::cl::desc("Adds an assertion check that the value of loaded "
+                   "expression is the same as the actual expression loaded "
+                   "from the store of Tracer-X."),
+    llvm::cl::init(false));
 #endif // ENABLE_Z3
 
 #ifdef ENABLE_METASMT


### PR DESCRIPTION
To trigger assertion value when the loaded value of LLVM `load` instruction differs between KLEE and Tracer-X.