### PR TITLE
Removed -interpolation-stat option

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -75,8 +75,6 @@ extern llvm::cl::opt<bool> NoInterpolation;
 
 extern llvm::cl::opt<bool> OutputTree;
 
-extern llvm::cl::opt<bool> InterpolationStat;
-
 extern llvm::cl::opt<bool> NoSubsumedTest;
 
 extern llvm::cl::opt<bool> NoExistential;

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -100,11 +100,6 @@ llvm::cl::opt<bool> OutputTree(
                    "format. At present, this feature is only available when "
                    "Z3 is compiled in and interpolation is enabled."));
 
-llvm::cl::opt<bool> InterpolationStat(
-    "interpolation-stat",
-    llvm::cl::desc(
-        "Displays an execution profile of the interpolation routines."));
-
 llvm::cl::opt<bool> NoSubsumedTest(
     "no-subsumed-test",
     llvm::cl::desc("Disables generation of test cases for subsumed paths."),

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4024,8 +4024,7 @@ void Executor::runFunctionAsMain(Function *f,
 
 #ifdef ENABLE_Z3
     // Print interpolation time statistics
-    if (InterpolationStat)
-      interpreterHandler->assignSubsumptionStats(TxTree::getInterpolationStat());
+    interpreterHandler->assignSubsumptionStats(TxTree::getInterpolationStat());
 #endif
   }
 


### PR DESCRIPTION
It is confusing that we need to specify -interpolation-stat to get the interpolation / subsumption stats when interpolation is already enabled. This PR removes this option, and generates interpolation stats whenever it is enabled.