### PR TITLE
Removed -loaded-value-check option

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -93,8 +93,6 @@ extern llvm::cl::opt<bool> ExactAddressInterpolant;
 
 extern llvm::cl::opt<bool> SpecialFunctionBoundInterpolation;
 
-extern llvm::cl::opt<bool> LoadedValueCheck;
-
 #endif
 
 #ifdef ENABLE_METASMT

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -161,13 +161,6 @@ llvm::cl::opt<bool> SpecialFunctionBoundInterpolation(
     llvm::cl::desc("Perform memory bound interpolation only within function "
                    "named tracerx_check."),
     llvm::cl::init(false));
-
-llvm::cl::opt<bool> LoadedValueCheck(
-    "loaded-value-check",
-    llvm::cl::desc("Adds an assertion check that the value of loaded "
-                   "expression is the same as the actual expression loaded "
-                   "from the store of Tracer-X."),
-    llvm::cl::init(false));
 #endif // ENABLE_Z3
 
 #ifdef ENABLE_METASMT

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1140,38 +1140,32 @@ void Dependency::execute(llvm::Instruction *instr,
         } else if (locations.size() == 1) {
           ref<MemoryLocation> loc = *(locations.begin());
 
-          if (LoadedValueCheck) {
-            std::map<ref<MemoryLocation>,
-                     std::pair<ref<VersionedValue>,
-                               ref<VersionedValue> > >::iterator storeIt =
-                concretelyAddressedStore.find(loc);
-            std::pair<ref<VersionedValue>, ref<VersionedValue> > target;
+          // Check the possible mismatch between Tracer-X and KLEE loaded value
+          std::map<ref<MemoryLocation>,
+                   std::pair<ref<VersionedValue>,
+                             ref<VersionedValue> > >::iterator storeIt =
+              concretelyAddressedStore.find(loc);
+          std::pair<ref<VersionedValue>, ref<VersionedValue> > target;
 
-            if (storeIt == concretelyAddressedStore.end()) {
+          if (storeIt == concretelyAddressedStore.end()) {
               storeIt = symbolicallyAddressedStore.find(loc);
               if (storeIt != symbolicallyAddressedStore.end()) {
                 target = storeIt->second;
               }
-            } else {
+          } else {
               target = storeIt->second;
-            }
+          }
 
-            if (!target.second.isNull()) {
-              if (debugSubsumptionLevel >= 1) {
-                if (valueExpr != target.second->getExpression()) {
-                  std::string msg;
-                  llvm::raw_string_ostream stream(msg);
-                  stream << "loaded value ";
-                  target.second->getExpression()->print(stream);
-                  stream << " should be ";
-                  valueExpr->print(stream);
-                  stream.flush();
-                  klee_message("%s", msg.c_str());
-                }
-              }
-              assert(valueExpr == target.second->getExpression() &&
-                     "Mismatched loaded value");
-            }
+          if (!target.second.isNull() &&
+              valueExpr != target.second->getExpression()) {
+            std::string msg;
+            llvm::raw_string_ostream stream(msg);
+            stream << "Loaded value ";
+            target.second->getExpression()->print(stream);
+            stream << " should be ";
+            valueExpr->print(stream);
+            stream.flush();
+            klee_warning("%s", msg.c_str());
           }
 
           if (isMainArgument(loc->getValue())) {


### PR DESCRIPTION
Instead print warning on loaded value mismatch in Tracer-X.