### PR TITLE
Fix to nondeterminism in subsumption profile

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -69,19 +69,31 @@ void Dependency::getConcreteStore(
 
     if (!coreOnly) {
       const llvm::Value *base = it1->first->getContext()->getValue();
-      concreteStore[base][it1->first->getInterpolantStyleAddress()] =
-          it1->second.second->getInterpolantStyleValue();
+      ref<TxInterpolantAddress> address =
+          it1->first->getInterpolantStyleAddress();
+      std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> > &
+      addressValueMap = concreteStore[base];
+      if (addressValueMap.find(address) == addressValueMap.end()) {
+        addressValueMap[address] =
+            it1->second.second->getInterpolantStyleValue();
+      }
     } else if (it1->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
       const llvm::Value *base = it1->first->getContext()->getValue();
+      ref<TxInterpolantAddress> address =
+          it1->first->getInterpolantStyleAddress();
+      std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> > &
+      addressValueMap = concreteStore[base];
+      if (addressValueMap.find(address) == addressValueMap.end()) {
 #ifdef ENABLE_Z3
-      if (!NoExistential) {
-        concreteStore[base][it1->first->getInterpolantStyleAddress()] =
-            it1->second.second->getInterpolantStyleValue(replacements);
-      } else
+        if (!NoExistential) {
+          addressValueMap[address] =
+              it1->second.second->getInterpolantStyleValue(replacements);
+        } else
 #endif
-        concreteStore[base][it1->first->getInterpolantStyleAddress()] =
-            it1->second.second->getInterpolantStyleValue();
+          addressValueMap[address] =
+              it1->second.second->getInterpolantStyleValue();
+      }
     }
   }
 }

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -181,10 +181,16 @@ namespace klee {
              std::pair<ref<TxStateValue>, ref<TxStateValue> > >
     concretelyAddressedStore;
 
+    /// \brief Ordered keys of the concretely-addressed store.
+    std::vector<ref<TxStateAddress> > concretelyAddressedStoreKeys;
+
     /// \brief The mapping of symbolic locations to stored value
     std::map<ref<TxStateAddress>,
              std::pair<ref<TxStateValue>, ref<TxStateValue> > >
     symbolicallyAddressedStore;
+
+    /// \brief Ordered keys of the symbolically-addressed store.
+    std::vector<ref<TxStateAddress> > symbolicallyAddressedStoreKeys;
 
     /// \brief The store of the versioned values
     std::map<llvm::Value *, std::vector<ref<TxStateValue> > > valuesMap;
@@ -324,6 +330,7 @@ namespace klee {
         const std::map<ref<TxStateAddress>,
                        std::pair<ref<TxStateValue>, ref<TxStateValue> > > &
             store,
+        const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
         std::set<const Array *> &replacements, bool coreOnly,
         Dependency::ConcreteStore &concreteStore) const;
 
@@ -332,6 +339,7 @@ namespace klee {
         const std::map<ref<TxStateAddress>,
                        std::pair<ref<TxStateValue>, ref<TxStateValue> > > &
             store,
+        const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
         std::set<const Array *> &replacements, bool coreOnly,
         Dependency::SymbolicStore &symbolicStore) const;
 


### PR DESCRIPTION
This fix nondeterminism in subumption profile. The cause is the lack of ordering in the addresses stored in the table. This fix the issue by introducing the ordered `Dependency::concretelyAddressedStoreKeys` and `Dependency::symbolicallyAddressedStoreKeys`.