### PR TITLE
Made subsumption table entry not created when states are dumped

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2820,7 +2820,7 @@ void Executor::updateStates(ExecutionState *current) {
       seedMap.erase(it3);
     processTree->remove(es->ptreeNode);
     if (INTERPOLATION_ENABLED)
-      txTree->remove(es->txTreeNode);
+      txTree->remove(es->txTreeNode, (current == 0));
     delete es;
   }
   removedStates.clear();
@@ -3159,7 +3159,7 @@ void Executor::terminateState(ExecutionState &state) {
     processTree->remove(state.ptreeNode);
 
     if (INTERPOLATION_ENABLED)
-      txTree->remove(state.txTreeNode);
+      txTree->remove(state.txTreeNode, false);
     delete &state;
   }
 }

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2348,11 +2348,8 @@ void TxTree::setCurrentINode(ExecutionState &state) {
   TxTreeGraph::setCurrentNode(state, currentTxTreeNode->nodeSequenceNumber);
 }
 
-void TxTree::remove(TxTreeNode *node) {
+void TxTree::remove(TxTreeNode *node, bool dumping) {
 #ifdef ENABLE_Z3
-  int debugSubsumptionLevel =
-      currentTxTreeNode->dependency->debugSubsumptionLevel;
-
   TimerStatIncrementer t(removeTime);
   assert(!node->left && !node->right);
   do {
@@ -2360,7 +2357,10 @@ void TxTree::remove(TxTreeNode *node) {
 
     // As the node is about to be deleted, it must have been completely
     // traversed, hence the correct time to table the interpolant.
-    if (!node->isSubsumed && node->storable) {
+    if (!dumping && !node->isSubsumed && node->storable) {
+      int debugSubsumptionLevel =
+          currentTxTreeNode->dependency->debugSubsumptionLevel;
+
       if (debugSubsumptionLevel >= 2) {
         klee_message("Storing entry for Node #%lu, Program Point %lu",
                      node->getNodeSequenceNumber(), node->getProgramPoint());

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2358,8 +2358,7 @@ void TxTree::remove(TxTreeNode *node, bool dumping) {
     // As the node is about to be deleted, it must have been completely
     // traversed, hence the correct time to table the interpolant.
     if (!dumping && !node->isSubsumed && node->storable) {
-      int debugSubsumptionLevel =
-          currentTxTreeNode->dependency->debugSubsumptionLevel;
+      int debugSubsumptionLevel = node->dependency->debugSubsumptionLevel;
 
       if (debugSubsumptionLevel >= 2) {
         klee_message("Storing entry for Node #%lu, Program Point %lu",

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -875,7 +875,12 @@ public:
   void setCurrentINode(ExecutionState &state);
 
   /// \brief Deletes the Tracer-X tree node
-  void remove(TxTreeNode *node);
+  ///
+  /// \param node The Tracer-X tree node to delete
+  /// \param dumping Indicates whether we are dumping the states at the point
+  /// KLEE itself is about to terminate. Here we should not create subsumption
+  /// table entry.
+  void remove(TxTreeNode *node, bool dumping);
 
   /// \brief Invokes the subsumption check
   bool subsumptionCheck(TimingSolver *solver, ExecutionState &state,


### PR DESCRIPTION
Resolves problem with `ExitOnErrorType.c` in #250. Following is the result of `make check` on tracerx server:
```
********************
Testing Time: 294.54s
********************
Failing Tests (2):
    KLEE :: Feature/Realloc.c
    KLEE :: Feature/const_array_opt1.c

  Expected Passes    : 179
  Expected Failures  : 2
  Unsupported Tests  : 2
  Unexpected Failures: 2
Makefile:49: recipe for target 'check-local' failed
make[1]: *** [check-local] Error 1
make[1]: Leaving directory '/home/dcsandr/software/klee/test'
/home/dcsandr/software/klee/Makefile.rules:1863: recipe for target 'check' failed
make: *** [check] Error 2
```
Also, all `basic` examples of `klee-examples` pass.
