### PR TITLE
Disable generation of tests from subsumed paths

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -75,8 +75,6 @@ extern llvm::cl::opt<bool> NoInterpolation;
 
 extern llvm::cl::opt<bool> OutputTree;
 
-extern llvm::cl::opt<bool> NoSubsumedTest;
-
 extern llvm::cl::opt<bool> NoExistential;
 
 extern llvm::cl::opt<int> MaxFailSubsumption;

--- a/include/klee/Interpreter.h
+++ b/include/klee/Interpreter.h
@@ -50,7 +50,6 @@ public:
   virtual void
   incTotalInstructionsOnSubsumption(unsigned currentInstruction) = 0;
   virtual void incSubsumptionTermination() = 0;
-  virtual void incSubsumptionTerminationTest() = 0;
   virtual void incEarlyTermination() = 0;
   virtual void incEarlyTerminationTest() = 0;
   virtual void incErrorTermination() = 0;

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -100,11 +100,6 @@ llvm::cl::opt<bool> OutputTree(
                    "format. At present, this feature is only available when "
                    "Z3 is compiled in and interpolation is enabled."));
 
-llvm::cl::opt<bool> NoSubsumedTest(
-    "no-subsumed-test",
-    llvm::cl::desc("Disables generation of test cases for subsumed paths."),
-    llvm::cl::init(false));
-
 llvm::cl::opt<bool> NoExistential(
     "no-existential",
     llvm::cl::desc(

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3175,13 +3175,6 @@ void Executor::terminateStateOnSubsumption(ExecutionState &state) {
   interpreterHandler->incTotalInstructionsOnSubsumption(
       state.txTreeNode->getInstructionsDepth());
 
-#ifdef ENABLE_Z3
-  if (!NoSubsumedTest && (!OnlyOutputStatesCoveringNew || state.coveredNew ||
-                          (AlwaysOutputSeeds && seedMap.count(&state)))) {
-    interpreterHandler->incSubsumptionTerminationTest();
-    interpreterHandler->processTestCase(state, 0, "early");
-  }
-#endif
   terminateState(state);
 }
 

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -337,12 +337,6 @@ public:
   }
   unsigned getSubsumptionTermination() { return m_subsumptionTermination; }
   void incSubsumptionTermination() { m_subsumptionTermination++; }
-  unsigned getSubsumptionTerminationTest() { return m_subsumptionTerminationTest; }
-  void incSubsumptionTerminationTest() {
-    if (!NoOutput) {
-      m_subsumptionTerminationTest++;
-    }
-  }
   unsigned getEarlyTermination() { return m_earlyTermination; }
   void incEarlyTermination() { m_earlyTermination++; }
   unsigned getEarlyTerminationTest() { return m_earlyTerminationTest; }
@@ -406,8 +400,7 @@ KleeHandler::KleeHandler(int argc, char **argv)
       m_totalInstructionsDepthOnErrorTermination(0),
       m_totalBranchingDepthOnSubsumption(0),
       m_totalInstructionsDepthOnSubsumption(0), m_subsumptionTermination(0),
-      m_subsumptionTerminationTest(0), m_earlyTermination(0),
-      m_earlyTerminationTest(0), m_errorTermination(0),
+      m_earlyTermination(0), m_earlyTerminationTest(0), m_errorTermination(0),
       m_errorTerminationTest(0), m_exitTermination(0), m_exitTerminationTest(0),
       m_otherTermination(0), m_argc(argc), m_argv(argv) {
 
@@ -1742,11 +1735,6 @@ int main(int argc, char **argv, char **envp) {
         << handler->getNumTestCases() << ", among which\n";
   stats << "KLEE: done:     early-terminating tests (instruction time limit, solver timeout, max-depth reached) = "
         << handler->getEarlyTerminationTest() << "\n";
-#ifdef ENABLE_Z3
-  if (!NoSubsumedTest && INTERPOLATION_ENABLED)
-    stats << "KLEE: done:     subsumed tests = "
-          << handler->getSubsumptionTerminationTest() << "\n";
-#endif
   stats << "KLEE: done:     error tests = "
         << handler->getErrorTerminationTest() << "\n";
   stats << "KLEE: done:     program exit tests = "


### PR DESCRIPTION
It does not make sense to generate tests from subsumed paths.