### PR TITLE
Allocation indexing

### DIFF
--- a/include/klee/Internal/Module/VersionedValue.h
+++ b/include/klee/Internal/Module/VersionedValue.h
@@ -248,16 +248,10 @@ public:
     return context->isPrefixOf(callHistory);
   }
 
-  int compare(const MemoryLocation &other) const {
+  int weakCompare(const MemoryLocation &other) const {
     int res = context->compare(*(other.context.get()));
     if (res)
       return res;
-
-    if (allocationId < other.allocationId)
-      return -3;
-
-    if (allocationId > other.allocationId)
-      return 3;
 
     if (offset == other.offset)
       return 0;
@@ -271,6 +265,20 @@ public:
       return -1;
 
     return 1;
+  }
+
+  int compare(const MemoryLocation &other) const {
+    int res = weakCompare(other);
+    if (res)
+      return res;
+
+    if (allocationId < other.allocationId)
+      return -3;
+
+    if (allocationId > other.allocationId)
+      return 3;
+
+    return 0;
   }
 
   /// \brief Adjust the offset bound for interpolation (a.k.a. slackening)

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -323,17 +323,19 @@ void Dependency::getConcreteStore(
 
     if (!coreOnly) {
       const llvm::Value *base = it->first->getContext()->getValue();
-      concreteStore[base][it->first] = StoredValue::create(it->second.second);
+      concreteStore[base][StoredAddress::create(it->first)] =
+          StoredValue::create(it->second.second);
     } else if (it->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
       const llvm::Value *base = it->first->getContext()->getValue();
 #ifdef ENABLE_Z3
       if (!NoExistential) {
-        concreteStore[base][it->first] =
+        concreteStore[base][StoredAddress::create(it->first)] =
             StoredValue::create(it->second.second, replacements);
       } else
 #endif
-        concreteStore[base][it->first] = StoredValue::create(it->second.second);
+        concreteStore[base][StoredAddress::create(it->first)] =
+            StoredValue::create(it->second.second);
     }
   }
 }
@@ -359,20 +361,23 @@ void Dependency::getSymbolicStore(
 
     if (!coreOnly) {
       llvm::Value *base = it->first->getContext()->getValue();
-      symbolicStore[base].push_back(Dependency::AddressValuePair(
-          it->first, StoredValue::create(it->second.second)));
+      symbolicStore[base].push_back(
+          Dependency::AddressValuePair(StoredAddress::create(it->first),
+                                       StoredValue::create(it->second.second)));
     } else if (it->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
       llvm::Value *base = it->first->getContext()->getValue();
 #ifdef ENABLE_Z3
       if (!NoExistential) {
         symbolicStore[base].push_back(Dependency::AddressValuePair(
-            MemoryLocation::create(it->first, replacements),
+            StoredAddress::create(
+                MemoryLocation::create(it->first, replacements)),
             StoredValue::create(it->second.second, replacements)));
       } else
 #endif
         symbolicStore[base].push_back(Dependency::AddressValuePair(
-            it->first, StoredValue::create(it->second.second)));
+            StoredAddress::create(it->first),
+            StoredValue::create(it->second.second)));
     }
   }
 }

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -45,9 +45,9 @@ class StoredAddress {
 public:
   unsigned refCount;
 
-private:
   ref<MemoryLocation> loc;
 
+private:
   StoredAddress(ref<MemoryLocation> _loc) : refCount(0), loc(_loc) {}
 
 public:
@@ -56,6 +56,14 @@ public:
     return ret;
   }
 
+  /// \brief The comparator of this class' objects. This member function is
+  /// weaker than standard comparator for MemoryLocation in that it does not
+  /// check for the equality of allocation id. Allocation id is used in
+  /// MemoryLocation (member variable MemoryLocation#allocationId) for the
+  /// purpose of distinguishing memory allocations of the same callsite and call
+  /// history, but of different loop iterations. This does not make sense when
+  /// comparing states for subsumption as in subsumption, related allocations in
+  /// different paths may have different allocation ids.
   int compare(const StoredAddress &other) const {
     return loc->weakCompare(*(other.loc.get()));
   }
@@ -281,8 +289,8 @@ public:
   class Dependency {
 
   public:
-    typedef std::pair<ref<MemoryLocation>, ref<StoredValue> > AddressValuePair;
-    typedef std::map<ref<MemoryLocation>, ref<StoredValue> > ConcreteStoreMap;
+    typedef std::pair<ref<StoredAddress>, ref<StoredValue> > AddressValuePair;
+    typedef std::map<ref<StoredAddress>, ref<StoredValue> > ConcreteStoreMap;
     typedef std::vector<AddressValuePair> SymbolicStoreMap;
     typedef std::map<const llvm::Value *, ConcreteStoreMap> ConcreteStore;
     typedef std::map<const llvm::Value *, SymbolicStoreMap> SymbolicStore;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -38,6 +38,29 @@
 
 namespace klee {
 
+/// \brief The address to be stored as an index in the subsumption table. This
+/// class wraps a memory location, supplying weaker address equality comparison
+/// for the purpose of subsumption checking
+class StoredAddress {
+public:
+  unsigned refCount;
+
+private:
+  ref<MemoryLocation> loc;
+
+  StoredAddress(ref<MemoryLocation> _loc) : refCount(0), loc(_loc) {}
+
+public:
+  static ref<StoredAddress> create(ref<MemoryLocation> loc) {
+    ref<StoredAddress> ret(new StoredAddress(loc));
+    return ret;
+  }
+
+  int compare(const StoredAddress &other) const {
+    return loc->weakCompare(*(other.loc.get()));
+  }
+};
+
   /// \brief A processed form of a value to be stored in the subsumption table
   class StoredValue {
   public:

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1118,8 +1118,7 @@ bool SubsumptionTableEntry::subsumed(
 
             // We make sure the context part of the addresses (the allocation
             // site and the call history) are equivalent.
-            if (it2->first->compareContext(it3->first->getValue(),
-                                           it3->first->getCallHistory()))
+            if (it2->first->getContext() != it3->first->getContext())
               continue;
 
             ref<Expr> stateSymbolicOffset = it3->first->getOffset();
@@ -1235,8 +1234,7 @@ bool SubsumptionTableEntry::subsumed(
 
           // We make sure the context part of the addresses (the allocation
           // site and the call history) are equivalent.
-          if (it2->first->compareContext(it3->first->getValue(),
-                                         it3->first->getCallHistory()))
+          if (it2->first->getContext() != it3->first->getContext())
             continue;
 
           ref<Expr> stateConcreteOffset = it3->first->getOffset();
@@ -1298,8 +1296,7 @@ bool SubsumptionTableEntry::subsumed(
 
           // We make sure the context part of the addresses (the allocation
           // site and the call history) are equivalent.
-          if (it2->first->compareContext(it3->first->getValue(),
-                                         it3->first->getCallHistory()))
+          if (it2->first->getContext() != it3->first->getContext())
             continue;
 
           ref<Expr> stateSymbolicOffset = it3->first->getOffset();

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1015,7 +1015,7 @@ bool SubsumptionTableEntry::subsumed(
               msg1 += " (with successful memory bound checks)";
             }
 
-            it2->first->print(stream, padding);
+            it2->first->loc->print(stream, padding);
             stream.flush();
             klee_message("#%lu=>#%lu: Check failure as memory region in the "
                          "table does not exist in the state%s:\n%s",
@@ -1095,7 +1095,7 @@ bool SubsumptionTableEntry::subsumed(
                   std::string msg3;
                   llvm::raw_string_ostream stream1(msg3);
 
-                  it2->first->print(stream1, makeTabs(1));
+                  it2->first->loc->print(stream1, makeTabs(1));
                   stream1.flush();
 
                   klee_message("with value stored in address:\n%s",
@@ -1108,7 +1108,7 @@ bool SubsumptionTableEntry::subsumed(
         }
 
         if (!stateSymbolicMap.empty()) {
-          const ref<Expr> tabledConcreteOffset = it2->first->getOffset();
+          const ref<Expr> tabledConcreteOffset = it2->first->loc->getOffset();
           ref<Expr> conjunction;
 
           for (Dependency::SymbolicStoreMap::const_iterator
@@ -1118,10 +1118,10 @@ bool SubsumptionTableEntry::subsumed(
 
             // We make sure the context part of the addresses (the allocation
             // site and the call history) are equivalent.
-            if (it2->first->getContext() != it3->first->getContext())
+            if (it2->first->loc->getContext() != it3->first->loc->getContext())
               continue;
 
-            ref<Expr> stateSymbolicOffset = it3->first->getOffset();
+            ref<Expr> stateSymbolicOffset = it3->first->loc->getOffset();
             ref<Expr> newTerm;
 
             stateValue = it3->second;
@@ -1224,7 +1224,7 @@ bool SubsumptionTableEntry::subsumed(
                it2 = tabledSymbolicMap.begin(),
                ie2 = tabledSymbolicMap.end();
            it2 != ie2; ++it2) {
-        ref<Expr> tabledSymbolicOffset = it2->first->getOffset();
+        ref<Expr> tabledSymbolicOffset = it2->first->loc->getOffset();
         ref<StoredValue> tabledValue = it2->second;
 
         for (Dependency::ConcreteStoreMap::const_iterator
@@ -1234,10 +1234,10 @@ bool SubsumptionTableEntry::subsumed(
 
           // We make sure the context part of the addresses (the allocation
           // site and the call history) are equivalent.
-          if (it2->first->getContext() != it3->first->getContext())
+          if (it2->first->loc->getContext() != it3->first->loc->getContext())
             continue;
 
-          ref<Expr> stateConcreteOffset = it3->first->getOffset();
+          ref<Expr> stateConcreteOffset = it3->first->loc->getOffset();
           ref<StoredValue> stateValue = it3->second;
           ref<Expr> newTerm;
 
@@ -1296,10 +1296,10 @@ bool SubsumptionTableEntry::subsumed(
 
           // We make sure the context part of the addresses (the allocation
           // site and the call history) are equivalent.
-          if (it2->first->getContext() != it3->first->getContext())
+          if (it2->first->loc->getContext() != it3->first->loc->getContext())
             continue;
 
-          ref<Expr> stateSymbolicOffset = it3->first->getOffset();
+          ref<Expr> stateSymbolicOffset = it3->first->loc->getOffset();
           ref<StoredValue> stateValue = it3->second;
           ref<Expr> newTerm;
 
@@ -1704,7 +1704,7 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
         if (it1 != is1 || it2 != is2)
           stream << tabsNext << "------------------------------------------\n";
         stream << tabsNext << "address:\n";
-        it2->first->print(stream, tabsNextNext);
+        it2->first->loc->print(stream, tabsNextNext);
         stream << "\n";
         stream << tabsNext << "content:\n";
         it2->second->print(stream, tabsNextNext);
@@ -1727,7 +1727,7 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
         if (it1 != is1 || it2 != is2)
           stream << tabsNext << "------------------------------------------\n";
         stream << tabsNext << "address:\n";
-        it2->first->print(stream, tabsNextNext);
+        it2->first->loc->print(stream, tabsNextNext);
         stream << "\n";
         stream << tabsNext << "content:\n";
         it2->second->print(stream, tabsNextNext);

--- a/lib/Core/VersionedValue.cpp
+++ b/lib/Core/VersionedValue.cpp
@@ -87,8 +87,8 @@ MemoryLocation::create(ref<MemoryLocation> loc,
       ShadowArray::getShadowExpression(loc->address, replacements)),
       _base(ShadowArray::getShadowExpression(loc->base, replacements)),
       _offset(ShadowArray::getShadowExpression(loc->offset, replacements));
-  ref<MemoryLocation> ret(
-      new MemoryLocation(loc->context, _address, _base, _offset, loc->size));
+  ref<MemoryLocation> ret(new MemoryLocation(
+      loc->context, _address, _base, _offset, loc->size, loc->allocationId));
   return ret;
 }
 

--- a/lib/Core/VersionedValue.cpp
+++ b/lib/Core/VersionedValue.cpp
@@ -56,7 +56,7 @@ void MemoryLocation::adjustOffsetBound(ref<VersionedValue> checkedAddress,
 
               // FIXME: A quick hack to avoid assertion check to make DirSeek.c
               // regression test pass.
-              llvm::Value *v = (*it2)->getValue();
+              llvm::Value *v = (*it2)->getContext()->getValue();
               if (v->getType()->isPointerTy()) {
                 llvm::Type *elementType = v->getType()->getPointerElementType();
                 if (elementType->isStructTy() &&
@@ -87,8 +87,8 @@ MemoryLocation::create(ref<MemoryLocation> loc,
       ShadowArray::getShadowExpression(loc->address, replacements)),
       _base(ShadowArray::getShadowExpression(loc->base, replacements)),
       _offset(ShadowArray::getShadowExpression(loc->offset, replacements));
-  ref<MemoryLocation> ret(new MemoryLocation(
-      loc->value, loc->callHistory, _address, _base, _offset, loc->size));
+  ref<MemoryLocation> ret(
+      new MemoryLocation(loc->context, _address, _base, _offset, loc->size));
   return ret;
 }
 
@@ -97,15 +97,15 @@ void MemoryLocation::print(llvm::raw_ostream &stream,
   std::string tabsNext = appendTab(prefix);
 
   stream << prefix << "function/value: ";
-  if (outputFunctionName(value, stream))
+  if (outputFunctionName(context->getValue(), stream))
     stream << "/";
-  value->print(stream);
+  context->getValue()->print(stream);
   stream << "\n";
 
   stream << prefix << "stack:\n";
   for (std::vector<llvm::Instruction *>::const_reverse_iterator
-           it = callHistory.rbegin(),
-           ib = it, ie = callHistory.rend();
+           it = context->getCallHistory().rbegin(),
+           ib = it, ie = context->getCallHistory().rend();
        it != ie; ++it) {
     stream << tabsNext;
     (*it)->print(stream);


### PR DESCRIPTION
This adds separation between allocations, where each allocation is identified by the pointer to the `Expr` object of its base address. This results in separation of allocations with the same callsites created in a loop.