### PR TITLE
Improvements on the tree DOT output

### DIFF
--- a/include/klee/util/TxTreeGraph.h
+++ b/include/klee/util/TxTreeGraph.h
@@ -81,10 +81,19 @@ private:
     /// Note that memoryError or assertionError implies errorPath.
     bool errorPath;
 
-    Node()
+    /// \brief The number of marked instruction visited along the path. A marked
+    /// instruction is a return from a function named tracerx_mark.
+    uint64_t markCount;
+
+    /// \brief The addition to the number of interesting instruction executed
+    /// while processing a node: The interesting instruction is a return from a
+    /// function named tracerx_mark.
+    uint64_t markAddition;
+
+    Node(uint64_t _markCount)
         : nodeSequenceNumber(0), internalNodeId(0), parent(0), falseTarget(0),
           trueTarget(0), subsumed(false), errorType(TxTreeGraph::NONE),
-          errorPath(false) {}
+          errorPath(false), markCount(_markCount), markAddition(0) {}
 
     ~Node() {
       if (falseTarget)
@@ -96,7 +105,9 @@ private:
       pathConditionTable.clear();
     }
 
-    static TxTreeGraph::Node *createNode() { return new TxTreeGraph::Node(); }
+    static TxTreeGraph::Node *createNode(uint64_t markCount) {
+      return new TxTreeGraph::Node(markCount);
+    }
   };
 
   class NumberedEdge {
@@ -128,11 +139,6 @@ private:
 
   /// \brief Maps leaves to leaf ids
   std::map<TxTreeGraph::Node *, uint64_t> leafToLeafSequenceNumber;
-
-  /// \brief The addition to the number of interesting instruction executed
-  /// while processing a node: The interesting instruction is a return from a
-  /// function named tracerx_mark.
-  std::map<uint64_t, uint64_t> markAddition;
 
   uint64_t subsumptionEdgeNumber;
 

--- a/include/klee/util/TxTreeGraph.h
+++ b/include/klee/util/TxTreeGraph.h
@@ -123,6 +123,12 @@ private:
   std::vector<TxTreeGraph::NumberedEdge *> subsumptionEdges;
   std::map<PathCondition *, TxTreeGraph::Node *> pathConditionMap;
 
+  /// \brief The set of known leaves
+  std::set<TxTreeGraph::Node *> leaves;
+
+  /// \brief Maps leaves to leaf ids
+  std::map<TxTreeGraph::Node *, uint64_t> leafToLeafSequenceNumber;
+
   uint64_t subsumptionEdgeNumber;
 
   uint64_t internalNodeId;

--- a/include/klee/util/TxTreeGraph.h
+++ b/include/klee/util/TxTreeGraph.h
@@ -129,10 +129,10 @@ private:
   /// \brief Maps leaves to leaf ids
   std::map<TxTreeGraph::Node *, uint64_t> leafToLeafSequenceNumber;
 
-  /// \brief The number of interesting instruction executed while processing a
-  /// node: The interesting instruction is a return from a function named
-  /// tracerx_mark.
-  std::map<uint64_t, uint64_t> interestingInstructionCount;
+  /// \brief The addition to the number of interesting instruction executed
+  /// while processing a node: The interesting instruction is a return from a
+  /// function named tracerx_mark.
+  std::map<uint64_t, uint64_t> markAddition;
 
   uint64_t subsumptionEdgeNumber;
 

--- a/include/klee/util/TxTreeGraph.h
+++ b/include/klee/util/TxTreeGraph.h
@@ -129,6 +129,11 @@ private:
   /// \brief Maps leaves to leaf ids
   std::map<TxTreeGraph::Node *, uint64_t> leafToLeafSequenceNumber;
 
+  /// \brief The number of interesting instruction executed while processing a
+  /// node: The interesting instruction is a return from a function named
+  /// tracerx_mark.
+  std::map<uint64_t, uint64_t> interestingInstructionCount;
+
   uint64_t subsumptionEdgeNumber;
 
   uint64_t internalNodeId;

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2015,6 +2015,9 @@ void TxTree::setCurrentINode(ExecutionState &state) {
   TimerStatIncrementer t(setCurrentINodeTime);
   currentTxTreeNode = state.txTreeNode;
   currentTxTreeNode->setProgramPoint(state.pc->inst);
+  if (!currentTxTreeNode->nodeSequenceNumber)
+    currentTxTreeNode->nodeSequenceNumber =
+        TxTreeNode::nextNodeSequenceNumber++;
   TxTreeGraph::setCurrentNode(state, currentTxTreeNode->nodeSequenceNumber);
 }
 
@@ -2255,7 +2258,7 @@ TxTreeNode::TxTreeNode(
     TxTreeNode *_parent, llvm::DataLayout *_targetData,
     std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *_globalAddresses)
     : parent(_parent), left(0), right(0), programPoint(0),
-      nodeSequenceNumber(nextNodeSequenceNumber++), storable(true),
+      nodeSequenceNumber(0), storable(true),
       graph(_parent ? _parent->graph : 0),
       instructionsDepth(_parent ? _parent->instructionsDepth : 0),
       targetData(_targetData), globalAddresses(_globalAddresses),

--- a/lib/Core/TxTreeGraph.cpp
+++ b/lib/Core/TxTreeGraph.cpp
@@ -1,4 +1,4 @@
-//===-- TxTreeGraph.h - Tracer-X tree DOT graph -----------------*- C++ -*-===//
+//===-- TxTreeGraph.cpp - Tracer-X tree DOT graph ---------------*- C++ -*-===//
 //
 //               The Tracer-X KLEE Symbolic Virtual Machine
 //

--- a/lib/Core/TxTreeGraph.cpp
+++ b/lib/Core/TxTreeGraph.cpp
@@ -118,9 +118,9 @@ std::string TxTreeGraph::recurseRender(TxTreeGraph::Node *node) {
     stream << "\\l";
   }
   std::map<uint64_t, uint64_t>::const_iterator it =
-      interestingInstructionCount.find(node->nodeSequenceNumber);
-  if (it != interestingInstructionCount.end()) {
-    stream << "interesting call(s): " << it->second << "\\l";
+      markAddition.find(node->nodeSequenceNumber);
+  if (it != markAddition.end()) {
+    stream << "mark(s): " << it->second << "\\l";
   }
   switch (node->errorType) {
   case ASSERTION: {
@@ -265,7 +265,7 @@ TxTreeGraph::~TxTreeGraph() {
 
   leafToLeafSequenceNumber.clear();
 
-  interestingInstructionCount.clear();
+  markAddition.clear();
 }
 
 void TxTreeGraph::addChildren(TxTreeNode *parent, TxTreeNode *falseChild,
@@ -318,13 +318,13 @@ void TxTreeGraph::setCurrentNode(ExecutionState &state,
     node->nodeSequenceNumber = _nodeSequenceNumber;
   }
 
-  // Increase the interesting instruction count when there is a return from a
-  // function named tracerx_mark.
+  // Increase the mark addition count when there is a return from a function
+  // named tracerx_mark.
   if (llvm::ReturnInst *ri = llvm::dyn_cast<llvm::ReturnInst>(state.pc->inst)) {
     if (ri->getParent()) {
       if (llvm::Function *f = ri->getParent()->getParent()) {
         if (f->getName().str() == "tracerx_mark") {
-          (instance->interestingInstructionCount[node->nodeSequenceNumber])++;
+          (instance->markAddition[node->nodeSequenceNumber])++;
         }
       }
     }

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -439,7 +439,7 @@ void TxInterpolantValue::print(llvm::raw_ostream &stream,
       stream << "\n";
       stream << prefix << "[";
       it->first->print(stream);
-      stream << "<={";
+      stream << "<{";
       for (std::set<ref<Expr> >::const_iterator it1 = it->second.begin(),
                                                 is1 = it1,
                                                 ie1 = it->second.end();


### PR DESCRIPTION
1. Now the nodes are numbered according the order of they are visited in the tree.
2. Added terminal number indexing as in [this example](http://www.comp.nus.edu.sg/~tracerx/web_files/pr267/regexp3.svg), where terminal nodes are numbered (terminal #N). The example was produced from executing [this program](http://www.comp.nus.edu.sg/~tracerx/web_files/pr267/regexp3.c).
3. Added feature to count calls to `tracerx_mark` function along the execution, also exemplified by the [same example as for No. 2](http://www.comp.nus.edu.sg/~tracerx/web_files/pr267/regexp3.svg), with `mark(s): N (+M)` where `N` is the total visitation of `tracerx_mark` function, and `+M` is the number of how many times the function is visited in the node (the number of returns from the function).

**EDIT:**
1. Corrected web links.