### PR TITLE
Correction to the semantics of getelementptr with negative index

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -340,8 +340,7 @@ Dependency::getLatestValue(llvm::Value *value,
   ref<TxStateValue> ret;
 
   if (llvm::Constant *c = llvm::dyn_cast<llvm::Constant>(value)) {
-    ref<TxStateValue> dummyBase;
-    ret = evalConstant(c, callHistory, dummyBase);
+    ret = evalConstant(c, callHistory);
   } else {
     ret = getLatestValueNoConstantCheck(value, valueExpr, allowInconsistency);
   }
@@ -1565,54 +1564,45 @@ inline ref<TxStateValue> Dependency::getLatestValueNoConstantCheckOrCreate(
 
 ref<TxStateValue>
 Dependency::evalConstant(llvm::Constant *c,
-                         const std::vector<llvm::Instruction *> &callHistory,
-                         ref<TxStateValue> &base) {
+                         const std::vector<llvm::Instruction *> &callHistory) {
   if (llvm::ConstantExpr *ce = llvm::dyn_cast<llvm::ConstantExpr>(c)) {
-    return evalConstantExpr(ce, callHistory, base);
+    return evalConstantExpr(ce, callHistory);
   } else {
     // We use empty call history for constants, since they are in a sense global
     const std::vector<llvm::Instruction *> emptyCallHistory;
 
     if (const llvm::ConstantInt *ci = llvm::dyn_cast<llvm::ConstantInt>(c)) {
-      base = getLatestValueNoConstantCheckOrCreate(
+      return getLatestValueNoConstantCheckOrCreate(
           c, emptyCallHistory, ConstantExpr::alloc(ci->getValue()));
-      return base;
     } else if (const llvm::ConstantFP *cf =
                    llvm::dyn_cast<llvm::ConstantFP>(c)) {
-      base = getLatestValueNoConstantCheckOrCreate(
+      return getLatestValueNoConstantCheckOrCreate(
           c, emptyCallHistory,
           ConstantExpr::alloc(cf->getValueAPF().bitcastToAPInt()));
-      return base;
     } else if (const llvm::GlobalValue *gv =
                    llvm::dyn_cast<llvm::GlobalValue>(c)) {
-      base = getLatestValueNoConstantCheckOrCreate(
+      return getLatestValueNoConstantCheckOrCreate(
           c, emptyCallHistory, globalAddresses->find(gv)->second);
-      return base;
     } else if (llvm::isa<llvm::ConstantPointerNull>(c)) {
-      base = getLatestValueNoConstantCheckOrCreate(c, emptyCallHistory,
+      return getLatestValueNoConstantCheckOrCreate(c, emptyCallHistory,
                                                    Expr::createPointer(0));
-      return base;
     } else if (llvm::isa<llvm::UndefValue>(c) ||
                llvm::isa<llvm::ConstantAggregateZero>(c)) {
-      base = getLatestValueNoConstantCheckOrCreate(
+      return getLatestValueNoConstantCheckOrCreate(
           c, emptyCallHistory,
           ConstantExpr::create(0, targetData->getTypeSizeInBits(c->getType())));
-      return base;
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 1)
     } else if (const llvm::ConstantDataSequential *cds =
                    llvm::dyn_cast<llvm::ConstantDataSequential>(c)) {
       std::vector<ref<Expr> > kids;
       for (unsigned i = 0, e = cds->getNumElements(); i != e; ++i) {
-        ref<TxStateValue> dummyBase;
-        ref<Expr> kid =
-            evalConstant(cds->getElementAsConstant(i), emptyCallHistory,
-                         dummyBase)->getExpression();
+        ref<Expr> kid = evalConstant(cds->getElementAsConstant(i),
+                                     emptyCallHistory)->getExpression();
         kids.push_back(kid);
       }
-      base = getLatestValueNoConstantCheckOrCreate(
+      return getLatestValueNoConstantCheckOrCreate(
           c, emptyCallHistory,
           cast<ConstantExpr>(ConcatExpr::createN(kids.size(), kids.data())));
-      return base;
 #endif
     } else if (const llvm::ConstantStruct *cs =
                    llvm::dyn_cast<llvm::ConstantStruct>(c)) {
@@ -1620,9 +1610,8 @@ Dependency::evalConstant(llvm::Constant *c,
       llvm::SmallVector<ref<Expr>, 4> kids;
       for (unsigned i = cs->getNumOperands(); i != 0; --i) {
         unsigned op = i - 1;
-        ref<TxStateValue> dummyBase;
-        ref<Expr> kid = evalConstant(cs->getOperand(op), emptyCallHistory,
-                                     dummyBase)->getExpression();
+        ref<Expr> kid =
+            evalConstant(cs->getOperand(op), emptyCallHistory)->getExpression();
 
         uint64_t thisOffset = sl->getElementOffsetInBits(op),
                  nextOffset = (op == cs->getNumOperands() - 1)
@@ -1635,24 +1624,21 @@ Dependency::evalConstant(llvm::Constant *c,
 
         kids.push_back(kid);
       }
-      base = getLatestValueNoConstantCheckOrCreate(
+      return getLatestValueNoConstantCheckOrCreate(
           c, emptyCallHistory,
           cast<ConstantExpr>(ConcatExpr::createN(kids.size(), kids.data())));
-      return base;
     } else if (const llvm::ConstantArray *ca =
                    llvm::dyn_cast<llvm::ConstantArray>(c)) {
       llvm::SmallVector<ref<Expr>, 4> kids;
       for (unsigned i = ca->getNumOperands(); i != 0; --i) {
         unsigned op = i - 1;
-        ref<TxStateValue> dummyBase;
-        ref<Expr> kid = evalConstant(ca->getOperand(op), emptyCallHistory,
-                                     dummyBase)->getExpression();
+        ref<Expr> kid =
+            evalConstant(ca->getOperand(op), emptyCallHistory)->getExpression();
         kids.push_back(kid);
       }
-      base = getLatestValueNoConstantCheckOrCreate(
+      return getLatestValueNoConstantCheckOrCreate(
           c, emptyCallHistory,
           cast<ConstantExpr>(ConcatExpr::createN(kids.size(), kids.data())));
-      return base;
     } else {
       // Constant{Vector}
       llvm::report_fatal_error("invalid argument to evalConstant()");
@@ -1661,8 +1647,8 @@ Dependency::evalConstant(llvm::Constant *c,
 }
 
 ref<TxStateValue> Dependency::evalConstantExpr(
-    llvm::ConstantExpr *ce, const std::vector<llvm::Instruction *> &callHistory,
-    ref<TxStateValue> &base) {
+    llvm::ConstantExpr *ce,
+    const std::vector<llvm::Instruction *> &callHistory) {
   LLVM_TYPE_Q llvm::Type *type = ce->getType();
 
   ref<TxStateValue> op1(0), op2(0), op3(0);
@@ -1671,17 +1657,15 @@ ref<TxStateValue> Dependency::evalConstantExpr(
   int numOperands = ce->getNumOperands();
 
   if (numOperands > 0) {
-    op1 = evalConstant(ce->getOperand(0), callHistory, base);
+    op1 = evalConstant(ce->getOperand(0), callHistory);
     op1Expr = cast<ConstantExpr>(op1->getExpression());
   }
   if (numOperands > 1) {
-    ref<TxStateValue> dummyBase;
-    op2 = evalConstant(ce->getOperand(1), callHistory, dummyBase);
+    op2 = evalConstant(ce->getOperand(1), callHistory);
     op2Expr = cast<ConstantExpr>(op2->getExpression());
   }
   if (numOperands > 2) {
-    ref<TxStateValue> dummyBase;
-    op3 = evalConstant(ce->getOperand(2), callHistory, dummyBase);
+    op3 = evalConstant(ce->getOperand(2), callHistory);
     op3Expr = cast<ConstantExpr>(op3->getExpression());
   }
 
@@ -1828,23 +1812,9 @@ ref<TxStateValue> Dependency::evalConstantExpr(
             Context::get().getPointerWidth());
       } else {
         const llvm::SequentialType *set = cast<llvm::SequentialType>(*ii);
-        ref<TxStateValue> dummyBase;
         ref<ConstantExpr> index = cast<ConstantExpr>(
-            evalConstant(cast<llvm::Constant>(ii.getOperand()), callHistory,
-                         dummyBase)->getExpression());
-
-        // FIXME: The following is to handle the case of having -1 as the index.
-        // This means that we are actually referring to the base of the struct
-        // where the variable is a member of. Here we make an assumption that
-        // this was the innermost constant, which may not be true in all
-        // circumstances, but true in case of of the getelementptr expression
-        // appearing in test/Runtime/POSIX/DirConsistency.c.
-        if (index == ConstantExpr::alloc(-1, index->getWidth())) {
-          op1 = base;
-          op1Base = cast<ConstantExpr>(base->getExpression());
-          offset = ConstantExpr::alloc(0, Context::get().getPointerWidth());
-          continue;
-        }
+            evalConstant(cast<llvm::Constant>(ii.getOperand()), callHistory)
+                ->getExpression());
         unsigned elementSize =
             targetData->getTypeStoreSize(set->getElementType());
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -477,14 +477,19 @@ void Dependency::addDependencyWithOffset(ref<TxStateValue> source,
   if (source.isNull() || target.isNull())
     return;
 
+  ConstantExpr *de = llvm::dyn_cast<ConstantExpr>(offsetDelta);
+  uint64_t d = de ? de->getZExtValue() : 0;
+
+  // Do not build dependency when the index is negative. Tracer-X does not
+  // support negative indexing.
+  if (d > LLONG_MAX)
+    return;
+
   std::set<ref<TxStateAddress> > locations = source->getLocations();
   ref<Expr> targetExpr(target->getExpression());
 
   ConstantExpr *ce = llvm::dyn_cast<ConstantExpr>(targetExpr);
   uint64_t a = ce ? ce->getZExtValue() : 0;
-
-  ConstantExpr *de = llvm::dyn_cast<ConstantExpr>(offsetDelta);
-  uint64_t d = de ? de->getZExtValue() : 0;
 
   uint64_t nLocations = locations.size();
   uint64_t i = 0;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -251,15 +251,13 @@ namespace klee {
     /// copied from Executor::evalConstant.
     ref<TxStateValue>
     evalConstant(llvm::Constant *c,
-                 const std::vector<llvm::Instruction *> &callHistory,
-                 ref<TxStateValue> &base);
+                 const std::vector<llvm::Instruction *> &callHistory);
 
     /// \brief Get a KLEE expression from a constant expression. This was
     /// shamelessly copied from Executor::evalConstantExpr.
     ref<TxStateValue>
     evalConstantExpr(llvm::ConstantExpr *ce,
-                     const std::vector<llvm::Instruction *> &callHistory,
-                     ref<TxStateValue> &base);
+                     const std::vector<llvm::Instruction *> &callHistory);
 
     /// \brief Gets the latest version of the location, but without checking
     /// for whether the value is constant or not.


### PR DESCRIPTION
Sometimes getelementptr has negative index. This patch ignores dependencies due to such indices and corrected the handling of getelementptr in Dependency::evalConstantExpr, which was based on the wrong assumption that -1 results in a base of the pointer value.