### PR TITLE
Forward domination and elimination of memory mapping in interpolant

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -483,6 +483,8 @@ public:
     return interpolantStyleAddress;
   }
 
+  llvm::Value *getValue() const { return interpolantStyleAddress->getBase(); }
+
   /// \brief Copy this address, but increment the indirection count
   ref<TxStateAddress> copyWithIndirectionCountIncrement() {
     ref<Expr> offset = interpolantStyleAddress->getOffset();

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -230,13 +230,6 @@ public:
     return 1;
   }
 
-  /// \brief Copy this address, but increment the indirection count
-  ref<TxInterpolantAddress> copyWithIndirectionCountIncrement() {
-    ref<TxInterpolantAddress> ret = create(context, offset);
-    (ret->indirectionCount)++;
-    return ret;
-  }
-
   void incrementIndirectionCount() { indirectionCount++; }
 
   bool isHeapAddress() { return context->ty == AllocationContext::HEAP; }

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -280,7 +280,7 @@ private:
   bool doNotUseBound;
 
   /// \brief Set of memory locations possibly being pointed to
-  std::set<ref<TxStateAddress> > locations;
+  std::set<ref<TxInterpolantAddress> > locations;
 
   /// \brief Reason this was stored as needed value
   std::set<std::string> coreReasons;
@@ -351,7 +351,9 @@ public:
 
   llvm::Value *getValue() const { return value; }
 
-  std::set<ref<TxStateAddress> > &getLocations() { return locations; }
+  std::set<ref<TxInterpolantAddress> > &getInterpolantAddresses() {
+    return locations;
+  }
 
   void print(llvm::raw_ostream &stream) const;
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -189,6 +189,8 @@ public:
     return ret;
   }
 
+  llvm::Value *getBase() const { return context->getValue(); }
+
   ref<AllocationContext> getContext() const { return context; }
 
   ref<Expr> getOffset() const { return offset; }

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -281,9 +281,6 @@ private:
   /// \brief Do not use bound in subsumption check
   bool doNotUseBound;
 
-  /// \brief Set of memory locations possibly being pointed to
-  std::set<ref<TxInterpolantAddress> > locations;
-
   /// \brief Reason this was stored as needed value
   std::set<std::string> coreReasons;
 
@@ -355,10 +352,6 @@ public:
   ref<Expr> getExpression() const { return expr; }
 
   llvm::Value *getValue() const { return value; }
-
-  std::set<ref<TxInterpolantAddress> > &getInterpolantAddresses() {
-    return locations;
-  }
 
   void print(llvm::raw_ostream &stream) const;
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -23,10 +23,14 @@
 #include "klee/Expr.h"
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
+#include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Instruction.h>
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/Value.h>
 #else
+#include <llvm/BasicBlock.h>
 #include <llvm/Instruction.h>
+#include <llvm/Instructions.h>
 #include <llvm/Value.h>
 #endif
 
@@ -43,6 +47,12 @@ class AllocationContext {
 public:
   unsigned refCount;
 
+  enum Type {
+    LOCAL,
+    GLOBAL,
+    HEAP
+  } ty;
+
 private:
   /// \brief The location's LLVM value
   llvm::Value *value;
@@ -50,19 +60,16 @@ private:
   /// \brief The call history by which the allocation is reached
   std::vector<llvm::Instruction *> callHistory;
 
-  AllocationContext(llvm::Value *_value,
+  AllocationContext(Type _ty, llvm::Value *_value,
                     const std::vector<llvm::Instruction *> &_callHistory)
-      : refCount(0), value(_value), callHistory(_callHistory) {}
+      : refCount(0), ty(_ty), value(_value), callHistory(_callHistory) {}
 
 public:
   ~AllocationContext() { callHistory.clear(); }
 
   static ref<AllocationContext>
   create(llvm::Value *_value,
-         const std::vector<llvm::Instruction *> &_callHistory) {
-    ref<AllocationContext> ret(new AllocationContext(_value, _callHistory));
-    return ret;
-  }
+         const std::vector<llvm::Instruction *> &_callHistory);
 
   llvm::Value *getValue() const { return value; }
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -237,6 +237,8 @@ public:
     return ret;
   }
 
+  void incrementIndirectionCount() { indirectionCount++; }
+
   bool isHeapAddress() { return context->ty == AllocationContext::HEAP; }
 
   void print(llvm::raw_ostream &stream) const { print(stream, ""); }
@@ -479,6 +481,15 @@ public:
 
   ref<TxInterpolantAddress> &getInterpolantStyleAddress() {
     return interpolantStyleAddress;
+  }
+
+  /// \brief Copy this address, but increment the indirection count
+  ref<TxStateAddress> copyWithIndirectionCountIncrement() {
+    ref<Expr> offset = interpolantStyleAddress->getOffset();
+    ref<TxStateAddress> ret(new TxStateAddress(
+        interpolantStyleAddress->getContext(), address, base, offset, size));
+    ret->interpolantStyleAddress->incrementIndirectionCount();
+    return ret;
   }
 
   bool

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -553,7 +553,7 @@ private:
   uint64_t directUseCount;
 
   /// \brief All load addresses, transitively
-  std::set<ref<TxStateValue> > allLoadAddresses;
+  std::set<ref<TxStateAddress> > allLoadAddresses;
 
   TxStateValue(llvm::Value *value,
                const std::vector<llvm::Instruction *> &_callHistory,
@@ -596,14 +596,16 @@ public:
 
   void setLoadAddress(ref<TxStateValue> _loadAddress) {
     loadAddress = _loadAddress;
-    allLoadAddresses.clear();
-    allLoadAddresses.insert(_loadAddress);
+    allLoadAddresses.insert(_loadAddress->getLocations().begin(),
+                            _loadAddress->getLocations().end());
   }
 
   ref<TxStateValue> getLoadAddress() { return loadAddress; }
 
   void setStoreAddress(ref<TxStateValue> _storeAddress) {
     storeAddress = _storeAddress;
+    allLoadAddresses.insert(_storeAddress->getLocations().begin(),
+                            _storeAddress->getLocations().end());
   }
 
   ref<TxStateValue> getStoreAddress() { return storeAddress; }
@@ -621,6 +623,8 @@ public:
   const std::map<ref<TxStateValue>, ref<TxStateAddress> > &getSources() {
     return sources;
   }
+
+  std::set<ref<TxStateAddress> > getLoadLocations() { return allLoadAddresses; }
 
   int compare(const TxStateValue other) const {
     if (id == other.id)

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -235,6 +235,8 @@ public:
     return ret;
   }
 
+  bool isHeapAddress() { return context->ty == AllocationContext::HEAP; }
+
   void print(llvm::raw_ostream &stream) const { print(stream, ""); }
 
   void print(llvm::raw_ostream &stream, const std::string &prefix) const;

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -549,6 +549,10 @@ private:
   /// \brief Reasons for this value to be in the core
   std::set<std::string> coreReasons;
 
+  /// \brief The memory locations this value depend upon. The values stored in
+  /// these memory locations have been used to compute the current value.
+  std::set<ref<TxStateAddress> > memoryDependency;
+
   TxStateValue(llvm::Value *value,
                const std::vector<llvm::Instruction *> &_callHistory,
                ref<Expr> _valueExpr)
@@ -658,7 +662,11 @@ public:
                                       coreReasons, locations, replacements);
   }
 
-  /// \brief Print the content of the object into a stream.
+  void addMemoryDependency(ref<TxStateAddress> loc) {
+    memoryDependency.insert(loc);
+  }
+
+  /// \brief Print the content of the object into a stream
   ///
   /// \param stream The stream to print the data to.
   void print(llvm::raw_ostream &stream) const {

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -277,6 +277,9 @@ private:
   /// \brief Do not use bound in subsumption check
   bool doNotUseBound;
 
+  /// \brief Set of memory locations possibly being pointed to
+  std::set<ref<TxStateAddress> > locations;
+
   /// \brief Reason this was stored as needed value
   std::set<std::string> coreReasons;
 
@@ -345,6 +348,8 @@ public:
   ref<Expr> getExpression() const { return expr; }
 
   llvm::Value *getValue() const { return value; }
+
+  std::set<ref<TxStateAddress> > &getLocations() { return locations; }
 
   void print(llvm::raw_ostream &stream) const;
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -347,6 +347,9 @@ public:
                            std::set<ref<Expr> > &bounds,
                            int debugSubsumptionLevel) const;
 
+  ref<Expr> getOffsetsCheck(ref<TxInterpolantValue> svalue,
+                            int debugSubsumptionLevel) const;
+
   ref<Expr> getExpression() const { return expr; }
 
   llvm::Value *getValue() const { return value; }

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -549,12 +549,15 @@ private:
   /// \brief Reasons for this value to be in the core
   std::set<std::string> coreReasons;
 
+  /// \brief Direct use count of this value by another value in all interpolants
+  uint64_t directUseCount;
+
   TxStateValue(llvm::Value *value,
                const std::vector<llvm::Instruction *> &_callHistory,
                ref<Expr> _valueExpr)
       : refCount(0), value(value), valueExpr(_valueExpr), core(false),
         id(reinterpret_cast<uint64_t>(this)), callHistory(_callHistory),
-        doNotInterpolateBound(false) {}
+        doNotInterpolateBound(false), directUseCount(0) {}
 
   /// \brief Print the content of the object, but without showing its source
   /// values.
@@ -636,6 +639,10 @@ public:
     if (!reason.empty())
       coreReasons.insert(reason);
   }
+
+  void incrementDirectUseCount() { ++directUseCount; }
+
+  uint64_t getDirectUseCount() { return directUseCount; }
 
   bool isCore() const { return core; }
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -232,8 +232,6 @@ public:
 
   void incrementIndirectionCount() { indirectionCount++; }
 
-  bool isHeapAddress() { return context->ty == AllocationContext::HEAP; }
-
   void print(llvm::raw_ostream &stream) const { print(stream, ""); }
 
   void print(llvm::raw_ostream &stream, const std::string &prefix) const;

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -549,10 +549,6 @@ private:
   /// \brief Reasons for this value to be in the core
   std::set<std::string> coreReasons;
 
-  /// \brief The memory locations this value depend upon. The values stored in
-  /// these memory locations have been used to compute the current value.
-  std::set<ref<TxStateAddress> > memoryDependency;
-
   TxStateValue(llvm::Value *value,
                const std::vector<llvm::Instruction *> &_callHistory,
                ref<Expr> _valueExpr)
@@ -660,10 +656,6 @@ public:
   getInterpolantStyleValue(std::set<const Array *> &replacements) {
     return TxInterpolantValue::create(value, valueExpr, canInterpolateBound(),
                                       coreReasons, locations, replacements);
-  }
-
-  void addMemoryDependency(ref<TxStateAddress> loc) {
-    memoryDependency.insert(loc);
   }
 
   /// \brief Print the content of the object into a stream

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -552,6 +552,9 @@ private:
   /// \brief Direct use count of this value by another value in all interpolants
   uint64_t directUseCount;
 
+  /// \brief All load addresses, transitively
+  std::set<ref<TxStateValue> > allLoadAddresses;
+
   TxStateValue(llvm::Value *value,
                const std::vector<llvm::Instruction *> &_callHistory,
                ref<Expr> _valueExpr)
@@ -593,6 +596,8 @@ public:
 
   void setLoadAddress(ref<TxStateValue> _loadAddress) {
     loadAddress = _loadAddress;
+    allLoadAddresses.clear();
+    allLoadAddresses.insert(_loadAddress);
   }
 
   ref<TxStateValue> getLoadAddress() { return loadAddress; }
@@ -607,6 +612,10 @@ public:
   /// target value
   void addDependency(ref<TxStateValue> source, ref<TxStateAddress> via) {
     sources[source] = via;
+    if (via.isNull()) {
+      allLoadAddresses.insert(source->allLoadAddresses.begin(),
+                              source->allLoadAddresses.end());
+    }
   }
 
   const std::map<ref<TxStateValue>, ref<TxStateAddress> > &getSources() {

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -54,19 +54,18 @@ void Dependency::removeAddressValue(
            ie = simpleStore.end();
        it != ie; ++it) {
     ref<TxInterpolantAddress> keyAddress = it->first;
-    std::set<ref<TxStateAddress> > &locations = it->second->getLocations();
-    if (locations.size() > 0) {
+    std::set<ref<TxInterpolantAddress> > &addresses =
+        it->second->getInterpolantAddresses();
+    if (addresses.size() > 0) {
       std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> >::iterator
       it1;
-
-      for (std::set<ref<TxStateAddress> >::iterator it2 = locations.begin(),
-                                                    ie2 = locations.end();
+      for (std::set<ref<TxInterpolantAddress> >::iterator
+               it2 = addresses.begin(),
+               ie2 = addresses.end();
            it2 != ie2; ++it2) {
-        ref<TxInterpolantAddress> searchAddress =
-            (*it2)->getInterpolantStyleAddress();
-        it1 = simpleStore.find(searchAddress);
+        it1 = simpleStore.find(*it2);
         if (it1 != simpleStore.end()) {
-          addressesToRemove.insert(searchAddress);
+          addressesToRemove.insert(*it2);
           // Found the address in the map;
           _concreteStore[keyAddress->copyWithIndirectionCountIncrement()] =
               it1->second;

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -374,7 +374,7 @@ void Dependency::addDependencyIntToPtr(ref<TxStateValue> source,
         SubExpr::create(targetExpr, sourceBase), (*it)->getOffset()));
     target->addLocation(TxStateAddress::create(*it, targetExpr, offsetDelta));
   }
-  target->addDependency(source, nullLocation);
+  addDependencyCore(source, target, nullLocation);
 }
 
 void Dependency::addDependencyWithOffset(ref<TxStateValue> source,
@@ -419,7 +419,7 @@ void Dependency::addDependencyWithOffset(ref<TxStateValue> source,
     target->addLocation(TxStateAddress::create(*it, targetExpr, offsetDelta));
     locationAdded = true;
   }
-  target->addDependency(source, nullLocation);
+  addDependencyCore(source, target, nullLocation);
 }
 
 void Dependency::addDependencyViaLocation(ref<TxStateValue> source,
@@ -434,7 +434,7 @@ void Dependency::addDependencyViaLocation(ref<TxStateValue> source,
        it != ie; ++it) {
     target->addLocation(*it);
   }
-  target->addDependency(source, via);
+  addDependencyCore(source, target, via);
 }
 
 void Dependency::addDependencyViaExternalFunction(
@@ -486,7 +486,7 @@ void Dependency::addDependencyToNonPointer(ref<TxStateValue> source,
     return;
 
   ref<TxStateAddress> nullLocation;
-  target->addDependency(source, nullLocation);
+  addDependencyCore(source, target, nullLocation);
 }
 
 std::vector<ref<TxStateValue> >
@@ -891,6 +891,7 @@ void Dependency::execute(llvm::Instruction *instr,
                   : getNewTxStateValue(instr, callHistory, valueExpr);
 
           updateStoreWithLoadedValue(loc, addressValue, loadedValue);
+          setLoadedFrom(loadedValue, loc);
           break;
         } else if (locations.size() == 1) {
           ref<TxStateAddress> loc = *(locations.begin());
@@ -952,6 +953,7 @@ void Dependency::execute(llvm::Instruction *instr,
                     : getNewTxStateValue(instr, callHistory, valueExpr);
 
             updateStoreWithLoadedValue(loc, addressValue, loadedValue);
+            setLoadedFrom(loadedValue, loc);
             break;
           }
         }
@@ -973,6 +975,7 @@ void Dependency::execute(llvm::Instruction *instr,
 
           updateStoreWithLoadedValue(*(locations.begin()), addressValue,
                                      loadedValue);
+          setLoadedFrom(loadedValue, *(locations.begin()));
           break;
         }
       }
@@ -1020,6 +1023,7 @@ void Dependency::execute(llvm::Instruction *instr,
           loadedValue->setLoadAddress(addressValue);
           loadedValue->setStoreAddress(addressValuePair.first);
         }
+        setLoadedFrom(loadedValue, *li);
       }
       break;
     }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1058,6 +1058,14 @@ void Dependency::execute(llvm::Instruction *instr,
                                                     ie = locations.end();
            it != ie; ++it) {
         updateStore(*it, addressValue, storedValue);
+        std::set<ref<MemoryLocation> > &sourceLocations =
+            loadedFromLocations[storedValue];
+        for (std::set<ref<MemoryLocation> >::iterator
+                 it1 = sourceLocations.begin(),
+                 ie1 = sourceLocations.end();
+             it1 != ie1; ++it1) {
+          directlyInfluencing[*it1].insert(*it);
+        }
       }
       break;
     }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -593,6 +593,10 @@ Dependency::Dependency(Dependency *parent, llvm::DataLayout *_targetData)
     symbolicallyAddressedStore = parent->symbolicallyAddressedStore;
     debugSubsumptionLevel = parent->debugSubsumptionLevel;
     debugStateLevel = parent->debugStateLevel;
+
+    loadedFromLocations = parent->loadedFromLocations;
+    directlyInfluencing = parent->directlyInfluencing;
+    directlyInfluencedBy = parent->directlyInfluencedBy;
   } else {
 #ifdef ENABLE_Z3
     debugSubsumptionLevel = DebugSubsumption;

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -46,7 +46,7 @@ namespace klee {
 void Dependency::removeAddressValue(
     std::map<ref<TxStateAddress>, ref<TxStateValue> > &simpleStore,
     Dependency::ConcreteStore &concreteStore,
-    std::set<const Array *> &replacements) {
+    std::set<const Array *> &replacements, bool coreOnly) {
   std::map<ref<TxStateAddress>, ref<TxStateValue> > _concreteStore;
   std::set<ref<TxStateAddress> > addressesToRemove;
 
@@ -85,7 +85,7 @@ void Dependency::removeAddressValue(
     if (addressesToRemove.find(it->first) == addressesToRemoveEnd) {
 #ifdef ENABLE_Z3
       ref<TxInterpolantValue> storedValue;
-      if (!NoExistential) {
+      if (coreOnly && !NoExistential) {
         storedValue = it->second->getInterpolantStyleValue(replacements);
       } else {
         storedValue = it->second->getInterpolantStyleValue();
@@ -106,7 +106,7 @@ void Dependency::removeAddressValue(
        it != ie; ++it) {
 #ifdef ENABLE_Z3
     ref<TxInterpolantValue> storedValue;
-    if (!NoExistential) {
+    if (coreOnly && !NoExistential) {
       storedValue = it->second->getInterpolantStyleValue(replacements);
     } else {
       storedValue = it->second->getInterpolantStyleValue();
@@ -196,7 +196,7 @@ void Dependency::getConcreteStore(
     //      it->second->dump();
     //    }
 
-    removeAddressValue(__concreteStore, concreteStore, replacements);
+    removeAddressValue(__concreteStore, concreteStore, replacements, true);
 
     //    llvm::errs() << "AFTER:\n";
     //    for (Dependency::ConcreteStore::iterator it = concreteStore.begin(),
@@ -216,7 +216,7 @@ void Dependency::getConcreteStore(
     //      }
     //    }
   } else {
-    removeAddressValue(_concreteStore, concreteStore, replacements);
+    removeAddressValue(_concreteStore, concreteStore, replacements, false);
   }
 }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -438,7 +438,7 @@ void Dependency::addDependencyIntToPtr(ref<TxStateValue> source,
         SubExpr::create(targetExpr, sourceBase), (*it)->getOffset()));
     target->addLocation(TxStateAddress::create(*it, targetExpr, offsetDelta));
   }
-  addDependencyCore(source, target, nullLocation);
+  target->addDependency(source, nullLocation);
 }
 
 void Dependency::addDependencyWithOffset(ref<TxStateValue> source,
@@ -483,7 +483,7 @@ void Dependency::addDependencyWithOffset(ref<TxStateValue> source,
     target->addLocation(TxStateAddress::create(*it, targetExpr, offsetDelta));
     locationAdded = true;
   }
-  addDependencyCore(source, target, nullLocation);
+  target->addDependency(source, nullLocation);
 }
 
 void Dependency::addDependencyViaLocation(ref<TxStateValue> source,
@@ -498,7 +498,7 @@ void Dependency::addDependencyViaLocation(ref<TxStateValue> source,
        it != ie; ++it) {
     target->addLocation(*it);
   }
-  addDependencyCore(source, target, via);
+  target->addDependency(source, via);
 }
 
 void Dependency::addDependencyViaExternalFunction(
@@ -550,7 +550,7 @@ void Dependency::addDependencyToNonPointer(ref<TxStateValue> source,
     return;
 
   ref<TxStateAddress> nullLocation;
-  addDependencyCore(source, target, nullLocation);
+  target->addDependency(source, nullLocation);
 }
 
 std::vector<ref<TxStateValue> >

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -179,6 +179,8 @@ void Dependency::getConcreteStore(
 //      it->second->dump();
 //    }
 
+    // The following performs computation of values that are dominated by other
+    // values, wrt. flow to the interpolant / unsat core.
     for (std::map<ref<TxStateValue>, uint64_t>::iterator it = useCount.begin(),
                                                          ie = useCount.end();
          it != ie; ++it) {
@@ -195,6 +197,7 @@ void Dependency::getConcreteStore(
       }
     }
 
+    // Copy only values whose use count not reduced to zero
     for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
              it = _concreteStore.begin(),
              ie = _concreteStore.end();
@@ -218,21 +221,20 @@ void Dependency::getConcreteStore(
     removeAddressValue(__concreteStore, concreteStore, replacements, true);
 
 //    llvm::errs() << "AFTER:\n";
-//    for (Dependency::ConcreteStore::iterator it = concreteStore.begin(),
-//	ie = concreteStore.end();
-//	it != ie; ++it) {
-//	std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> >
-//	addressValueMap =
-//	    it->second;
-//	for (std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue>
-//	    >::iterator
-//	    it1 = addressValueMap.begin(),
-//	    ie1 = addressValueMap.end();
-//	    it1 != ie1; ++it1) {
-//	    llvm::errs() << "-----------------------------\n";
-//	    it1->first->dump();
-//	    it1->second->dump();
-//	}
+//    for (Dependency::InterpolantStore::iterator it = concreteStore.begin(),
+//                                                ie = concreteStore.end();
+//         it != ie; ++it) {
+//      std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> >
+//      addressValueMap = it->second;
+//      for (std::map<ref<TxInterpolantAddress>,
+//                    ref<TxInterpolantValue> >::iterator
+//               it1 = addressValueMap.begin(),
+//               ie1 = addressValueMap.end();
+//           it1 != ie1; ++it1) {
+//        llvm::errs() << "-----------------------------\n";
+//        it1->first->dump();
+//        it1->second->dump();
+//      }
 //    }
   } else {
     removeAddressValue(_concreteStore, concreteStore, replacements, false);

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1062,9 +1062,9 @@ void Dependency::execute(llvm::Instruction *instr,
                                                     ie = locations.end();
            it != ie; ++it) {
         updateStore(*it, addressValue, storedValue);
-        std::set<ref<MemoryLocation> > &sourceLocations =
+        std::set<ref<TxStateAddress> > &sourceLocations =
             loadedFromLocations[storedValue];
-        for (std::set<ref<MemoryLocation> >::iterator
+        for (std::set<ref<TxStateAddress> >::iterator
                  it1 = sourceLocations.begin(),
                  ie1 = sourceLocations.end();
              it1 != ie1; ++it1) {

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1065,6 +1065,7 @@ void Dependency::execute(llvm::Instruction *instr,
                  ie1 = sourceLocations.end();
              it1 != ie1; ++it1) {
           directlyInfluencing[*it1].insert(*it);
+          directlyInfluencedBy[*it].insert(*it1);
         }
       }
       break;

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -146,13 +146,13 @@ void Dependency::getConcreteStore(
     if (!coreOnly) {
       _concreteStore[it->first] = it->second.second;
     } else if (it->second.second->isCore()) {
-        // An address is in the core if it stores a value that is in the core
+      // An address is in the core if it stores a value that is in the core
       _concreteStore[it->first] = it->second.second;
-        std::set<ref<TxStateAddress> > loadLocations =
-            it->second.second->getLoadLocations();
-        valueAddressMap[it->first] =
-            std::pair<std::set<ref<TxStateAddress> >, uint64_t>(
-                loadLocations, it->second.second->getDirectUseCount());
+      std::set<ref<TxStateAddress> > loadLocations =
+          it->second.second->getLoadLocations();
+      valueAddressMap[it->first] =
+          std::pair<std::set<ref<TxStateAddress> >, uint64_t>(
+              loadLocations, it->second.second->getDirectUseCount());
     }
   }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -180,6 +180,9 @@ void Dependency::getConcreteStore(
       for (std::set<ref<TxStateAddress> >::const_iterator it1 = sources.begin(),
                                                           ie1 = sources.end();
            it1 != ie1; ++it1) {
+        // To prevent cycle
+        if ((*it1) == it->first)
+          continue;
         mapIter = valueAddressMap.find(*it1);
         if (mapIter != valueAddressMap.end() && mapIter->second.second > 0)
           --(mapIter->second.second);

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -159,6 +159,16 @@ void Dependency::getConcreteStore(
   if (coreOnly) {
     std::map<ref<TxStateAddress>, ref<TxStateValue> > __concreteStore;
 
+//    llvm::errs() << "STEP0:\n";
+//    for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
+//             it = _concreteStore.begin(),
+//             ie = _concreteStore.end();
+//         it != ie; ++it) {
+//      llvm::errs() << "-----------------------------\n";
+//      it->first->dump();
+//      it->second->dump();
+//    }
+
     for (std::map<ref<TxStateAddress>, std::pair<std::set<ref<TxStateAddress> >,
                                                  uint64_t> >::iterator
              it = valueAddressMap.begin(),
@@ -185,36 +195,35 @@ void Dependency::getConcreteStore(
         __concreteStore[it->first] = _concreteStore[it->first];
     }
 
-    //    llvm::errs() << "BEFORE:\n";
-    //    for (std::map<ref<TxStateAddress>, ref<TxStateValue>
-    // >::iterator
-    //             it = __concreteStore.begin(),
-    //             ie = __concreteStore.end();
-    //         it != ie; ++it) {
-    //      llvm::errs() << "-----------------------------\n";
-    //      it->first->dump();
-    //      it->second->dump();
-    //    }
+//    llvm::errs() << "STEP1:\n";
+//    for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
+//             it = __concreteStore.begin(),
+//             ie = __concreteStore.end();
+//         it != ie; ++it) {
+//      llvm::errs() << "-----------------------------\n";
+//      it->first->dump();
+//      it->second->dump();
+//    }
 
     removeAddressValue(__concreteStore, concreteStore, replacements, true);
 
-    //    llvm::errs() << "AFTER:\n";
-    //    for (Dependency::ConcreteStore::iterator it = concreteStore.begin(),
-    //                                             ie = concreteStore.end();
-    //         it != ie; ++it) {
-    //      std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> >
-    // addressValueMap =
-    //          it->second;
-    //      for (std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue>
-    // >::iterator
-    //               it1 = addressValueMap.begin(),
-    //               ie1 = addressValueMap.end();
-    //           it1 != ie1; ++it1) {
-    //        llvm::errs() << "-----------------------------\n";
-    //        it1->first->dump();
-    //        it1->second->dump();
-    //      }
-    //    }
+//    llvm::errs() << "AFTER:\n";
+//    for (Dependency::ConcreteStore::iterator it = concreteStore.begin(),
+//	ie = concreteStore.end();
+//	it != ie; ++it) {
+//	std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> >
+//	addressValueMap =
+//	    it->second;
+//	for (std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue>
+//	    >::iterator
+//	    it1 = addressValueMap.begin(),
+//	    ie1 = addressValueMap.end();
+//	    it1 != ie1; ++it1) {
+//	    llvm::errs() << "-----------------------------\n";
+//	    it1->first->dump();
+//	    it1->second->dump();
+//	}
+//    }
   } else {
     removeAddressValue(_concreteStore, concreteStore, replacements, false);
   }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -63,7 +63,7 @@ void Dependency::removeAddressValue(
         it1 = simpleStore.find((*it2)->getInterpolantStyleAddress());
         if (it1 != simpleStore.end()) {
           // Found the address in the map;
-          const llvm::Value *base = keyAddress->getContext()->getValue();
+          const llvm::Value *base = keyAddress->getBase();
           concreteStore[base][keyAddress->copyWithIndirectionCountIncrement()] =
               it1->second;
           break;
@@ -71,7 +71,7 @@ void Dependency::removeAddressValue(
       }
     } else if (!it->first->isHeapAddress()) {
       // Not a heap pointer value, copy as is
-      llvm::Value *base = keyAddress->getContext()->getValue();
+      llvm::Value *base = keyAddress->getBase();
       concreteStore[base][keyAddress] = simpleStore[keyAddress];
     }
   }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -332,7 +332,6 @@ void Dependency::updateStoreWithLoadedValue(ref<TxStateAddress> loc,
                                             ref<TxStateValue> value) {
   updateStore(loc, address, value);
   value->setLoadAddress(address);
-  value->addMemoryDependency(loc);
 }
 
 void Dependency::updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -200,6 +200,12 @@ namespace klee {
     std::map<ref<TxStateValue>, std::set<ref<TxStateAddress> > >
     loadedFromLocations;
 
+    /// \brief Set the address a value was loaded from
+    void setLoadedFrom(ref<TxStateValue> value, ref<TxStateAddress> loc) {
+      loadedFromLocations[value].clear();
+      loadedFromLocations[value].insert(loc);
+    }
+
     /// \brief Tests if a pointer points to a main function's argument
     static bool isMainArgument(const llvm::Value *loc);
 
@@ -260,6 +266,14 @@ namespace klee {
     /// \brief Newly relate an location with its stored value
     void updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
                      ref<TxStateValue> value);
+
+    /// \brief The core procedure for connecting the dependency graph
+    void addDependencyCore(ref<TxStateValue> source, ref<TxStateValue> target,
+                           ref<TxStateAddress> via) {
+      target->addDependency(source, via);
+      std::set<ref<TxStateAddress> > &locations = loadedFromLocations[source];
+      loadedFromLocations[target].insert(locations.begin(), locations.end());
+    }
 
     /// \brief Add flow dependency between source and target value
     void addDependency(ref<TxStateValue> source, ref<TxStateValue> target,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -196,31 +196,6 @@ namespace klee {
     /// \brief The data layout of the analysis target program
     llvm::DataLayout *targetData;
 
-    /// \brief A mapping to record where each value was loaded from
-    std::map<ref<TxStateValue>, std::set<ref<TxStateAddress> > >
-    loadedFromLocations;
-
-    /// \brief A relation encoding direct influencing of a memory location to
-    /// another
-    std::map<ref<TxStateAddress>, std::set<ref<TxStateAddress> > >
-    directlyInfluencing;
-
-    /// \brief A relation encoding memory locations influencing another
-    std::map<ref<TxStateAddress>, std::set<ref<TxStateAddress> > >
-    directlyInfluencedBy;
-
-    /// \brief Set the address a value was loaded from
-    void setLoadedFrom(ref<TxStateValue> value, ref<TxStateAddress> loc) {
-      std::map<ref<TxStateValue>, std::set<ref<TxStateAddress> > >::iterator
-      it = loadedFromLocations.find(value);
-      if (it != loadedFromLocations.end()) {
-        it->second.clear();
-        it->second.insert(loc);
-      } else {
-        loadedFromLocations[value].insert(loc);
-      }
-    }
-
     /// \brief Tests if a pointer points to a main function's argument
     static bool isMainArgument(const llvm::Value *loc);
 
@@ -286,8 +261,6 @@ namespace klee {
     void addDependencyCore(ref<TxStateValue> source, ref<TxStateValue> target,
                            ref<TxStateAddress> via) {
       target->addDependency(source, via);
-      std::set<ref<TxStateAddress> > &locations = loadedFromLocations[source];
-      loadedFromLocations[target].insert(locations.begin(), locations.end());
     }
 
     /// \brief Add flow dependency between source and target value

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -202,17 +202,27 @@ namespace klee {
 
     /// \brief A relation encoding direct influencing of a memory location to
     /// another
-    std::map<ref<MemoryLocation>, std::set<ref<MemoryLocation> > >
+    std::map<ref<TxStateAddress>, std::set<ref<TxStateAddress> > >
     directlyInfluencing;
 
     /// \brief A relation encoding memory locations influencing another
-    std::map<ref<MemoryLocation>, std::set<ref<MemoryLocation> > >
+    std::map<ref<TxStateAddress>, std::set<ref<TxStateAddress> > >
     directlyInfluencedBy;
+
+    /// \brief This counts the number of uses of a memory location by another
+    /// memory location, of the locations that belong to the interpolant
+    std::map<ref<TxStateAddress>, uint64_t> directUseCount;
 
     /// \brief Set the address a value was loaded from
     void setLoadedFrom(ref<TxStateValue> value, ref<TxStateAddress> loc) {
-      loadedFromLocations[value].clear();
-      loadedFromLocations[value].insert(loc);
+      std::map<ref<TxStateValue>, std::set<ref<TxStateAddress> > >::iterator
+      it = loadedFromLocations.find(value);
+      if (it != loadedFromLocations.end()) {
+        it->second.clear();
+        it->second.insert(loc);
+      } else {
+        loadedFromLocations[value].insert(loc);
+      }
     }
 
     /// \brief Tests if a pointer points to a main function's argument

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -330,7 +330,7 @@ namespace klee {
     static void removeAddressValue(
         std::map<ref<TxStateAddress>, ref<TxStateValue> > &simpleStore,
         Dependency::ConcreteStore &concreteStore,
-        std::set<const Array *> &replacements);
+        std::set<const Array *> &replacements, bool coreOnly);
 
     void getConcreteStore(
         const std::vector<llvm::Instruction *> &callHistory,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -247,6 +247,12 @@ namespace klee {
     ref<TxStateValue> getLatestValueForMarking(llvm::Value *val,
                                                ref<Expr> expr);
 
+    /// \brief Newly relate a location with its stored value, when the value is
+    /// loaded from the location
+    void updateStoreWithLoadedValue(ref<TxStateAddress> loc,
+                                    ref<TxStateValue> address,
+                                    ref<TxStateValue> value);
+
     /// \brief Newly relate an location with its stored value
     void updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
                      ref<TxStateValue> value);

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -200,6 +200,11 @@ namespace klee {
     std::map<ref<TxStateValue>, std::set<ref<TxStateAddress> > >
     loadedFromLocations;
 
+    /// \brief A relation encoding direct influencing of a memory location to
+    /// another
+    std::map<ref<MemoryLocation>, std::set<ref<MemoryLocation> > >
+    directlyInfluencing;
+
     /// \brief Set the address a value was loaded from
     void setLoadedFrom(ref<TxStateValue> value, ref<TxStateAddress> loc) {
       loadedFromLocations[value].clear();

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -327,10 +327,10 @@ namespace klee {
         std::vector<ref<Expr> > &arguments,
         std::vector<ref<TxStateValue> > &argumentValuesList);
 
-    static void
-    removeAddressValue(std::map<ref<TxInterpolantAddress>,
-                                ref<TxInterpolantValue> > &simpleStore,
-                       Dependency::ConcreteStore &concreteStore);
+    static void removeAddressValue(
+        std::map<ref<TxStateAddress>, ref<TxStateValue> > &simpleStore,
+        Dependency::ConcreteStore &concreteStore,
+        std::set<const Array *> &replacements);
 
     void getConcreteStore(
         const std::vector<llvm::Instruction *> &callHistory,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -327,6 +327,11 @@ namespace klee {
         std::vector<ref<Expr> > &arguments,
         std::vector<ref<TxStateValue> > &argumentValuesList);
 
+    static void
+    removeAddressValue(std::map<ref<TxInterpolantAddress>,
+                                ref<TxInterpolantValue> > &simpleStore,
+                       Dependency::ConcreteStore &concreteStore);
+
     void getConcreteStore(
         const std::vector<llvm::Instruction *> &callHistory,
         const std::map<ref<TxStateAddress>,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -196,6 +196,10 @@ namespace klee {
     /// \brief The data layout of the analysis target program
     llvm::DataLayout *targetData;
 
+    /// \brief A mapping to record where each value was loaded from
+    std::map<ref<TxStateValue>, std::set<ref<TxStateAddress> > >
+    loadedFromLocations;
+
     /// \brief Tests if a pointer points to a main function's argument
     static bool isMainArgument(const llvm::Value *loc);
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -209,9 +209,9 @@ namespace klee {
     std::map<ref<TxStateAddress>, std::set<ref<TxStateAddress> > >
     directlyInfluencedBy;
 
-    /// \brief This counts the number of uses of a memory location by another
-    /// memory location, of the locations that belong to the interpolant
-    std::map<ref<TxStateAddress>, uint64_t> directUseCount;
+    /// \brief This counts the number of direct uses of a value by another
+    /// value, of the values that belong to the interpolant
+    std::map<ref<TxStateValue>, uint64_t> directUseCount;
 
     /// \brief Set the address a value was loaded from
     void setLoadedFrom(ref<TxStateValue> value, ref<TxStateAddress> loc) {

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -205,6 +205,10 @@ namespace klee {
     std::map<ref<MemoryLocation>, std::set<ref<MemoryLocation> > >
     directlyInfluencing;
 
+    /// \brief A relation encoding memory locations influencing another
+    std::map<ref<MemoryLocation>, std::set<ref<MemoryLocation> > >
+    directlyInfluencedBy;
+
     /// \brief Set the address a value was loaded from
     void setLoadedFrom(ref<TxStateValue> value, ref<TxStateAddress> loc) {
       loadedFromLocations[value].clear();

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -257,12 +257,6 @@ namespace klee {
     void updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
                      ref<TxStateValue> value);
 
-    /// \brief The core procedure for connecting the dependency graph
-    void addDependencyCore(ref<TxStateValue> source, ref<TxStateValue> target,
-                           ref<TxStateAddress> via) {
-      target->addDependency(source, via);
-    }
-
     /// \brief Add flow dependency between source and target value
     void addDependency(ref<TxStateValue> source, ref<TxStateValue> target,
                        bool multiLocationsCheck = true);

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -209,10 +209,6 @@ namespace klee {
     std::map<ref<TxStateAddress>, std::set<ref<TxStateAddress> > >
     directlyInfluencedBy;
 
-    /// \brief This counts the number of direct uses of a value by another
-    /// value, of the values that belong to the interpolant
-    std::map<ref<TxStateValue>, uint64_t> directUseCount;
-
     /// \brief Set the address a value was loaded from
     void setLoadedFrom(ref<TxStateValue> value, ref<TxStateAddress> loc) {
       std::map<ref<TxStateValue>, std::set<ref<TxStateAddress> > >::iterator
@@ -335,7 +331,8 @@ namespace klee {
 
     /// \brief Mark as core all the values and locations that flows to the
     /// target
-    void markFlow(ref<TxStateValue> target, const std::string &reason) const;
+    void markFlow(ref<TxStateValue> target, const std::string &reason,
+                  bool incrementDirectUseCount = true) const;
 
     /// \brief Mark as core all the pointer values and that flows to the target;
     /// and adjust its offset bound for memory bounds interpolation (a.k.a.
@@ -353,7 +350,8 @@ namespace klee {
     void markPointerFlow(ref<TxStateValue> target,
                          ref<TxStateValue> checkedOffset,
                          std::set<ref<Expr> > &bounds,
-                         const std::string &reason) const;
+                         const std::string &reason,
+                         bool incrementUseCount = true) const;
 
     /// \brief Record the expressions of a call's arguments
     void populateArgumentValuesList(

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1038,9 +1038,11 @@ bool SubsumptionTableEntry::subsumed(
 
   ref<Expr> stateEqualityConstraints;
 
-  std::map<ref<TxInterpolantValue>, std::set<ref<Expr> > >
-  corePointerValues; // Pointer values in the core for memory bounds
-  // interpolation
+  // Pointer values in the core for memory bounds interpolation
+  std::map<ref<TxInterpolantValue>, std::set<ref<Expr> > > corePointerValues;
+
+  // Pointer values in the core for exact equality
+  std::set<ref<TxInterpolantValue> > coreExactPointerValues;
 
   {
     TimerStatIncrementer t(concreteStoreExpressionBuildTime);
@@ -1118,30 +1120,53 @@ bool SubsumptionTableEntry::subsumed(
                            nodeSequenceNumber, msg.c_str());
             }
             return false;
-          } else if (!NoBoundInterpolation && !ExactAddressInterpolant &&
-                     tabledValue->isPointer() && stateValue->isPointer() &&
-                     tabledValue->useBound()) {
-            std::set<ref<Expr> > bounds;
-            ref<Expr> boundsCheck =
-                tabledValue->getBoundsCheck(stateValue, bounds, debugSubsumptionLevel);
-            if (boundsCheck->isFalse()) {
-              if (debugSubsumptionLevel >= 1) {
-                std::string msg;
-                if (!corePointerValues.empty()) {
-                  msg += " (with successful memory bound checks)";
+          } else if (!NoBoundInterpolation && tabledValue->isPointer() &&
+                     stateValue->isPointer()) {
+            if (!ExactAddressInterpolant && tabledValue->useBound()) {
+              std::set<ref<Expr> > bounds;
+              ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
+                  stateValue, bounds, debugSubsumptionLevel);
+              if (boundsCheck->isFalse()) {
+                if (debugSubsumptionLevel >= 1) {
+                  std::string msg;
+                  if (!corePointerValues.empty()) {
+                    msg += " (with successful memory bound checks)";
+                  }
+                  klee_message("#%lu=>#%lu: Check failure due to failure in "
+                               "memory bounds check%s",
+                               state.txTreeNode->getNodeSequenceNumber(),
+                               nodeSequenceNumber, msg.c_str());
                 }
-                klee_message("#%lu=>#%lu: Check failure due to failure in "
-                             "memory bounds check%s",
-                             state.txTreeNode->getNodeSequenceNumber(),
-                             nodeSequenceNumber, msg.c_str());
+                return false;
               }
-              return false;
-            }
-            if (!boundsCheck->isTrue())
-              res = boundsCheck;
+              if (!boundsCheck->isTrue())
+                res = boundsCheck;
 
-            // We record the LLVM value of the pointer
-            corePointerValues[stateValue] = bounds;
+              // We record the LLVM value of the pointer
+              corePointerValues[stateValue] = bounds;
+            } else {
+              ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
+                  stateValue, debugSubsumptionLevel);
+
+              if (offsetsCheck->isFalse()) {
+                if (debugSubsumptionLevel >= 1) {
+                  std::string msg;
+                  if (!corePointerValues.empty()) {
+                    msg += " (with successful offset equality checks)";
+                  }
+                  klee_message("#%lu=>#%lu: Check failure due to failure in "
+                               "offset equality check%s",
+                               state.txTreeNode->getNodeSequenceNumber(),
+                               nodeSequenceNumber, msg.c_str());
+                }
+                return false;
+              }
+              if (!offsetsCheck->isTrue())
+                res = offsetsCheck;
+
+              // We record the value of the pointer for interpolation marking
+              coreExactPointerValues.insert(stateValue);
+            }
           } else {
             res = EqExpr::create(tabledValue->getExpression(),
                                  stateValue->getExpression());
@@ -1239,27 +1264,50 @@ bool SubsumptionTableEntry::subsumed(
                   ConstantExpr::create(0, Expr::Bool),
                   EqExpr::create(tabledConcreteOffset, stateSymbolicOffset));
 
-            } else if (!NoBoundInterpolation && !ExactAddressInterpolant &&
-                       tabledValue->isPointer() && stateValue->isPointer() &&
-                       tabledValue->useBound()) {
-              std::set<ref<Expr> > bounds;
-              ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
-                  stateValue, bounds, debugSubsumptionLevel);
+            } else if (!NoBoundInterpolation && tabledValue->isPointer() &&
+                       stateValue->isPointer()) {
+              if (!ExactAddressInterpolant && tabledValue->useBound()) {
+                std::set<ref<Expr> > bounds;
+                ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
+                    stateValue, bounds, debugSubsumptionLevel);
 
-              if (!boundsCheck->isTrue()) {
-                newTerm = EqExpr::create(
-                    ConstantExpr::create(0, Expr::Bool),
-                    EqExpr::create(tabledConcreteOffset, stateSymbolicOffset));
+                if (!boundsCheck->isTrue()) {
+                  newTerm = EqExpr::create(ConstantExpr::create(0, Expr::Bool),
+                                           EqExpr::create(tabledConcreteOffset,
+                                                          stateSymbolicOffset));
 
-                if (!boundsCheck->isFalse()) {
-                  // Implication: if tabledConcreteAddress ==
-                  // stateSymbolicAddress then bounds check must hold
-                  newTerm = OrExpr::create(newTerm, boundsCheck);
+                  if (!boundsCheck->isFalse()) {
+                    // Implication: if tabledConcreteAddress ==
+                    // stateSymbolicAddress then bounds check must hold
+                    newTerm = OrExpr::create(newTerm, boundsCheck);
+                  }
                 }
-              }
 
-              // We record the LLVM value of the pointer
-              corePointerValues[stateValue] = bounds;
+                // We record the LLVM value of the pointer
+                corePointerValues[stateValue] = bounds;
+              } else {
+                ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
+                    stateValue, debugSubsumptionLevel);
+
+                if (offsetsCheck->isFalse()) {
+                  if (debugSubsumptionLevel >= 1) {
+                    std::string msg;
+                    if (!corePointerValues.empty()) {
+                      msg += " (with successful offset equality checks)";
+                    }
+                    klee_message("#%lu=>#%lu: Check failure due to failure in "
+                                 "offset equality check%s",
+                                 state.txTreeNode->getNodeSequenceNumber(),
+                                 nodeSequenceNumber, msg.c_str());
+                  }
+                  return false;
+                }
+                if (!offsetsCheck->isTrue())
+                  res = offsetsCheck;
+
+                // We record the value of the pointer for interpolation marking
+                coreExactPointerValues.insert(stateValue);
+              }
             } else {
               // Implication: if tabledConcreteAddress == stateSymbolicAddress,
               // then tabledValue->getExpression() ==
@@ -1353,27 +1401,47 @@ bool SubsumptionTableEntry::subsumed(
             newTerm = EqExpr::create(
                 ConstantExpr::create(0, Expr::Bool),
                 EqExpr::create(tabledSymbolicOffset, stateConcreteOffset));
-          } else if (!NoBoundInterpolation && !ExactAddressInterpolant &&
-                     tabledValue->isPointer() && stateValue->isPointer() &&
-                     tabledValue->useBound()) {
-            std::set<ref<Expr> > bounds;
-            ref<Expr> boundsCheck =
-                tabledValue->getBoundsCheck(stateValue, bounds, debugSubsumptionLevel);
+          } else if (!NoBoundInterpolation && tabledValue->isPointer() &&
+                     stateValue->isPointer()) {
+            if (!ExactAddressInterpolant && tabledValue->useBound()) {
+              std::set<ref<Expr> > bounds;
+              ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
+                  stateValue, bounds, debugSubsumptionLevel);
 
-            if (!boundsCheck->isTrue()) {
-              newTerm = EqExpr::create(
-                  ConstantExpr::create(0, Expr::Bool),
-                  EqExpr::create(tabledSymbolicOffset, stateConcreteOffset));
+              if (!boundsCheck->isTrue()) {
+                newTerm = EqExpr::create(
+                    ConstantExpr::create(0, Expr::Bool),
+                    EqExpr::create(tabledSymbolicOffset, stateConcreteOffset));
 
-              if (!boundsCheck->isFalse()) {
-                // Implication: if tabledConcreteAddress == stateSymbolicAddress
-                // then bounds check must hold
-                newTerm = OrExpr::create(newTerm, boundsCheck);
+                if (!boundsCheck->isFalse()) {
+                  // Implication: if tabledConcreteAddress ==
+                  // stateSymbolicAddress
+                  // then bounds check must hold
+                  newTerm = OrExpr::create(newTerm, boundsCheck);
+                }
               }
-            }
 
-            // We record the LLVM value of the pointer
-            corePointerValues[stateValue] = bounds;
+              // We record the LLVM value of the pointer
+              corePointerValues[stateValue] = bounds;
+            } else {
+              ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
+                  stateValue, debugSubsumptionLevel);
+
+              if (!offsetsCheck->isTrue()) {
+                newTerm = EqExpr::create(
+                    ConstantExpr::create(0, Expr::Bool),
+                    EqExpr::create(tabledSymbolicOffset, stateConcreteOffset));
+
+                if (!offsetsCheck->isFalse()) {
+                  // Implication: if tabledConcreteAddress ==
+                  // stateSymbolicAddress then offsets must be equal
+                  newTerm = OrExpr::create(newTerm, offsetsCheck);
+                }
+              }
+
+              // We record the value of the pointer for interpolation marking
+              coreExactPointerValues.insert(stateValue);
+            }
           } else {
             // Implication: if tabledSymbolicAddress == stateConcreteAddress,
             // then tabledValue == stateValue
@@ -1415,27 +1483,48 @@ bool SubsumptionTableEntry::subsumed(
             newTerm = EqExpr::create(
                 ConstantExpr::create(0, Expr::Bool),
                 EqExpr::create(tabledSymbolicOffset, stateSymbolicOffset));
-          } else if (!NoBoundInterpolation && !ExactAddressInterpolant &&
-                     tabledValue->isPointer() && stateValue->isPointer() &&
-                     tabledValue->useBound()) {
-            std::set<ref<Expr> > bounds;
-            ref<Expr> boundsCheck =
-                tabledValue->getBoundsCheck(stateValue, bounds, debugSubsumptionLevel);
+          } else if (!NoBoundInterpolation && tabledValue->isPointer() &&
+                     stateValue->isPointer()) {
+            if (!ExactAddressInterpolant && tabledValue->useBound()) {
+              std::set<ref<Expr> > bounds;
+              ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
+                  stateValue, bounds, debugSubsumptionLevel);
 
-            if (!boundsCheck->isTrue()) {
-              newTerm = EqExpr::create(
-                  ConstantExpr::create(0, Expr::Bool),
-                  EqExpr::create(tabledSymbolicOffset, stateSymbolicOffset));
+              if (!boundsCheck->isTrue()) {
+                newTerm = EqExpr::create(
+                    ConstantExpr::create(0, Expr::Bool),
+                    EqExpr::create(tabledSymbolicOffset, stateSymbolicOffset));
 
-              if (!boundsCheck->isFalse()) {
-                // Implication: if tabledConcreteAddress == stateSymbolicAddress
-                // then bounds check must hold
-                newTerm = OrExpr::create(newTerm, boundsCheck);
+                if (!boundsCheck->isFalse()) {
+                  // Implication: if tabledConcreteAddress ==
+                  // stateSymbolicAddress
+                  // then bounds check must hold
+                  newTerm = OrExpr::create(newTerm, boundsCheck);
+                }
               }
-            }
 
-            // We record the LLVM value of the pointer
-            corePointerValues[stateValue] = bounds;
+              // We record the LLVM value of the pointer
+              corePointerValues[stateValue] = bounds;
+            } else {
+              std::set<ref<Expr> > bounds;
+              ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
+                  stateValue, debugSubsumptionLevel);
+
+              if (!offsetsCheck->isTrue()) {
+                newTerm = EqExpr::create(
+                    ConstantExpr::create(0, Expr::Bool),
+                    EqExpr::create(tabledSymbolicOffset, stateSymbolicOffset));
+
+                if (!offsetsCheck->isFalse()) {
+                  // Implication: if tabledConcreteAddress ==
+                  // stateSymbolicAddress then offsets must be equal
+                  newTerm = OrExpr::create(newTerm, offsetsCheck);
+                }
+              }
+
+              // We record the value of the pointer
+              coreExactPointerValues.insert(stateValue);
+            }
           } else {
             // Implication: if tabledSymbolicAddress == stateSymbolicAddress
             // then tabledValue == stateValue
@@ -1525,6 +1614,14 @@ bool SubsumptionTableEntry::subsumed(
         state.txTreeNode->pointerValuesInterpolation(it->first->getValue(),
                                                      it->first->getExpression(),
                                                      it->second, reason);
+      }
+
+      for (std::set<ref<TxInterpolantValue> >::iterator
+               it = coreExactPointerValues.begin(),
+               ie = coreExactPointerValues.end();
+           it != ie; ++it) {
+        state.txTreeNode->exactPointerValuesInterpolation(
+            (*it)->getValue(), (*it)->getExpression(), reason);
       }
       return true;
     }

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -669,6 +669,12 @@ public:
     dependency->markAllPointerValues(value, address, bounds, reason);
   }
 
+  /// \brief Exact pointer value interpolation from a target address
+  void exactPointerValuesInterpolation(llvm::Value *value, ref<Expr> address,
+                                       const std::string &reason) {
+    dependency->markAllValues(value, address, reason);
+  }
+
   /// \brief Print the content of the tree node object to the LLVM error stream.
   void dump() const;
 

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -143,6 +143,8 @@ void TxInterpolantValue::init(llvm::Value *_value, ref<Expr> _expr,
 
   doNotUseBound = !canInterpolateBound;
 
+  locations = _locations;
+
   coreReasons = _coreReasons;
 
   for (std::set<ref<TxStateAddress> >::const_iterator it = _locations.begin(),

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -32,12 +32,60 @@ using namespace klee;
 
 namespace klee {
 
+ref<AllocationContext> AllocationContext::create(
+    llvm::Value *_value, const std::vector<llvm::Instruction *> &_callHistory) {
+  Type ty = GLOBAL;
+
+  if (llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(_value)) {
+    if (inst->getParent() && inst->getParent()->getParent()) {
+      // Heap-allocated memory is considered global, and to be recorded in
+      // global frame. Here we test if the allocation was a call to *alloc and
+      // getenv functions.
+      if (llvm::CallInst *ci = llvm::dyn_cast<llvm::CallInst>(inst)) {
+        // Here we determine if this was a call to *alloc or getenv functions
+        // from the LLVM source of the call instruction instead of
+        // llvm::Function::getName(). This is to circumvent segmentation fault
+        // issue when libc is not linked.
+        std::string buf;
+        llvm::raw_string_ostream stream(buf);
+        ci->print(stream);
+        stream.flush();
+        if (buf.find("@malloc(") != std::string::npos ||
+            buf.find("@realloc(") != std::string::npos ||
+            buf.find("@calloc(") != std::string::npos) {
+          ty = HEAP;
+        } else if (buf.find("@getenv(") != std::string::npos) {
+          ty = GLOBAL;
+        }
+      } else {
+        ty = LOCAL;
+      }
+    }
+  }
+
+  ref<AllocationContext> ret(new AllocationContext(ty, _value, _callHistory));
+  return ret;
+}
+
 void AllocationContext::print(llvm::raw_ostream &stream,
                               const std::string &prefix) const {
   std::string tabs = makeTabs(1);
   if (value) {
     stream << prefix << "Location: ";
     value->print(stream);
+    switch (ty) {
+    case LOCAL:
+      stream << " (local)";
+      break;
+    case GLOBAL:
+      stream << " (global)";
+      break;
+    case HEAP:
+      stream << " (heap)";
+      break;
+    default:
+      break;
+    }
   }
   if (callHistory.size() > 0) {
     stream << "\n" << prefix << "Call history:";

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -105,7 +105,15 @@ void TxInterpolantAddress::print(llvm::raw_ostream &stream,
                                  const std::string &prefix) const {
   std::string tabsNext = appendTab(prefix);
 
-  stream << prefix << "function/value: ";
+  stream << prefix << "indirection: ";
+  if (indirectionCount == 0)
+    stream << "(none)";
+  else {
+    for (uint64_t i = 0; i < indirectionCount; ++i) {
+      stream << "*";
+    }
+  }
+  stream << prefix << "\nfunction/value: ";
   if (outputFunctionName(context->getValue(), stream))
     stream << "/";
   context->getValue()->print(stream);

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -151,13 +151,14 @@ void TxInterpolantValue::init(llvm::Value *_value, ref<Expr> _expr,
 
   doNotUseBound = !canInterpolateBound;
 
-  locations = _locations;
-
   coreReasons = _coreReasons;
 
   for (std::set<ref<TxStateAddress> >::const_iterator it = _locations.begin(),
                                                       ie = _locations.end();
        it != ie; ++it) {
+    // We initialize the locations member variable
+    locations.insert((*it)->getInterpolantStyleAddress());
+
     ref<AllocationContext> context =
         (*it)->getContext(); // The allocation context
 

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -156,9 +156,6 @@ void TxInterpolantValue::init(llvm::Value *_value, ref<Expr> _expr,
   for (std::set<ref<TxStateAddress> >::const_iterator it = _locations.begin(),
                                                       ie = _locations.end();
        it != ie; ++it) {
-    // We initialize the locations member variable
-    locations.insert((*it)->getInterpolantStyleAddress());
-
     ref<AllocationContext> context =
         (*it)->getContext(); // The allocation context
 

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -113,7 +113,7 @@ void TxInterpolantAddress::print(llvm::raw_ostream &stream,
       stream << "*";
     }
   }
-  stream << prefix << "\nfunction/value: ";
+  stream << "\n" << prefix << "function/value: ";
   if (outputFunctionName(context->getValue(), stream))
     stream << "/";
   context->getValue()->print(stream);


### PR DESCRIPTION
This PR implements forward domination algorithm towards resolving issue #199 and in addition, abstracts memory addresses that are dereferenced via another address. For the second issue, see example `basic/malloc3.c` of `klee-examples` repository. In this example, the malloc addresses assigned to `y` are regarded as address `*y`. In effect, we *eliminated* the malloc address from the expression. As such, they can be related at subsumption checks, as both interpolant table entry and the state to be subsumed would contain the same key.