### PR TITLE
Eliminate warnings for klee_make_symbolic

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -455,6 +455,10 @@ Dependency::getLatestValue(llvm::Value *value,
     } else if (llvm::isa<llvm::IntToPtrInst>(asInstruction)) {
 	// 0 signifies unknown size
       return getNewPointerValue(value, callHistory, valueExpr, 0);
+    } else if (llvm::BitCastInst *bci =
+                   llvm::dyn_cast<llvm::BitCastInst>(asInstruction)) {
+      return getLatestValue(bci->getOperand(0), callHistory, valueExpr,
+                            constraint);
     }
   }
 
@@ -1478,13 +1482,6 @@ void Dependency::executeMakeSymbolic(
     const std::vector<llvm::Instruction *> &callHistory, ref<Expr> address,
     const Array *array) {
   llvm::Value *pointer = instr->getOperand(0);
-
-  if (llvm::ConstantExpr *ce = llvm::dyn_cast<llvm::ConstantExpr>(pointer)) {
-    if (llvm::BitCastInst *bci =
-            llvm::dyn_cast<llvm::BitCastInst>(ce->getAsInstruction())) {
-      pointer = bci->getOperand(0);
-    }
-  }
 
   ref<VersionedValue> storedValue = getNewVersionedValue(
       instr, callHistory, ConstantExpr::create(0, Expr::Bool));

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -484,6 +484,12 @@ public:
                  const std::vector<llvm::Instruction *> &callHistory,
                  std::vector<ref<Expr> > &args, bool symbolicExecutionError);
 
+    /// \brief Execution of klee_make_symbolic
+    void
+    executeMakeSymbolic(llvm::Instruction *instr,
+                        const std::vector<llvm::Instruction *> &callHistory,
+                        ref<Expr> address, const Array *array);
+
     /// \brief Build dependencies from PHI node
     void executePHI(llvm::Instruction *instr, unsigned int incomingBlock,
                     const std::vector<llvm::Instruction *> &callHistory,

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3834,6 +3834,7 @@ void Executor::executeMakeSymbolic(ExecutionState &state,
       const Array *shadow =
           arrayCache.CreateArray(ShadowArray::getShadowName(uniqueName), mo->size);
       ShadowArray::addShadowArrayMap(array, shadow);
+      txTree->executeMakeSymbolic(state.prevPC->inst, mo->getBaseExpr(), array);
     }
 
     bindObjectInState(state, mo, false, array);

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -883,6 +883,13 @@ public:
   /// building dependency information.
   void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
 
+  /// \brief Execution of klee_make_symbolic
+  void executeMakeSymbolic(llvm::Instruction *instr, ref<Expr> address,
+                           const Array *array) {
+    currentTxTreeNode->dependency->executeMakeSymbolic(
+        instr, currentTxTreeNode->callHistory, address, array);
+  }
+
   /// \brief Abstractly execute a PHI instruction for building dependency
   /// information.
   void executePHI(llvm::Instruction *instr, unsigned incomingBlock,


### PR DESCRIPTION
Warnings are shown when `klee_make_symbolic` is executed in a loop. This is because the value of the old expression recorded by Tracer-X is compared against a fresh symbolic expression newly generated by `klee_make_symbolic` in the new iteration in `Dependency::execute`. This resolved the issue by silencing the warning for when the value comes from a call to `klee_make_symbolic`.