### PR TITLE
Separated the removal of unsubstituted equalities and the generation …

### DIFF
--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -449,15 +449,20 @@ class SubsumptionTableEntry {
   static ref<Expr> simplifyArithmeticBody(ref<Expr> existsExpr,
                                           bool &hasExistentialsOnly);
 
-  static ref<Expr> getSubstitution(ref<Expr> equalities,
-                                   std::map<ref<Expr>, ref<Expr> > &map);
+  /// \brief Function to collect substitution from a conjunction of equalities.
+  static void getSubstitution(ref<Expr> equalities,
+                              std::map<ref<Expr>, ref<Expr> > &map);
+
+  /// \brief Function to remove equalities whose lhs is a variable in the set.
+  static ref<Expr> removeUnsubstituted(std::set<const Array *> &variables,
+                                       ref<Expr> equalities);
 
   bool empty() {
     return interpolant.isNull() && concreteAddressStore.empty() &&
            symbolicAddressStore.empty();
   }
 
-  /// \brief For printing member functions running time statistics
+  /// \brief For printing member functions running time statistics,
   static void printStat(std::stringstream &stream);
 
 public:


### PR DESCRIPTION
…of substitutioin in `Dependency::simplifyExistsExpression`. This resolves the following issue with 6-elements bubble sort (`scalability/bubble6.c` in `klee-examples` repository), where the simplification result is wrong.
```
KLEE: Before simplification:
antecedent:
        !(a[7].a[6].a[5].a[4] \< a[3].a[2].a[1].a[0])
        !(a[11].a[10].a[9].a[8] \< a[7].a[6].a[5].a[4])
        !(a[15].a[14].a[13].a[12] \< a[11].a[10].a[9].a[8])
        (a[19].a[18].a[17].a[16] \< a[15].a[14].a[13].a[12])
        (a[23].a[22].a[21].a[20] \< a[15].a[14].a[13].a[12])
        !(a[19].a[18].a[17].a[16] \< a[11].a[10].a[9].a[8])
consequent:
        (exists (__shadow__a) ((((((!(__shadow__a[19].__shadow__a[18].__shadow__a[17].__shadow__a[16] \< __shadow__a[11].__shadow__a[10].__shadow__a[9].__shadow__a[8]) & !(__shadow__a[23].__shadow__a[22].__shadow__a[21].__shadow__a[20] \< __shadow__a[15].__shadow__a[14].__shadow__a[13].__shadow__a[12])) & (__shadow__a[19].__shadow__a[18].__shadow__a[17].__shadow__a[16] \< __shadow__a[15].__shadow__a[14].__shadow__a[13].__shadow__a[12])) & !(__shadow__a[15].__shadow__a[14].__shadow__a[13].__shadow__a[12] \< __shadow__a[11].__shadow__a[10].__shadow__a[9].__shadow__a[8])) & !(__shadow__a[11].__shadow__a[10].__shadow__a[9].__shadow__a[8] \< __shadow__a[7].__shadow__a[6].__shadow__a[5].__shadow__a[4])) & !(__shadow__a[7].__shadow__a[6].__shadow__a[5].__shadow__a[4] \< __shadow__a[3].__shadow__a[2].__shadow__a[1].__shadow__a[0])) & ((__shadow__a[23].__shadow__a[22].__shadow__a[21].__shadow__a[20] = a[15].a[14].a[13].a[12]) & ((__shadow__a[15].__shadow__a[14].__shadow__a[13].__shadow__a[12] = a[23].a[22].a[21].a[20]) & ((__shadow__a[19].__shadow__a[18].__shadow__a[17].__shadow__a[16] = a[19].a[18].a[17].a[16]) & ((__shadow__a[11].__shadow__a[10].__shadow__a[9].__shadow__a[8] = a[11].a[10].a[9].a[8]) & ((__shadow__a[7].__shadow__a[6].__shadow__a[5].__shadow__a[4] = a[7].a[6].a[5].a[4]) & ((__shadow__a[3].__shadow__a[2].__shadow__a[1].__shadow__a[0] = a[3].a[2].a[1].a[0]) & (__shadow__a[15].__shadow__a[14].__shadow__a[13].__shadow__a[12] = a[15].a[14].a[13].a[12])))))))))

KLEE: Querying for subsumption check:
antecedent:
        !(a[7].a[6].a[5].a[4] \< a[3].a[2].a[1].a[0])
        !(a[11].a[10].a[9].a[8] \< a[7].a[6].a[5].a[4])
        !(a[15].a[14].a[13].a[12] \< a[11].a[10].a[9].a[8])
        (a[19].a[18].a[17].a[16] \< a[15].a[14].a[13].a[12])
        (a[23].a[22].a[21].a[20] \< a[15].a[14].a[13].a[12])
        !(a[19].a[18].a[17].a[16] \< a[11].a[10].a[9].a[8])
consequent:
        (((((!(a[19].a[18].a[17].a[16] \< a[11].a[10].a[9].a[8]) & !(a[15].a[14].a[13].a[12] \< a[15].a[14].a[13].a[12])) & (a[19].a[18].a[17].a[16] \< a[15].a[14].a[13].a[12])) & !(a[15].a[14].a[13].a[12] \< a[11].a[10].a[9].a[8])) & !(a[11].a[10].a[9].a[8] \< a[7].a[6].a[5].a[4])) & !(a[7].a[6].a[5].a[4] \< a[3].a[2].a[1].a[0]))

KLEE: #28=>#22: Check success as solver decided validity
```
The entailment should be invalid. The reason why validity was decided is because an equality `a[15].a[14].a[13].a[12] = a[23].a[22].a[21].a[20]` was incorrectly eliminated from the consequent. This equality corresponds to `__shadow__a[15].__shadow__a[14].__shadow__a[13].__shadow__a[12] = a[15].a[14].a[13].a[12]` before the simplification.