### PR TITLE
Fix to assertion failure due to Tracer-X conservative validity check

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1432,7 +1432,6 @@ void Dependency::executeMemoryOperation(
 
     ref<TxStateValue> val(getLatestValueForMarking(addressOperand, address));
     if (!val->getLocations().empty()) {
-      std::set<ref<TxStateAddress> > locations(val->getLocations());
       std::string reason = "";
       if (debugSubsumptionLevel > 1) {
         llvm::raw_string_ostream stream(reason);

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -535,8 +535,20 @@ void TxStateAddress::adjustOffsetBound(ref<TxStateValue> checkedAddress,
                 }
               }
 
-              assert(newBound > offsetInt && "incorrect bound");
-              concreteOffsetBound = newBound;
+              if (newBound > offsetInt) {
+                concreteOffsetBound = newBound;
+              } else {
+                // Incorrect bounds would pass this assertion, as long as the
+                // value of the checked offset is reasonable (non-negative). We
+                // need to pass some wrong bounds since Tracer-X is more
+                // conservative than KLEE: KLEE can still determine that memory
+                // access is valid as it happens to be in a valid region.
+                // Tracer-X, on the other hand, associates every pointer with a
+                // set of allocations, and the memory bound is violated whenever
+                // there is an access to a memory outside of the region
+                // associated with any of the allocations.
+                assert(c->getZExtValue() <= LLONG_MAX && "incorrect bound");
+              }
             }
             continue;
           }


### PR DESCRIPTION
Assertion failure in TxStateAddress::adjustOffsetBound was triggered by the following example:
```
/*
 * Simple regular expression matching.
 *
 * From:
 *   The Practice of Programming
 *   Brian W. Kernighan, Rob Pike
 *
 * This code with KLEE harness is obtained from the following
 * page of the KLEE tutorial on December 2015:
 *   http://klee.github.io/resources/Regexp.c.html
 */
#ifdef LLBMC
#include <llbmc.h>
#else
#include <klee/klee.h>
#endif

char _bound[4];
char *wcet;
void tracerx_check(char *p) { printf("Timing of Path:%d\n",((uint64_t)p)-((uint64_t)(&(_bound)))); *p;}

static int matchhere(char*,char*);

static int matchstar(int c, char *re, char *text) {
  do {
    if (matchhere(re, text)){
      wcet++;   
      return 1;
    }
  } while (*text != '\0' && (*text++ == c || c== '.'));
  return 0;
}

static int matchhere(char *re, char *text) {
  if (re[0] == '\0'){
     wcet++;
     return 0;
  }
  if (re[1] == '*'){
    return matchstar(re[0], re+2, text);
    wcet++;
  }
  if (re[0] == '$' && re[1]=='\0'){
    wcet++;
    return *text == '\0';
  }
  if (*text!='\0' && (re[0]=='.' || re[0]==*text)){
    wcet++;
    return matchhere(re+1, text+1);
  }
  return 0;
}

int match(char *re, char *text) {
  if (re[0] == '^'){
    wcet++;
    return matchhere(re+1, text);
  }
  do {
    if (matchhere(re, text)){
      wcet++;
      return 1;
    }
  } while (*text++ != '\0');
  return 0;
}

/*
 * Harness for testing with KLEE.
 */

// The size of the buffer to test with.
#define SIZE 10

int main() {
  wcet=_bound;
  // The input regular expression.
  char re[SIZE];
  wcet++;

// Make the input symbolic.
#ifdef LLBMC
  for (int i = 0; i < SIZE; ++i) {
    re[i] = __llbmc_nondef_char();
  }
#else
  klee_make_symbolic(re, sizeof re, "re");
  klee_assume(re[SIZE-1] == '\0');
#endif

  // Try to match against a constant string "hello".
  match(re, "hello");
  tracerx_check(wcet);
  return 0;
}
```
This because KLEE allows `wcet` pointer access beyond the size of `_bound`, if it happens to be still within some valid region. KLEE's valid acess may not be Tracer-X valid access, as Tracer-X associates `wcet` to the array `_bound` and checks if its value stays within the valid region of `_bound`.