### PR TITLE
Added isLiteral() check in TxStateAddress::adjustOffsetBound()

### DIFF
--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -525,10 +525,13 @@ void TxStateAddress::adjustOffsetBound(ref<TxStateValue> checkedAddress,
               llvm::Value *v = (*it2)->getContext()->getValue();
               if (v->getType()->isPointerTy()) {
                 llvm::Type *elementType = v->getType()->getPointerElementType();
-                if (elementType->isStructTy() &&
-                    elementType->getStructName() == "struct.dirent") {
-                  concreteOffsetBound = newBound;
-                  continue;
+                if (llvm::StructType *elementStructType =
+                        llvm::dyn_cast<llvm::StructType>(elementType)) {
+                  if (!elementStructType->isLiteral() &&
+                      elementType->getStructName() == "struct.dirent") {
+                    concreteOffsetBound = newBound;
+                    continue;
+                  }
                 }
               }
 


### PR DESCRIPTION
This is to prevent LLVM assertion failure as follows, when `make check` is run:
```
klee: /usr/local/lib/llvm-3.4.2/src/lib/IR/Type.cpp:581: llvm::StringRef llvm::StructType::getName() const: Assertion `!isLiteral() && "Literal structs never have names"' failed.
0  klee            0x0000000000f55662 llvm::sys::PrintStackTrace(_IO_FILE*) + 50
1  klee            0x0000000000f54dd4
2  libpthread.so.0 0x00002b8783ce5390
3  libc.so.6       0x00002b8786557428 gsignal + 56
4  libc.so.6       0x00002b878655902a abort + 362
5  libc.so.6       0x00002b878654fbd7
6  libc.so.6       0x00002b878654fc82
7  klee            0x0000000000ef373b
8  klee            0x0000000000ef3754 llvm::Type::getStructName() const + 20
9  klee            0x00000000005e20cf klee::TxStateAddress::adjustOffsetBound(klee::ref<klee::TxStateValue>, std::set<klee::ref<klee::Expr>, std::less<klee::ref<klee::Expr> >, std::allocator<klee::ref<klee::Expr> > >&) + 1711
10 klee            0x00000000005f31e0 klee::Dependency::markPointerFlow(klee::ref<klee::TxStateValue>, klee::ref<klee::TxStateValue>, std::set<klee::ref<klee::Expr>, std::less<klee::ref<klee::Expr> >, std::allocator<klee::ref<klee::Expr> > >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) const + 784
11 klee            0x00000000005f3095 klee::Dependency::markPointerFlow(klee::ref<klee::TxStateValue>, klee::ref<klee::TxStateValue>, std::set<klee::ref<klee::Expr>, std::less<klee::ref<klee::Expr> >, std::allocator<klee::ref<klee::Expr> > >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) const + 453
12 klee            0x00000000005f32b2 klee::Dependency::markAllPointerValues(llvm::Value*, klee::ref<klee::Expr>, std::set<klee::ref<klee::Expr>, std::less<klee::ref<klee::Expr> >, std::allocator<klee::ref<klee::Expr> > >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 146
13 klee            0x00000000005fe771 klee::Dependency::markAllPointerValues(llvm::Value*, klee::ref<klee::Expr>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 97
14 klee            0x00000000005f8b9a klee::Dependency::executeMemoryOperation(llvm::Instruction*, std::vector<llvm::Instruction*, std::allocator<llvm::Instruction*> > const&, std::vector<klee::ref<klee::Expr>, std::allocator<klee::ref<klee::Expr> > >&, bool, bool) + 1226
15 klee            0x00000000005a096f klee::TxTree::executeMemoryOperation(llvm::Instruction*, klee::ref<klee::Expr>, klee::ref<klee::Expr>, bool) + 223
16 klee            0x0000000000595707 klee::Executor::executeMemoryOperation(klee::ExecutionState&, bool, klee::ref<klee::Expr>, klee::ref<klee::Expr>, klee::KInstruction*) + 4039
17 klee            0x000000000059831c klee::Executor::executeInstruction(klee::ExecutionState&, klee::KInstruction*) + 7868
18 klee            0x000000000059cb51 klee::Executor::run(klee::ExecutionState&) + 1649
19 klee            0x000000000059d530 klee::Executor::runFunctionAsMain(llvm::Function*, int, char**, char**) + 1664
20 klee            0x000000000056a2db main + 12779
21 libc.so.6       0x00002b8786542830 __libc_start_main + 240
22 klee            0x000000000057f289 _start + 41
```