### PR TITLE
WIP: Unified three options into one

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -10,6 +10,10 @@
 #include "klee/Config/config.h"
 
 #ifdef ENABLE_Z3
+#define BOUND_INTERPOLATION(instr)                                             \
+  (SpecialFunctionBoundInterpolation &&((instr)->getParent()) &&               \
+   ((instr)->getParent()->getParent()) &&                                      \
+   ((instr)->getParent()->getParent()->getName().str() == "tracerx_check"))
 #ifdef ENABLE_STP
 #define INTERPOLATION_ENABLED (CoreSolverToUse == Z3_SOLVER && !NoInterpolation)
 #else

--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -11,9 +11,10 @@
 
 #ifdef ENABLE_Z3
 #define BOUND_INTERPOLATION(instr)                                             \
-  (SpecialFunctionBoundInterpolation &&((instr)->getParent()) &&               \
-   ((instr)->getParent()->getParent()) &&                                      \
-   ((instr)->getParent()->getParent()->getName().str() == "tracerx_check"))
+  (!SpecialFunctionBoundInterpolation ||                                       \
+   ((instr) && ((instr)->getParent()) &&                                       \
+    ((instr)->getParent()->getParent()) &&                                     \
+    ((instr)->getParent()->getParent()->getName().str() == "tracerx_check")))
 #ifdef ENABLE_STP
 #define INTERPOLATION_ENABLED (CoreSolverToUse == Z3_SOLVER && !NoInterpolation)
 #else

--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -10,11 +10,6 @@
 #include "klee/Config/config.h"
 
 #ifdef ENABLE_Z3
-#define BOUND_INTERPOLATION(instr)                                             \
-  (!SpecialFunctionBoundInterpolation ||                                       \
-   ((instr) && ((instr)->getParent()) &&                                       \
-    ((instr)->getParent()->getParent()) &&                                     \
-    ((instr)->getParent()->getParent()->getName().str() == "tracerx_check")))
 #ifdef ENABLE_STP
 #define INTERPOLATION_ENABLED (CoreSolverToUse == Z3_SOLVER && !NoInterpolation)
 #else

--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -85,8 +85,6 @@ extern llvm::cl::opt<int> DebugState;
 
 extern llvm::cl::opt<int> DebugSubsumption;
 
-extern llvm::cl::opt<bool> NoBoundCheck;
-
 extern llvm::cl::opt<bool> ExactAddressInterpolant;
 
 extern llvm::cl::opt<bool> SpecialFunctionBoundInterpolation;

--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -87,8 +87,6 @@ extern llvm::cl::opt<int> DebugSubsumption;
 
 extern llvm::cl::opt<bool> NoBoundCheck;
 
-extern llvm::cl::opt<bool> NoBoundInterpolation;
-
 extern llvm::cl::opt<bool> ExactAddressInterpolant;
 
 extern llvm::cl::opt<bool> SpecialFunctionBoundInterpolation;

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -138,11 +138,6 @@ llvm::cl::opt<int> DebugSubsumption(
                    "higher the more (default=0 (off))."),
     llvm::cl::init(0));
 
-llvm::cl::opt<bool> NoBoundCheck(
-    "no-bound-check",
-    llvm::cl::desc("This option disables memory access out-of-bound check."),
-    llvm::cl::init(false));
-
 llvm::cl::opt<bool> ExactAddressInterpolant(
     "exact-address-interpolant",
     llvm::cl::desc("This option uses exact address for interpolating "

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -143,12 +143,6 @@ llvm::cl::opt<bool> NoBoundCheck(
     llvm::cl::desc("This option disables memory access out-of-bound check."),
     llvm::cl::init(false));
 
-llvm::cl::opt<bool> NoBoundInterpolation(
-    "no-bound-interpolation",
-    llvm::cl::desc("This option disables the generation of interpolant from "
-                   "each successful out-of-bound check: It may result in loss "
-                   "of error report(s)"));
-
 llvm::cl::opt<bool> ExactAddressInterpolant(
     "exact-address-interpolant",
     llvm::cl::desc("This option uses exact address for interpolating "

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1483,11 +1483,6 @@ void Dependency::executeMemoryOperation(
     std::vector<ref<Expr> > &args, bool inBounds, bool symbolicExecutionError) {
   execute(instr, callHistory, args, symbolicExecutionError);
 #ifdef ENABLE_Z3
-  if (NoBoundCheck)
-    // No Bounds check is needed to be performed. So, we just return. This is
-    // important when the user wants to get the skeleton tree.
-    return;
-
   if (boundInterpolation(instr) && inBounds) {
     // The bounds check has been proven valid, we keep the dependency on the
     // address. Calling va_start within a variadic function also triggers memory

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1515,41 +1515,38 @@ void Dependency::executeMemoryOperation(
     }
     }
 
-    if (SpecialFunctionBoundInterpolation) {
+    if (BOUND_INTERPOLATION(instr)) {
       // Limit interpolation to only within function tracerx_check
       ref<TxStateValue> val(getLatestValueForMarking(addressOperand, address));
       if (llvm::isa<llvm::LoadInst>(instr) && !val->getLocations().empty()) {
-        if (instr->getParent()->getParent()->getName().str() ==
-            "tracerx_check") {
-          std::set<ref<TxStateAddress> > locations(val->getLocations());
-          for (std::set<ref<TxStateAddress> >::iterator it = locations.begin(),
-                                                        ie = locations.end();
-               it != ie; ++it) {
-            if (llvm::ConstantExpr *ce = llvm::dyn_cast<llvm::ConstantExpr>(
-                    (*it)->getContext()->getValue())) {
-              if (ce->getOpcode() == llvm::Instruction::GetElementPtr) {
-                std::string reason = "";
-                if (debugSubsumptionLevel >= 1) {
-                  llvm::raw_string_ostream stream(reason);
-                  stream << "pointer use [";
-                  if (instr->getParent()->getParent()) {
-                    stream << instr->getParent()->getParent()->getName().str()
-                           << ": ";
-                  }
-                  if (llvm::MDNode *n = instr->getMetadata("dbg")) {
-                    llvm::DILocation loc(n);
-                    stream << "Line " << loc.getLineNumber();
-                  }
-                  stream << "]";
-                  stream.flush();
+        std::set<ref<TxStateAddress> > locations(val->getLocations());
+        for (std::set<ref<TxStateAddress> >::iterator it = locations.begin(),
+                                                      ie = locations.end();
+             it != ie; ++it) {
+          if (llvm::ConstantExpr *ce = llvm::dyn_cast<llvm::ConstantExpr>(
+                  (*it)->getContext()->getValue())) {
+            if (ce->getOpcode() == llvm::Instruction::GetElementPtr) {
+              std::string reason = "";
+              if (debugSubsumptionLevel >= 1) {
+                llvm::raw_string_ostream stream(reason);
+                stream << "pointer use [";
+                if (instr->getParent()->getParent()) {
+                  stream << instr->getParent()->getParent()->getName().str()
+                         << ": ";
                 }
-                if (ExactAddressInterpolant) {
-                  markAllValues(addressOperand, address, reason);
-                } else {
-                  markAllPointerValues(addressOperand, address, reason);
+                if (llvm::MDNode *n = instr->getMetadata("dbg")) {
+                  llvm::DILocation loc(n);
+                  stream << "Line " << loc.getLineNumber();
                 }
-                break;
+                stream << "]";
+                stream.flush();
               }
+              if (ExactAddressInterpolant) {
+                markAllValues(addressOperand, address, reason);
+              } else {
+                markAllPointerValues(addressOperand, address, reason);
+              }
+              break;
             }
           }
         }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1493,7 +1493,7 @@ void Dependency::executeMemoryOperation(
     // important when the user wants to get the skeleton tree.
     return;
 
-  if (!NoBoundInterpolation && inBounds) {
+  if (BOUND_INTERPOLATION(instr) && inBounds) {
     // The bounds check has been proven valid, we keep the dependency on the
     // address. Calling va_start within a variadic function also triggers memory
     // operation, but we ignored it here as this method is only called when load
@@ -1515,7 +1515,7 @@ void Dependency::executeMemoryOperation(
     }
     }
 
-    if (BOUND_INTERPOLATION(instr)) {
+    if (SpecialFunctionBoundInterpolation) {
       // Limit interpolation to only within function tracerx_check
       ref<TxStateValue> val(getLatestValueForMarking(addressOperand, address));
       if (llvm::isa<llvm::LoadInst>(instr) && !val->getLocations().empty()) {

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -618,10 +618,7 @@ void Dependency::addDependencyViaExternalFunction(
   if (source.isNull() || target.isNull())
     return;
 
-#ifdef ENABLE_Z3
-  if (!NoBoundInterpolation) {
-    std::set<ref<TxStateAddress> > locations = source->getLocations();
-    if (!locations.empty()) {
+  if (!source->getLocations().empty()) {
       std::string reason = "";
       if (debugSubsumptionLevel >= 1) {
         llvm::raw_string_ostream stream(reason);
@@ -633,9 +630,7 @@ void Dependency::addDependencyViaExternalFunction(
         stream.flush();
       }
       markPointerFlow(source, source, reason);
-    }
   }
-#endif
 
   // Add new location to the target in case of pointer return value
   llvm::Type *t = target->getValue()->getType();

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -444,6 +444,9 @@ namespace klee {
                               std::set<ref<Expr> > &bounds,
                               const std::string &reason);
 
+    /// \brief Tests if bound interpolation shold be enabled
+    static bool boundInterpolation(llvm::Value *val = 0);
+
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {
       this->print(llvm::errs());

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3709,7 +3709,7 @@ void Executor::executeMemoryOperation(ExecutionState &state, bool isWrite,
 
     bool inBounds;
 #ifdef ENABLE_Z3
-    if (NoBoundCheck) {
+    if (!Dependency::boundInterpolation(target->inst)) {
         // No Bounds check is needed to be performed. So, inBounds is set to
         // be true. This is used when the user wants to get the skeleton tree.
         inBounds = true;

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1181,8 +1181,8 @@ bool SubsumptionTableEntry::subsumed(
                            nodeSequenceNumber, msg.c_str());
             }
             return false;
-          } else if (!NoBoundInterpolation && tabledValue->isPointer() &&
-                     stateValue->isPointer()) {
+          } else if (Dependency::boundInterpolation() &&
+                     tabledValue->isPointer() && stateValue->isPointer()) {
             if (!ExactAddressInterpolant && tabledValue->useBound()) {
               std::set<ref<Expr> > bounds;
               ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
@@ -1313,8 +1313,8 @@ bool SubsumptionTableEntry::subsumed(
                   ConstantExpr::create(0, Expr::Bool),
                   EqExpr::create(tabledConcreteOffset, stateSymbolicOffset));
 
-            } else if (!NoBoundInterpolation && tabledValue->isPointer() &&
-                       stateValue->isPointer()) {
+            } else if (Dependency::boundInterpolation() &&
+                       tabledValue->isPointer() && stateValue->isPointer()) {
               if (!ExactAddressInterpolant && tabledValue->useBound()) {
                 std::set<ref<Expr> > bounds;
                 ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
@@ -1446,8 +1446,8 @@ bool SubsumptionTableEntry::subsumed(
             newTerm = EqExpr::create(
                 ConstantExpr::create(0, Expr::Bool),
                 EqExpr::create(tabledSymbolicOffset, stateConcreteOffset));
-          } else if (!NoBoundInterpolation && tabledValue->isPointer() &&
-                     stateValue->isPointer()) {
+          } else if (Dependency::boundInterpolation() &&
+                     tabledValue->isPointer() && stateValue->isPointer()) {
             if (!ExactAddressInterpolant && tabledValue->useBound()) {
               std::set<ref<Expr> > bounds;
               ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
@@ -1528,8 +1528,8 @@ bool SubsumptionTableEntry::subsumed(
             newTerm = EqExpr::create(
                 ConstantExpr::create(0, Expr::Bool),
                 EqExpr::create(tabledSymbolicOffset, stateSymbolicOffset));
-          } else if (!NoBoundInterpolation && tabledValue->isPointer() &&
-                     stateValue->isPointer()) {
+          } else if (Dependency::boundInterpolation() &&
+                     tabledValue->isPointer() && stateValue->isPointer()) {
             if (!ExactAddressInterpolant && tabledValue->useBound()) {
               std::set<ref<Expr> > bounds;
               ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
@@ -1783,7 +1783,7 @@ bool SubsumptionTableEntry::subsumed(
                        nodeSequenceNumber, msg.c_str());
         }
 
-        if (!NoBoundInterpolation && !ExactAddressInterpolant) {
+        if (Dependency::boundInterpolation() && !ExactAddressInterpolant) {
           // We build memory bounds interpolants from pointer values
           std::string reason = "";
           if (debugSubsumptionLevel >= 1) {
@@ -1843,7 +1843,7 @@ bool SubsumptionTableEntry::subsumed(
       // We create path condition marking structure and mark core constraints
       state.txTreeNode->unsatCoreInterpolation(unsatCore);
 
-      if (!NoBoundInterpolation && !ExactAddressInterpolant) {
+      if (Dependency::boundInterpolation() && !ExactAddressInterpolant) {
         // We build memory bounds interpolants from pointer values
         std::string reason = "";
         if (debugSubsumptionLevel >= 1) {


### PR DESCRIPTION
Three options `-special-function-bound-interpolation`,  `-no-bound-check` and `-no-bound-interpolation` is unified into a single option `-special-function-bound-interpolation`.

For resolving tracer-x/klee#252.

@rasoolmaghareh I'm still going to test it.
