### PR TITLE
Fix to over-subsumption

### DIFF
--- a/include/klee/Constraints.h
+++ b/include/klee/Constraints.h
@@ -43,6 +43,8 @@ public:
 
   ref<Expr> simplifyExpr(ref<Expr> e) const;
 
+  ref<Expr> simplifyExpr(ref<Expr> e, std::vector<ref<Expr> > &core) const;
+
   void addConstraint(ref<Expr> e);
   
   bool empty() const {

--- a/include/klee/Constraints.h
+++ b/include/klee/Constraints.h
@@ -43,7 +43,7 @@ public:
 
   ref<Expr> simplifyExpr(ref<Expr> e) const;
 
-  ref<Expr> simplifyExpr(ref<Expr> e, std::vector<unsigned> &core) const;
+  ref<Expr> simplifyExpr(ref<Expr> e, std::vector<ref<Expr> > &core) const;
 
   void addConstraint(ref<Expr> e);
   

--- a/include/klee/Constraints.h
+++ b/include/klee/Constraints.h
@@ -43,7 +43,7 @@ public:
 
   ref<Expr> simplifyExpr(ref<Expr> e) const;
 
-  ref<Expr> simplifyExpr(ref<Expr> e, std::vector<ref<Expr> > &core) const;
+  ref<Expr> simplifyExpr(ref<Expr> e, std::vector<unsigned> &core) const;
 
   void addConstraint(ref<Expr> e);
   

--- a/include/klee/IncompleteSolver.h
+++ b/include/klee/IncompleteSolver.h
@@ -61,25 +61,26 @@ public:
   /// The IncompleteSolver class provides an implementation of
   /// computeValidity using computeTruth. Sub-classes may override
   /// this if a more efficient implementation is available.
-  virtual IncompleteSolver::PartialValidity computeValidity(const Query&);
+  virtual IncompleteSolver::PartialValidity
+  computeValidity(const Query &, std::vector<ref<Expr> > &unsatCore);
 
   /// computeValidity - Compute a partial validity for the given query.
   ///
   /// The passed expression is non-constant with bool type.
-  virtual IncompleteSolver::PartialValidity computeTruth(const Query&) = 0;
-  
+  virtual IncompleteSolver::PartialValidity
+  computeTruth(const Query &, std::vector<ref<Expr> > &unsatCore) = 0;
+
   /// computeValue - Attempt to compute a value for the given expression.
   virtual bool computeValue(const Query&, ref<Expr> &result) = 0;
 
   /// computeInitialValues - Attempt to compute the constant values
   /// for the initial state of each given object. If a correct result
   /// is not found, then the values array must be unmodified.
-  virtual bool computeInitialValues(const Query&,
-                                    const std::vector<const Array*> 
-                                      &objects,
-                                    std::vector< std::vector<unsigned char> > 
-                                      &values,
-                                    bool &hasSolution) = 0;
+  virtual bool
+  computeInitialValues(const Query &, const std::vector<const Array *> &objects,
+                       std::vector<std::vector<unsigned char> > &values,
+                       bool &hasSolution,
+                       std::vector<ref<Expr> > &unsatCore) = 0;
 };
 
 /// StagedSolver - Adapter class for staging an incomplete solver with
@@ -93,20 +94,20 @@ private:
 public:
   StagedSolverImpl(IncompleteSolver *_primary, Solver *_secondary);
   ~StagedSolverImpl();
-    
-  bool computeTruth(const Query&, bool &isValid);
-  bool computeValidity(const Query&, Solver::Validity &result);
+
+  bool computeTruth(const Query &, bool &isValid,
+                    std::vector<ref<Expr> > &unsatCore);
+  bool computeValidity(const Query &, Solver::Validity &result,
+                       std::vector<ref<Expr> > &unsatCore);
   bool computeValue(const Query&, ref<Expr> &result);
-  bool computeInitialValues(const Query&,
-                            const std::vector<const Array*> &objects,
-                            std::vector< std::vector<unsigned char> > &values,
-                            bool &hasSolution);
+  bool computeInitialValues(const Query &,
+                            const std::vector<const Array *> &objects,
+                            std::vector<std::vector<unsigned char> > &values,
+                            bool &hasSolution,
+                            std::vector<ref<Expr> > &unsatCore);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query&);
   void setCoreSolverTimeout(double timeout);
-  std::vector<ref<Expr> > &getUnsatCore() {
-    return secondary->impl->getUnsatCore();
-  }
 };
 
 }

--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -84,8 +84,9 @@ namespace klee {
     /// Solver::Unknown
     ///
     /// \return True on success.
-    bool evaluate(const Query&, Validity &result);
-  
+    bool evaluate(const Query &, Validity &result,
+                  std::vector<ref<Expr> > &unsatCore);
+
     /// mustBeTrue - Determine if the expression is provably true.
     /// 
     /// This evaluates the following logical formula:
@@ -183,9 +184,10 @@ namespace klee {
     // FIXME: This API is lame. We should probably just provide an API which
     // returns an Assignment object, then clients can get out whatever values
     // they want. This also allows us to optimize the representation.
-    bool getInitialValues(const Query&, 
-                          const std::vector<const Array*> &objects,
-                          std::vector< std::vector<unsigned char> > &result);
+    bool getInitialValues(const Query &,
+                          const std::vector<const Array *> &objects,
+                          std::vector<std::vector<unsigned char> > &result,
+                          std::vector<ref<Expr> > &unsatCore);
 
     /// getRange - Compute a tight range of possible values for a given
     /// expression.
@@ -201,14 +203,6 @@ namespace klee {
     
     virtual char *getConstraintLog(const Query& query);
     virtual void setCoreSolverTimeout(double timeout);
-
-    /// getUnsatCore - get the unsatisfiability core. Beware that the unsat core
-    /// is only available with certain solvers, e.g., Z3, and even so, may not
-    /// be always available in unsatisfiability cases when wrapped in e.g.,
-    /// IncompleteSolver (which may replace the core Z3 solver).
-    ///
-    /// \return Vector of ref<Expr>
-    virtual std::vector<ref<Expr> > &getUnsatCore();
   };
 
   #ifdef ENABLE_STP
@@ -255,7 +249,8 @@ namespace klee {
 
     /// directComputeValidity - Compute validity directly without other
     /// layers of solving
-    bool directComputeValidity(const Query &query, Solver::Validity &result);
+    bool directComputeValidity(const Query &query, Solver::Validity &result,
+                               std::vector<ref<Expr> > &unsatCore);
   };
   #endif // ENABLE_Z3
 

--- a/include/klee/SolverImpl.h
+++ b/include/klee/SolverImpl.h
@@ -58,8 +58,9 @@ namespace klee {
     /// Solver::Unknown
     ///
     /// \return True on success
-    virtual bool computeValidity(const Query& query, Solver::Validity &result);
-    
+    virtual bool computeValidity(const Query &query, Solver::Validity &result,
+                                 std::vector<ref<Expr> > &unsatCore);
+
     /// computeTruth - Determine whether the given query expression is provably true
     /// given the constraints.
     ///
@@ -75,7 +76,8 @@ namespace klee {
     ///
     /// \param [out] isValid - On success, true iff the logical formula is true.
     /// \return True on success
-    virtual bool computeTruth(const Query& query, bool &isValid) = 0;
+    virtual bool computeTruth(const Query &query, bool &isValid,
+                              std::vector<ref<Expr> > &unsatCore) = 0;
 
     /// computeValue - Compute a feasible value for the expression.
     ///
@@ -85,13 +87,11 @@ namespace klee {
     virtual bool computeValue(const Query& query, ref<Expr> &result) = 0;
     
     /// \sa Solver::getInitialValues()
-    virtual bool computeInitialValues(const Query& query,
-                                      const std::vector<const Array*> 
-                                        &objects,
-                                      std::vector< std::vector<unsigned char> > 
-                                        &values,
-                                      bool &hasSolution) = 0;
-    
+    virtual bool computeInitialValues(
+        const Query &query, const std::vector<const Array *> &objects,
+        std::vector<std::vector<unsigned char> > &values, bool &hasSolution,
+        std::vector<ref<Expr> > &unsatCore) = 0;
+
     /// getOperationStatusCode - get the status of the last solver operation
     virtual SolverRunStatus getOperationStatusCode() = 0;
 
@@ -105,14 +105,6 @@ namespace klee {
     }
 
     virtual void setCoreSolverTimeout(double timeout) {};
-
-    /// getUnsatCore - get the unsatisfiability core. Beware that the unsat core
-    /// is only available with certain solvers, e.g., Z3, and even so, may not
-    /// be always available in unsatisfiability cases when wrapped in e.g.,
-    /// IncompleteSolver (which may replace the core Z3 solver).
-    ///
-    /// \return Vector of ref<Expr>
-    virtual std::vector<ref<Expr> > &getUnsatCore();
   };
 
 }

--- a/include/klee/util/Assignment.h
+++ b/include/klee/util/Assignment.h
@@ -83,9 +83,7 @@ namespace klee {
       return a;
     }
 
-    std::vector< ref<Expr> > getCore() const {
-      return unsatCore;
-    }
+    const std::vector<ref<Expr> > &getCore() const { return unsatCore; }
   };
 
   /***/

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -159,11 +159,9 @@ void Dependency::getConcreteStore(
     if (it->second.second.isNull())
       continue;
 
-    if (!coreOnly) {
-      _concreteStore[it->first] = it->second.second;
-    } else if (it->second.second->isCore()) {
+    _concreteStore[it->first] = it->second.second;
+    if (coreOnly && it->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
-      _concreteStore[it->first] = it->second.second;
       useCount[it->second.second] = it->second.second->getDirectUseCount();
     }
   }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -164,8 +164,6 @@ void Dependency::getConcreteStore(
     } else if (it->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
       _concreteStore[it->first] = it->second.second;
-      std::set<ref<TxStateAddress> > loadLocations =
-          it->second.second->getLoadLocations();
       useCount[it->second.second] = it->second.second->getDirectUseCount();
     }
   }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -50,7 +50,7 @@ void Dependency::removeAddressValue(
     Dependency::InterpolantStore &concreteStore,
     std::set<const Array *> &replacements, bool coreOnly) const {
   std::map<ref<TxStateAddress>, ref<TxStateValue> > _concreteStore;
-  std::set<ref<TxStateAddress> > addressesToRemove;
+  std::set<ref<TxStateAddress> > addressToBeReplaced;
 
   for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
            it = simpleStore.begin(),
@@ -67,7 +67,7 @@ void Dependency::removeAddressValue(
            it2 != ie2; ++it2) {
         it1 = simpleStore.find(*it2);
         if (it1 != simpleStore.end()) {
-          addressesToRemove.insert(*it2);
+          addressToBeReplaced.insert(*it2);
           // Found the address in the map;
           _concreteStore[keyAddress->copyWithIndirectionCountIncrement()] =
               it1->second;
@@ -78,7 +78,7 @@ void Dependency::removeAddressValue(
   }
 
   std::set<ref<TxStateAddress> >::iterator addressesToRemoveEnd =
-      addressesToRemove.end();
+      addressToBeReplaced.end();
 
   // FIXME: Perhaps it is more efficient to iterate on
   // Dependency::concretelyAddressedStoreKeys earlier.
@@ -89,7 +89,7 @@ void Dependency::removeAddressValue(
     std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator it1 =
         simpleStore.find(*it);
     if (it1 != simpleStore.end() &&
-        addressesToRemove.find(it1->first) == addressesToRemoveEnd) {
+        addressToBeReplaced.find(it1->first) == addressesToRemoveEnd) {
       const llvm::Value *base = it1->first->getValue();
       ref<TxInterpolantAddress> address =
           it1->first->getInterpolantStyleAddress();
@@ -110,8 +110,10 @@ void Dependency::removeAddressValue(
       }
     }
 
-    it1 = _concreteStore.find(*it);
-    if (it1 != _concreteStore.end()) {
+    for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
+             it1 = _concreteStore.begin(),
+             ie1 = _concreteStore.end();
+         it1 != ie1; ++it1) {
       const llvm::Value *base = it1->first->getValue();
       ref<TxInterpolantAddress> address =
           it1->first->getInterpolantStyleAddress();

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -17,6 +17,8 @@
 #ifndef KLEE_DEPENDENCY_H
 #define KLEE_DEPENDENCY_H
 
+#include "TxStore.h"
+
 #include "klee/Config/Version.h"
 #include "klee/Internal/Module/TxValues.h"
 
@@ -158,37 +160,20 @@ namespace klee {
   ///
   /// \see TxTree
   /// \see TxTreeNode
+/// \see TxStore
 /// \see TxStateValue
 /// \see TxStateAddress
   class Dependency {
 
-  public:
-    typedef std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> >
-    InterpolantStoreMap;
-    typedef std::map<const llvm::Value *, InterpolantStoreMap> InterpolantStore;
-
   private:
+    /// The store
+    TxStore store;
+
     /// \brief Previous path condition
     Dependency *parent;
 
     /// \brief Argument values to be passed onto callee
     std::vector<ref<TxStateValue> > argumentValuesList;
-
-    /// \brief The mapping of concrete locations to stored value
-    std::map<ref<TxStateAddress>,
-             std::pair<ref<TxStateValue>, ref<TxStateValue> > >
-    concretelyAddressedStore;
-
-    /// \brief Ordered keys of the concretely-addressed store.
-    std::vector<ref<TxStateAddress> > concretelyAddressedStoreKeys;
-
-    /// \brief The mapping of symbolic locations to stored value
-    std::map<ref<TxStateAddress>,
-             std::pair<ref<TxStateValue>, ref<TxStateValue> > >
-    symbolicallyAddressedStore;
-
-    /// \brief Ordered keys of the symbolically-addressed store.
-    std::vector<ref<TxStateAddress> > symbolicallyAddressedStoreKeys;
 
     /// \brief The store of the versioned values
     std::map<llvm::Value *, std::vector<ref<TxStateValue> > > valuesMap;
@@ -271,16 +256,6 @@ namespace klee {
     ref<TxStateValue> getLatestValueForMarking(llvm::Value *val,
                                                ref<Expr> expr);
 
-    /// \brief Newly relate a location with its stored value, when the value is
-    /// loaded from the location
-    void updateStoreWithLoadedValue(ref<TxStateAddress> loc,
-                                    ref<TxStateValue> address,
-                                    ref<TxStateValue> value);
-
-    /// \brief Newly relate an location with its stored value
-    void updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
-                     ref<TxStateValue> value);
-
     /// \brief Add flow dependency between source and target value
     void addDependency(ref<TxStateValue> source, ref<TxStateValue> target,
                        bool multiLocationsCheck = true);
@@ -352,29 +327,6 @@ namespace klee {
         std::vector<ref<Expr> > &arguments,
         std::vector<ref<TxStateValue> > &argumentValuesList);
 
-    void removeAddressValue(
-        std::map<ref<TxStateAddress>, ref<TxStateValue> > &simpleStore,
-        Dependency::InterpolantStore &concreteStore,
-        std::set<const Array *> &replacements, bool coreOnly) const;
-
-    void getConcreteStore(
-        const std::vector<llvm::Instruction *> &callHistory,
-        const std::map<ref<TxStateAddress>,
-                       std::pair<ref<TxStateValue>, ref<TxStateValue> > > &
-            store,
-        const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
-        std::set<const Array *> &replacements, bool coreOnly,
-        Dependency::InterpolantStore &concreteStore) const;
-
-    void getSymbolicStore(
-        const std::vector<llvm::Instruction *> &callHistory,
-        const std::map<ref<TxStateAddress>,
-                       std::pair<ref<TxStateValue>, ref<TxStateValue> > > &
-            store,
-        const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
-        std::set<const Array *> &replacements, bool coreOnly,
-        Dependency::InterpolantStore &symbolicStore) const;
-
   public:
     /// \brief This is for dynamic setting up of debug messages.
     int debugSubsumptionLevel;
@@ -389,6 +341,30 @@ namespace klee {
     ~Dependency();
 
     Dependency *cdr() const;
+
+    /// \brief This retrieves the locations known at this state, and the
+    /// expressions stored in the locations. Returns as the last argument a pair
+    /// of the store part indexed by constants, and the store part indexed by
+    /// symbolic expressions.
+    ///
+    /// \param replacements The replacement bound variables when
+    /// retrieving state for creating subsumption table entry: As the
+    /// resulting expression will be used for storing in the
+    /// subsumption table, the variables need to be replaced with the
+    /// bound ones.
+    /// \param coreOnly Indicate whether we are retrieving only data
+    /// for locations relevant to an unsatisfiability core.
+    ///
+    /// \sa TxStore#getStoredExpressions()
+    void getStoredExpressions(
+        const std::vector<llvm::Instruction *> &callHistory,
+        std::set<const Array *> &replacements, bool coreOnly,
+        TxStore::TopInterpolantStore &concretelyAddressedStore,
+        TxStore::TopInterpolantStore &symbolicallyAddressedStore) {
+      store.getStoredExpressions(callHistory, replacements, coreOnly,
+                                 concretelyAddressedStore,
+                                 symbolicallyAddressedStore);
+    }
 
     ref<TxStateValue>
     getLatestValue(llvm::Value *value,
@@ -419,23 +395,6 @@ namespace klee {
                            std::vector<ref<Expr> > &args, bool inBounds,
                            bool symbolicExecutionError);
 
-    /// \brief This retrieves the locations known at this state, and the
-    /// expressions stored in the locations. Returns as the last argument a pair
-    /// of the store part indexed by constants, and the store part indexed by
-    /// symbolic expressions.
-    ///
-    /// \param replacements The replacement bound variables when
-    /// retrieving state for creating subsumption table entry: As the
-    /// resulting expression will be used for storing in the
-    /// subsumption table, the variables need to be replaced with the
-    /// bound ones.
-    /// \param coreOnly Indicate whether we are retrieving only data
-    /// for locations relevant to an unsatisfiability core.
-    void
-    getStoredExpressions(const std::vector<llvm::Instruction *> &callHistory,
-                         std::set<const Array *> &replacements, bool coreOnly,
-                         InterpolantStore &_concretelyAddressedStore,
-                         InterpolantStore &_symbolicallyAddressedStore);
 
     /// \brief Record call arguments in a function call
     void bindCallArguments(llvm::Instruction *instr,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -193,10 +193,6 @@ namespace klee {
     /// \brief The store of the versioned values
     std::map<llvm::Value *, std::vector<ref<TxStateValue> > > valuesMap;
 
-    /// \brief Locations of this node and its ancestors that are needed for
-    /// the core and dominates other locations.
-    std::set<ref<TxStateAddress> > coreLocations;
-
     /// \brief The data layout of the analysis target program
     llvm::DataLayout *targetData;
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -248,9 +248,10 @@ namespace klee {
 
     /// \brief Find existing value or if not found immediately register a new
     /// one.
-    inline ref<TxStateValue> getLatestValueNoConstantCheckOrCreate(
-        llvm::Value *value, const std::vector<llvm::Instruction *> &callHistory,
-        ref<Expr> expr);
+    inline ref<TxStateValue>
+    createConstantValue(llvm::Value *value,
+                        const std::vector<llvm::Instruction *> &callHistory,
+                        ref<Expr> expr);
 
     /// \brief Gets the latest pointer value for marking
     ref<TxStateValue> getLatestValueForMarking(llvm::Value *val,

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -349,8 +349,7 @@ Executor::Executor(const InterpreterOptions &opts, InterpreterHandler *ih)
       interpreterHandler->getOutputFilename(ALL_QUERIES_PC_FILE_NAME),
       interpreterHandler->getOutputFilename(SOLVER_QUERIES_PC_FILE_NAME));
 
-  this->solver =
-      new TimingSolver(solver, EqualitySubstitution && !INTERPOLATION_ENABLED);
+  this->solver = new TimingSolver(solver, EqualitySubstitution);
   memory = new MemoryManager(&arrayCache);
 
   if (optionIsSet(DebugPrintInstructions, FILE_ALL) ||

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -349,7 +349,8 @@ Executor::Executor(const InterpreterOptions &opts, InterpreterHandler *ih)
       interpreterHandler->getOutputFilename(ALL_QUERIES_PC_FILE_NAME),
       interpreterHandler->getOutputFilename(SOLVER_QUERIES_PC_FILE_NAME));
 
-  this->solver = new TimingSolver(solver, EqualitySubstitution);
+  this->solver =
+      new TimingSolver(solver, EqualitySubstitution && !INTERPOLATION_ENABLED);
   memory = new MemoryManager(&arrayCache);
 
   if (optionIsSet(DebugPrintInstructions, FILE_ALL) ||

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -94,14 +94,8 @@ bool TimingSolver::evaluate(const ExecutionState& state, ref<Expr> expr,
     expr = state.constraints.simplifyExpr(expr, simplificationCore);
 
   bool success = solver->evaluate(Query(state.constraints, expr), result);
-#ifdef SUPPORT_Z3
-#ifdef SUPPORT_STP
-  if (SelectSolver == SOLVER_Z3)
+  if (INTERPOLATION_ENABLED)
     buildCachedUnsatCore(state, simplificationCore);
-#else
-  buildCachedUnsatCore(state, simplificationCore);
-#endif
-#endif
 
   sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
@@ -126,13 +120,8 @@ bool TimingSolver::mustBeTrue(const ExecutionState& state, ref<Expr> expr,
     expr = state.constraints.simplifyExpr(expr, simplificationCore);
 
   bool success = solver->mustBeTrue(Query(state.constraints, expr), result);
-#ifdef SUPPORT_Z3
-#ifdef SUPPORT_STP
-  if (SelectSolver == SOLVER_Z3)
+  if (INTERPOLATION_ENABLED)
     buildCachedUnsatCore(state, simplificationCore);
-#endif
-  buildCachedUnsatCore(state, simplificationCore);
-#endif
 
   sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
@@ -180,13 +169,8 @@ bool TimingSolver::getValue(const ExecutionState& state, ref<Expr> expr,
     expr = state.constraints.simplifyExpr(expr, simplificationCore);
 
   bool success = solver->getValue(Query(state.constraints, expr), result);
-#ifdef SUPPORT_Z3
-#ifdef SUPPORT_STP
-  if (SelectSolver == SOLVER_Z3)
+  if (INTERPOLATION_ENABLED)
     buildCachedUnsatCore(state, simplificationCore);
-#endif
-  buildCachedUnsatCore(state, simplificationCore);
-#endif
 
   sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
@@ -210,13 +194,8 @@ TimingSolver::getInitialValues(const ExecutionState& state,
   bool success = solver->getInitialValues(Query(state.constraints,
                                                 ConstantExpr::alloc(0, Expr::Bool)), 
                                           objects, result);
-#ifdef SUPPORT_Z3
-#ifdef SUPPORT_STP
-  if (SelectSolver == SOLVER_Z3)
+  if (INTERPOLATION_ENABLED)
     buildCachedUnsatCore(state);
-#endif
-  buildCachedUnsatCore(state);
-#endif
 
   sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
@@ -230,13 +209,8 @@ std::pair< ref<Expr>, ref<Expr> >
 TimingSolver::getRange(const ExecutionState& state, ref<Expr> expr) {
   std::pair<ref<Expr>, ref<Expr> > ret =
       solver->getRange(Query(state.constraints, expr));
-#ifdef SUPPORT_Z3
-#ifdef SUPPORT_STP
-  if (SelectSolver == SOLVER_Z3)
+  if (INTERPOLATION_ENABLED)
     buildCachedUnsatCore(state);
-#endif
-  buildCachedUnsatCore(state);
-#endif
   return ret;
 }
 

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -37,17 +37,28 @@ void TimingSolver::buildCachedUnsatCore(
     if (!unsatCore.empty()) {
       std::vector<ref<Expr> >::iterator simplificationIt =
           simplificationCore.begin();
+      std::vector<ref<Expr> >::iterator simplificationItEnd =
+          simplificationCore.end();
       std::vector<ref<Expr> >::iterator unsatIt = unsatCore.begin();
+      std::vector<ref<Expr> >::iterator unsatItEnd = unsatCore.end();
+
       for (ConstraintManager::const_iterator it = state.constraints.begin(),
                                              itEnd = state.constraints.end();
            it != itEnd; ++it) {
-        if (*it == *simplificationIt) {
-          ++simplificationIt;
-          if (*it == *unsatIt) {
-            ++unsatIt;
+        if (simplificationIt != simplificationItEnd) {
+          if (*it == *simplificationIt) {
+            ++simplificationIt;
+            if (unsatIt != unsatItEnd && *it == *unsatIt) {
+              ++unsatIt;
+            }
+            cachedUnsatCore.push_back(*it);
+            continue;
           }
-          cachedUnsatCore.push_back(*it);
-        } else if (*it == *unsatIt) {
+        } else if (unsatIt == unsatItEnd) {
+          break;
+        }
+
+        if (*it == *unsatIt) {
           ++unsatIt;
           cachedUnsatCore.push_back(*it);
         }

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -55,6 +55,7 @@ TimingSolver::buildCachedUnsatCore(const ExecutionState &state,
               ++unsatIt;
             }
             cachedUnsatCore.push_back(*it);
+            ++constraintIndex;
             continue;
           }
         } else if (unsatIt == unsatItEnd) {

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -9,6 +9,7 @@
 
 #include "TimingSolver.h"
 
+#include "klee/CommandLine.h"
 #include "klee/Config/Version.h"
 #include "klee/ExecutionState.h"
 #include "klee/Solver.h"
@@ -93,7 +94,14 @@ bool TimingSolver::evaluate(const ExecutionState& state, ref<Expr> expr,
     expr = state.constraints.simplifyExpr(expr, simplificationCore);
 
   bool success = solver->evaluate(Query(state.constraints, expr), result);
+#ifdef SUPPORT_Z3
+#ifdef SUPPORT_STP
+  if (SelectSolver == SOLVER_Z3)
+    buildCachedUnsatCore(state, simplificationCore);
+#else
   buildCachedUnsatCore(state, simplificationCore);
+#endif
+#endif
 
   sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
@@ -118,7 +126,13 @@ bool TimingSolver::mustBeTrue(const ExecutionState& state, ref<Expr> expr,
     expr = state.constraints.simplifyExpr(expr, simplificationCore);
 
   bool success = solver->mustBeTrue(Query(state.constraints, expr), result);
+#ifdef SUPPORT_Z3
+#ifdef SUPPORT_STP
+  if (SelectSolver == SOLVER_Z3)
+    buildCachedUnsatCore(state, simplificationCore);
+#endif
   buildCachedUnsatCore(state, simplificationCore);
+#endif
 
   sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
@@ -166,7 +180,13 @@ bool TimingSolver::getValue(const ExecutionState& state, ref<Expr> expr,
     expr = state.constraints.simplifyExpr(expr, simplificationCore);
 
   bool success = solver->getValue(Query(state.constraints, expr), result);
+#ifdef SUPPORT_Z3
+#ifdef SUPPORT_STP
+  if (SelectSolver == SOLVER_Z3)
+    buildCachedUnsatCore(state, simplificationCore);
+#endif
   buildCachedUnsatCore(state, simplificationCore);
+#endif
 
   sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
@@ -190,7 +210,13 @@ TimingSolver::getInitialValues(const ExecutionState& state,
   bool success = solver->getInitialValues(Query(state.constraints,
                                                 ConstantExpr::alloc(0, Expr::Bool)), 
                                           objects, result);
+#ifdef SUPPORT_Z3
+#ifdef SUPPORT_STP
+  if (SelectSolver == SOLVER_Z3)
+    buildCachedUnsatCore(state);
+#endif
   buildCachedUnsatCore(state);
+#endif
 
   sys::TimeValue delta = util::getWallTimeVal();
   delta -= now;
@@ -204,7 +230,13 @@ std::pair< ref<Expr>, ref<Expr> >
 TimingSolver::getRange(const ExecutionState& state, ref<Expr> expr) {
   std::pair<ref<Expr>, ref<Expr> > ret =
       solver->getRange(Query(state.constraints, expr));
+#ifdef SUPPORT_Z3
+#ifdef SUPPORT_STP
+  if (SelectSolver == SOLVER_Z3)
+    buildCachedUnsatCore(state);
+#endif
   buildCachedUnsatCore(state);
+#endif
   return ret;
 }
 

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -40,17 +40,16 @@ bool TimingSolver::evaluate(const ExecutionState &state, ref<Expr> expr,
   if (simplifyExprs)
     expr = state.constraints.simplifyExpr(expr, simplificationCore);
 
+  unsatCore.clear();
+
   bool success =
       solver->evaluate(Query(state.constraints, expr), result, unsatCore);
   if (INTERPOLATION_ENABLED) {
     if (result != Solver::Unknown) {
-      if (unsatCore.empty() && simplifyExprs) {
-        unsatCore.clear();
+      if (simplifyExprs) {
         unsatCore.insert(unsatCore.begin(), simplificationCore.begin(),
                          simplificationCore.end());
       }
-    } else {
-      unsatCore.clear();
     }
   }
 

--- a/lib/Core/TimingSolver.cpp
+++ b/lib/Core/TimingSolver.cpp
@@ -62,7 +62,7 @@ TimingSolver::buildCachedUnsatCore(const ExecutionState &state,
           break;
         }
 
-        if (*it == *unsatIt) {
+        if (unsatIt != unsatItEnd && *it == *unsatIt) {
           ++unsatIt;
           cachedUnsatCore.push_back(*it);
         }

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -22,6 +22,13 @@ namespace klee {
   /// TimingSolver - A simple class which wraps a solver and handles
   /// tracking the statistics that we care about.
   class TimingSolver {
+    std::vector<ref<Expr> > cachedUnsatCore;
+
+    void buildCachedUnsatCore(const ExecutionState &state);
+
+    void buildCachedUnsatCore(const ExecutionState &state,
+                              std::vector<ref<Expr> > &simplificationCore);
+
   public:
     Solver *solver;
     bool simplifyExprs;

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -22,8 +22,6 @@ namespace klee {
   /// TimingSolver - A simple class which wraps a solver and handles
   /// tracking the statistics that we care about.
   class TimingSolver {
-    std::vector<ref<Expr> > cachedUnsatCore;
-
   public:
     Solver *solver;
     bool simplifyExprs;
@@ -48,7 +46,8 @@ namespace klee {
       return solver->getConstraintLog(query);
     }
 
-    bool evaluate(const ExecutionState&, ref<Expr>, Solver::Validity &result);
+    bool evaluate(const ExecutionState &, ref<Expr>, Solver::Validity &result,
+                  std::vector<ref<Expr> > &unsatCore);
 
     bool mustBeTrue(const ExecutionState&, ref<Expr>, bool &result);
 
@@ -61,13 +60,13 @@ namespace klee {
     bool getValue(const ExecutionState &, ref<Expr> expr, 
                   ref<ConstantExpr> &result);
 
-    bool getInitialValues(const ExecutionState&, 
-                          const std::vector<const Array*> &objects,
-                          std::vector< std::vector<unsigned char> > &result);
+    bool getInitialValues(const ExecutionState &,
+                          const std::vector<const Array *> &objects,
+                          std::vector<std::vector<unsigned char> > &result,
+                          std::vector<ref<Expr> > &unsatCore);
 
     std::pair< ref<Expr>, ref<Expr> >
     getRange(const ExecutionState&, ref<Expr> query);
-    std::vector<ref<Expr> > &getUnsatCore();
   };
 
 }

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -24,11 +24,6 @@ namespace klee {
   class TimingSolver {
     std::vector<ref<Expr> > cachedUnsatCore;
 
-    void buildCachedUnsatCore(const ExecutionState &state);
-
-    void buildCachedUnsatCore(const ExecutionState &state,
-                              std::vector<unsigned> &simplificationCore);
-
   public:
     Solver *solver;
     bool simplifyExprs;

--- a/lib/Core/TimingSolver.h
+++ b/lib/Core/TimingSolver.h
@@ -27,7 +27,7 @@ namespace klee {
     void buildCachedUnsatCore(const ExecutionState &state);
 
     void buildCachedUnsatCore(const ExecutionState &state,
-                              std::vector<ref<Expr> > &simplificationCore);
+                              std::vector<unsigned> &simplificationCore);
 
   public:
     Solver *solver;

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -1,5 +1,4 @@
-//===-- TxStore.cpp - A view of program memory -------------------*- C++
-//-*-===//
+//===-- TxStore.cpp - A view of program memory ------------------*- C++ -*-===//
 //
 //               The Tracer-X KLEE Symbolic Virtual Machine
 //

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -150,9 +150,11 @@ void TxStore::getConcreteStore(
     if (it->second.second.isNull())
       continue;
 
-    _concreteStore[it->first] = it->second.second;
-    if (coreOnly && it->second.second->isCore()) {
+    if (!coreOnly) {
+      _concreteStore[it->first] = it->second.second;
+    } else if (it->second.second->isCore()) {
       // An address is in the core if it stores a value that is in the core
+      _concreteStore[it->first] = it->second.second;
       useCount[it->second.second] = it->second.second->getDirectUseCount();
     }
   }

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -1,0 +1,366 @@
+//===-- TxStore.cpp - A view of program memory -------------------*- C++
+//-*-===//
+//
+//               The Tracer-X KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementations of the shadow memory to support the
+/// dependency computation of memory locations and the generation of
+/// interpolants.
+///
+//===----------------------------------------------------------------------===//
+
+#include "TxStore.h"
+
+#include "klee/CommandLine.h"
+#include "klee/util/TxPrintUtil.h"
+
+using namespace klee;
+
+namespace klee {
+
+void TxStore::getStoredExpressions(
+    const std::vector<llvm::Instruction *> &callHistory,
+    std::set<const Array *> &replacements, bool coreOnly,
+    TopInterpolantStore &_concretelyAddressedStore,
+    TopInterpolantStore &_symbolicallyAddressedStore) {
+  getConcreteStore(callHistory, concretelyAddressedStore,
+                   concretelyAddressedStoreKeys, replacements, coreOnly,
+                   _concretelyAddressedStore);
+  getSymbolicStore(callHistory, symbolicallyAddressedStore,
+                   symbolicallyAddressedStoreKeys, replacements, coreOnly,
+                   _symbolicallyAddressedStore);
+}
+
+void TxStore::removeAddressValue(
+    std::map<ref<TxStateAddress>, ref<TxStateValue> > &simpleStore,
+    TopInterpolantStore &concreteStore, std::set<const Array *> &replacements,
+    bool coreOnly) const {
+  std::map<ref<TxStateAddress>, ref<TxStateValue> > _concreteStore;
+  std::set<ref<TxStateAddress> > addressToBeReplaced;
+
+  for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
+           it = simpleStore.begin(),
+           ie = simpleStore.end();
+       it != ie; ++it) {
+    ref<TxStateAddress> keyAddress = it->first;
+    const std::set<ref<TxStateAddress> > &addresses =
+        it->second->getLocations();
+    if (addresses.size() > 0) {
+      std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator it1;
+      for (std::set<ref<TxStateAddress> >::const_iterator
+               it2 = addresses.begin(),
+               ie2 = addresses.end();
+           it2 != ie2; ++it2) {
+        it1 = simpleStore.find(*it2);
+        if (it1 != simpleStore.end()) {
+          addressToBeReplaced.insert(*it2);
+          // Found the address in the map;
+          _concreteStore[keyAddress->copyWithIndirectionCountIncrement()] =
+              it1->second;
+          break;
+        }
+      }
+    }
+  }
+
+  std::set<ref<TxStateAddress> >::iterator addressesToRemoveEnd =
+      addressToBeReplaced.end();
+
+  // FIXME: Perhaps it is more efficient to iterate on
+  // Dependency::concretelyAddressedStoreKeys earlier.
+  for (std::vector<ref<TxStateAddress> >::const_reverse_iterator
+           it = concretelyAddressedStoreKeys.rbegin(),
+           ie = concretelyAddressedStoreKeys.rend();
+       it != ie; ++it) {
+    std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator it1 =
+        simpleStore.find(*it);
+    if (it1 != simpleStore.end() &&
+        addressToBeReplaced.find(it1->first) == addressesToRemoveEnd) {
+      const llvm::Value *base = it1->first->getValue();
+      ref<TxInterpolantAddress> address =
+          it1->first->getInterpolantStyleAddress();
+      std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> > &
+      addressValueMap = concreteStore[base];
+      if (addressValueMap.find(address) == addressValueMap.end()) {
+        ref<TxInterpolantValue> storedValue;
+#ifdef ENABLE_Z3
+        if (coreOnly && !NoExistential) {
+          storedValue = it1->second->getInterpolantStyleValue(replacements);
+        } else {
+          storedValue = it1->second->getInterpolantStyleValue();
+        }
+#else
+        storedValue = it1->second->getInterpolantStyleValue();
+#endif
+        addressValueMap[address] = storedValue;
+      }
+    }
+
+    for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
+             it1 = _concreteStore.begin(),
+             ie1 = _concreteStore.end();
+         it1 != ie1; ++it1) {
+      const llvm::Value *base = it1->first->getValue();
+      ref<TxInterpolantAddress> address =
+          it1->first->getInterpolantStyleAddress();
+      std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> > &
+      addressValueMap = concreteStore[base];
+      if (addressValueMap.find(address) == addressValueMap.end()) {
+        ref<TxInterpolantValue> storedValue;
+#ifdef ENABLE_Z3
+        if (coreOnly && !NoExistential) {
+          storedValue = it1->second->getInterpolantStyleValue(replacements);
+        } else {
+          storedValue = it1->second->getInterpolantStyleValue();
+        }
+#else
+        storedValue = it1->second->getInterpolantStyleValue();
+#endif
+        addressValueMap[address] = storedValue;
+      }
+    }
+  }
+}
+
+void TxStore::getConcreteStore(
+    const std::vector<llvm::Instruction *> &callHistory,
+    const std::map<ref<TxStateAddress>,
+                   std::pair<ref<TxStateValue>, ref<TxStateValue> > > &store,
+    const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
+    std::set<const Array *> &replacements, bool coreOnly,
+    TopInterpolantStore &concreteStore) const {
+  std::map<ref<TxStateAddress>, ref<TxStateValue> > _concreteStore;
+
+  std::map<ref<TxStateValue>, uint64_t> useCount;
+
+  for (std::map<
+           ref<TxStateAddress>,
+           std::pair<ref<TxStateValue>, ref<TxStateValue> > >::const_iterator
+           it = store.begin(),
+           ie = store.end();
+       it != ie; ++it) {
+    if (!it->first->contextIsPrefixOf(callHistory))
+      continue;
+
+    if (it->second.second.isNull())
+      continue;
+
+    _concreteStore[it->first] = it->second.second;
+    if (coreOnly && it->second.second->isCore()) {
+      // An address is in the core if it stores a value that is in the core
+      useCount[it->second.second] = it->second.second->getDirectUseCount();
+    }
+  }
+
+  if (coreOnly) {
+    std::map<ref<TxStateAddress>, ref<TxStateValue> > __concreteStore;
+
+    //    llvm::errs() << "STEP0:\n";
+    //    for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
+    //             it = _concreteStore.begin(),
+    //             ie = _concreteStore.end();
+    //         it != ie; ++it) {
+    //      llvm::errs() << "-----------------------------\n";
+    //      it->first->dump();
+    //      it->second->dump();
+    //    }
+
+    // The following performs computation of values that are dominated by other
+    // values, wrt. flow to the interpolant / unsat core.
+    for (std::map<ref<TxStateValue>, uint64_t>::iterator it = useCount.begin(),
+                                                         ie = useCount.end();
+         it != ie; ++it) {
+      std::map<ref<TxStateValue>, uint64_t>::iterator mapIter;
+      const std::map<ref<TxStateValue>, ref<TxStateAddress> > &sources =
+          it->first->getSources();
+      for (std::map<ref<TxStateValue>, ref<TxStateAddress> >::const_iterator
+               it1 = sources.begin(),
+               ie1 = sources.end();
+           it1 != ie1; ++it1) {
+        mapIter = useCount.find(it1->first);
+        if (mapIter != useCount.end() && mapIter->second > 0)
+          --(mapIter->second);
+      }
+    }
+
+    // Copy only values whose use count not reduced to zero
+    for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
+             it = _concreteStore.begin(),
+             ie = _concreteStore.end();
+         it != ie; ++it) {
+      std::map<ref<TxStateValue>, uint64_t>::iterator it1 =
+          useCount.find(it->second);
+      if (it1 != useCount.end() && it1->second > 0)
+        __concreteStore[it->first] = it->second;
+    }
+
+    //    llvm::errs() << "STEP1:\n";
+    //    for (std::map<ref<TxStateAddress>, ref<TxStateValue> >::iterator
+    //             it = __concreteStore.begin(),
+    //             ie = __concreteStore.end();
+    //         it != ie; ++it) {
+    //      llvm::errs() << "-----------------------------\n";
+    //      it->first->dump();
+    //      it->second->dump();
+    //    }
+
+    removeAddressValue(__concreteStore, concreteStore, replacements, true);
+
+    //    llvm::errs() << "AFTER:\n";
+    //    for (Dependency::InterpolantStore::iterator it =
+    // concreteStore.begin(),
+    //                                                ie = concreteStore.end();
+    //         it != ie; ++it) {
+    //      std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> >
+    //      addressValueMap = it->second;
+    //      for (std::map<ref<TxInterpolantAddress>,
+    //                    ref<TxInterpolantValue> >::iterator
+    //               it1 = addressValueMap.begin(),
+    //               ie1 = addressValueMap.end();
+    //           it1 != ie1; ++it1) {
+    //        llvm::errs() << "-----------------------------\n";
+    //        it1->first->dump();
+    //        it1->second->dump();
+    //      }
+    //    }
+  } else {
+    removeAddressValue(_concreteStore, concreteStore, replacements, false);
+  }
+}
+
+void TxStore::getSymbolicStore(
+    const std::vector<llvm::Instruction *> &callHistory,
+    const std::map<ref<TxStateAddress>,
+                   std::pair<ref<TxStateValue>, ref<TxStateValue> > > &store,
+    const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
+    std::set<const Array *> &replacements, bool coreOnly,
+    TopInterpolantStore &symbolicStore) const {
+  for (std::vector<ref<TxStateAddress> >::const_reverse_iterator
+           it = orderedStoreKeys.rbegin(),
+           ie = orderedStoreKeys.rend();
+       it != ie; ++it) {
+    std::map<ref<TxStateAddress>,
+             std::pair<ref<TxStateValue>, ref<TxStateValue> > >::const_iterator
+    it1 = store.find(*it);
+    if (it1 == store.end())
+      continue;
+
+    if (!it1->first->contextIsPrefixOf(callHistory))
+      continue;
+
+    if (it1->second.second.isNull())
+      continue;
+
+    if (!coreOnly) {
+      const llvm::Value *base = it1->first->getContext()->getValue();
+      ref<TxInterpolantAddress> address =
+          it1->first->getInterpolantStyleAddress();
+      std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> > &
+      addressValueMap = symbolicStore[base];
+      if (addressValueMap.find(address) == addressValueMap.end()) {
+        addressValueMap[address] =
+            it1->second.second->getInterpolantStyleValue();
+      }
+    } else if (it1->second.second->isCore()) {
+      // An address is in the core if it stores a value that is in the core
+      const llvm::Value *base = it1->first->getContext()->getValue();
+      ref<TxInterpolantAddress> address =
+          it1->first->getInterpolantStyleAddress();
+      std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> > &
+      addressValueMap = symbolicStore[base];
+      if (addressValueMap.find(address) == addressValueMap.end()) {
+#ifdef ENABLE_Z3
+        if (!NoExistential) {
+          address = TxStateAddress::create(it1->first, replacements)
+                        ->getInterpolantStyleAddress();
+          addressValueMap[address] =
+              it1->second.second->getInterpolantStyleValue(replacements);
+        } else
+#endif
+          addressValueMap[address] =
+              it1->second.second->getInterpolantStyleValue();
+      }
+    }
+  }
+}
+
+void TxStore::updateStoreWithLoadedValue(ref<TxStateAddress> loc,
+                                         ref<TxStateValue> address,
+                                         ref<TxStateValue> value) {
+  updateStore(loc, address, value);
+  value->setLoadAddress(address);
+}
+
+void TxStore::updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
+                          ref<TxStateValue> value) {
+  if (loc->hasConstantAddress()) {
+    concretelyAddressedStore[loc] =
+        std::pair<ref<TxStateValue>, ref<TxStateValue> >(address, value);
+    concretelyAddressedStoreKeys.push_back(loc);
+  } else {
+    symbolicallyAddressedStore[loc] =
+        std::pair<ref<TxStateValue>, ref<TxStateValue> >(address, value);
+    symbolicallyAddressedStoreKeys.push_back(loc);
+  }
+}
+
+/// \brief Print the content of the object to the LLVM error stream
+void TxStore::print(llvm::raw_ostream &stream) const { this->print(stream, 0); }
+
+void TxStore::print(llvm::raw_ostream &stream,
+                    const unsigned paddingAmount) const {
+  std::string tabs = makeTabs(paddingAmount);
+  std::string tabsNext = appendTab(tabs);
+  std::string tabsNextNext = appendTab(tabsNext);
+
+  if (concretelyAddressedStore.empty()) {
+    stream << tabs << "concrete store = []\n";
+  } else {
+    stream << tabs << "concrete store = [\n";
+    for (std::map<
+             ref<TxStateAddress>,
+             std::pair<ref<TxStateValue>, ref<TxStateValue> > >::const_iterator
+             is = concretelyAddressedStore.begin(),
+             ie = concretelyAddressedStore.end(), it = is;
+         it != ie; ++it) {
+      if (it != is)
+        stream << tabsNext << "------------------------------------------\n";
+      stream << tabsNext << "address:\n";
+      it->first->print(stream, tabsNextNext);
+      stream << "\n";
+      stream << tabsNext << "content:\n";
+      it->second.second->print(stream, tabsNextNext);
+      stream << "\n";
+    }
+    stream << tabs << "]\n";
+  }
+
+  if (symbolicallyAddressedStore.empty()) {
+    stream << tabs << "symbolic store = []\n";
+  } else {
+    stream << tabs << "symbolic store = [\n";
+    for (std::map<
+             ref<TxStateAddress>,
+             std::pair<ref<TxStateValue>, ref<TxStateValue> > >::const_iterator
+             is = symbolicallyAddressedStore.begin(),
+             ie = symbolicallyAddressedStore.end(), it = is;
+         it != ie; ++it) {
+      if (it != is)
+        stream << tabsNext << "------------------------------------------\n";
+      stream << tabsNext << "address:\n";
+      it->first->print(stream, tabsNextNext);
+      stream << "\n";
+      stream << tabsNext << "content:\n";
+      it->second.second->print(stream, tabsNextNext);
+      stream << "\n";
+    }
+    stream << "]\n";
+  }
+}
+}

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -130,8 +130,7 @@ void TxStore::removeAddressValue(
 
 void TxStore::getConcreteStore(
     const std::vector<llvm::Instruction *> &callHistory,
-    const std::map<ref<TxStateAddress>,
-                   std::pair<ref<TxStateValue>, ref<TxStateValue> > > &store,
+    const StateStore &store,
     const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
     std::set<const Array *> &replacements, bool coreOnly,
     TopInterpolantStore &concreteStore) const {
@@ -236,8 +235,7 @@ void TxStore::getConcreteStore(
 
 void TxStore::getSymbolicStore(
     const std::vector<llvm::Instruction *> &callHistory,
-    const std::map<ref<TxStateAddress>,
-                   std::pair<ref<TxStateValue>, ref<TxStateValue> > > &store,
+    const StateStore &store,
     const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
     std::set<const Array *> &replacements, bool coreOnly,
     TopInterpolantStore &symbolicStore) const {

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -29,18 +29,15 @@ void TxStore::getStoredExpressions(
     std::set<const Array *> &replacements, bool coreOnly,
     TopInterpolantStore &_concretelyAddressedStore,
     TopInterpolantStore &_symbolicallyAddressedStore) {
-  getConcreteStore(callHistory, concretelyAddressedStore,
-                   concretelyAddressedStoreKeys, replacements, coreOnly,
-                   _concretelyAddressedStore);
-  getSymbolicStore(callHistory, symbolicallyAddressedStore,
-                   symbolicallyAddressedStoreKeys, replacements, coreOnly,
-                   _symbolicallyAddressedStore);
+  getConcreteStore(callHistory, concretelyAddressedStore, replacements,
+                   coreOnly, _concretelyAddressedStore);
+  getSymbolicStore(callHistory, symbolicallyAddressedStore, replacements,
+                   coreOnly, _symbolicallyAddressedStore);
 }
 
 void TxStore::getConcreteStore(
     const std::vector<llvm::Instruction *> &callHistory,
     const StateStore &store,
-    const std::vector<ref<TxInterpolantAddress> > &orderedStoreKeys,
     std::set<const Array *> &replacements, bool coreOnly,
     TopInterpolantStore &concreteStore) const {
   for (StateStore::const_iterator it = store.begin(), ie = store.end();
@@ -78,7 +75,6 @@ void TxStore::getConcreteStore(
 void TxStore::getSymbolicStore(
     const std::vector<llvm::Instruction *> &callHistory,
     const StateStore &store,
-    const std::vector<ref<TxInterpolantAddress> > &orderedStoreKeys,
     std::set<const Array *> &replacements, bool coreOnly,
     TopInterpolantStore &symbolicStore) const {
   for (StateStore::const_iterator it = store.begin(), ie = store.end();
@@ -126,11 +122,9 @@ void TxStore::updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
   if (loc->hasConstantAddress()) {
     concretelyAddressedStore[loc->getInterpolantStyleAddress()] =
         ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
-    concretelyAddressedStoreKeys.push_back(loc->getInterpolantStyleAddress());
   } else {
     symbolicallyAddressedStore[loc->getInterpolantStyleAddress()] =
         ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
-    symbolicallyAddressedStoreKeys.push_back(loc->getInterpolantStyleAddress());
   }
 }
 

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -1,0 +1,158 @@
+//===--- TxStore.h - A view of program memory -------------------*- C++ -*-===//
+//
+//               The Tracer-X KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declarations for the implementations of the shadow
+/// memory to support the dependency computation of memory locations and the
+/// generation of interpolants.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef KLEE_TXSTORE_H
+#define KLEE_TXSTORE_H
+
+#include "klee/Internal/Module/TxValues.h"
+#include "klee/util/Ref.h"
+
+#include <map>
+
+namespace klee {
+
+class TxStore {
+public:
+  typedef std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> >
+  LowerInterpolantStore;
+  typedef std::map<const llvm::Value *, LowerInterpolantStore>
+  TopInterpolantStore;
+  typedef std::map<ref<TxStateAddress>,
+                   std::pair<ref<TxStateValue>, ref<TxStateValue> > >
+  StateStore;
+
+private:
+  /// \brief The mapping of concrete locations to stored value
+  StateStore concretelyAddressedStore;
+
+  /// \brief Ordered keys of the concretely-addressed store.
+  std::vector<ref<TxStateAddress> > concretelyAddressedStoreKeys;
+
+  /// \brief The mapping of symbolic locations to stored value
+  StateStore symbolicallyAddressedStore;
+
+  /// \brief Ordered keys of the symbolically-addressed store.
+  std::vector<ref<TxStateAddress> > symbolicallyAddressedStoreKeys;
+
+  void removeAddressValue(
+      std::map<ref<TxStateAddress>, ref<TxStateValue> > &simpleStore,
+      TopInterpolantStore &concreteStore, std::set<const Array *> &replacements,
+      bool coreOnly) const;
+
+  void
+  getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
+                   const StateStore &store,
+                   const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
+                   std::set<const Array *> &replacements, bool coreOnly,
+                   TopInterpolantStore &concreteStore) const;
+
+  void
+  getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
+                   const StateStore &store,
+                   const std::vector<ref<TxStateAddress> > &orderedStoreKeys,
+                   std::set<const Array *> &replacements, bool coreOnly,
+                   TopInterpolantStore &symbolicStore) const;
+
+public:
+  /// \brief Constructor for an empty store.
+  TxStore() {}
+
+  /// \brief The copy constructor of this class.
+  TxStore(const TxStore &src)
+      : concretelyAddressedStore(src.concretelyAddressedStore),
+        concretelyAddressedStoreKeys(src.concretelyAddressedStoreKeys),
+        symbolicallyAddressedStore(src.symbolicallyAddressedStore),
+        symbolicallyAddressedStoreKeys(src.symbolicallyAddressedStoreKeys) {}
+
+  ~TxStore() {
+    // Delete the locally-constructed relations
+    concretelyAddressedStore.clear();
+    concretelyAddressedStoreKeys.clear();
+    symbolicallyAddressedStore.clear();
+    symbolicallyAddressedStoreKeys.clear();
+  }
+
+  StateStore::iterator concreteFind(ref<TxStateAddress> loc) {
+    return concretelyAddressedStore.find(loc);
+  }
+
+  StateStore::iterator concreteBegin() {
+    return concretelyAddressedStore.begin();
+  }
+
+  StateStore::iterator concreteEnd() { return concretelyAddressedStore.end(); }
+
+  StateStore::iterator symbolicFind(ref<TxStateAddress> loc) {
+    return symbolicallyAddressedStore.find(loc);
+  }
+
+  StateStore::iterator symbolicBegin() {
+    return symbolicallyAddressedStore.begin();
+  }
+
+  StateStore::iterator symbolicEnd() {
+    return symbolicallyAddressedStore.end();
+  }
+
+  /// \brief This retrieves the locations known at this state, and the
+  /// expressions stored in the locations. Returns as the last argument a pair
+  /// of the store part indexed by constants, and the store part indexed by
+  /// symbolic expressions.
+  ///
+  /// \param replacements The replacement bound variables when
+  /// retrieving state for creating subsumption table entry: As the
+  /// resulting expression will be used for storing in the
+  /// subsumption table, the variables need to be replaced with the
+  /// bound ones.
+  /// \param coreOnly Indicate whether we are retrieving only data
+  /// for locations relevant to an unsatisfiability core.
+  void getStoredExpressions(const std::vector<llvm::Instruction *> &callHistory,
+                            std::set<const Array *> &replacements,
+                            bool coreOnly,
+                            TopInterpolantStore &_concretelyAddressedStore,
+                            TopInterpolantStore &_symbolicallyAddressedStore);
+
+  /// \brief Newly relate a location with its stored value, when the value is
+  /// loaded from the location
+  void updateStoreWithLoadedValue(ref<TxStateAddress> loc,
+                                  ref<TxStateValue> address,
+                                  ref<TxStateValue> value);
+
+  /// \brief Newly relate an location with its stored value
+  void updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
+                   ref<TxStateValue> value);
+
+  /// \brief Print the content of the object to the LLVM error stream
+  void dump() const {
+    this->print(llvm::errs());
+    llvm::errs() << "\n";
+  }
+
+  /// \brief Print the content of the object into a stream.
+  ///
+  /// \param stream The stream to print the data to.
+  void print(llvm::raw_ostream &stream) const;
+
+  /// \brief Print the content of the object into a stream.
+  ///
+  /// \param stream The stream to print the data to.
+  /// \param paddingAmount The number of whitespaces to be printed before each
+  /// line.
+  void print(llvm::raw_ostream &stream, const unsigned paddingAmount) const;
+};
+}
+
+#endif

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -75,11 +75,6 @@ private:
   /// \brief Ordered keys of the symbolically-addressed store.
   std::vector<ref<TxInterpolantAddress> > symbolicallyAddressedStoreKeys;
 
-  void removeAddressValue(
-      std::map<ref<TxInterpolantAddress>, ref<TxStateValue> > &simpleStore,
-      TopInterpolantStore &concreteStore, std::set<const Array *> &replacements,
-      bool coreOnly) const;
-
   void getConcreteStore(
       const std::vector<llvm::Instruction *> &callHistory,
       const StateStore &store,

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -78,14 +78,12 @@ private:
   void getConcreteStore(
       const std::vector<llvm::Instruction *> &callHistory,
       const StateStore &store,
-      const std::vector<ref<TxInterpolantAddress> > &orderedStoreKeys,
       std::set<const Array *> &replacements, bool coreOnly,
       TopInterpolantStore &concreteStore) const;
 
   void getSymbolicStore(
       const std::vector<llvm::Instruction *> &callHistory,
       const StateStore &store,
-      const std::vector<ref<TxInterpolantAddress> > &orderedStoreKeys,
       std::set<const Array *> &replacements, bool coreOnly,
       TopInterpolantStore &symbolicStore) const;
 
@@ -96,16 +94,12 @@ public:
   /// \brief The copy constructor of this class.
   TxStore(const TxStore &src)
       : concretelyAddressedStore(src.concretelyAddressedStore),
-        concretelyAddressedStoreKeys(src.concretelyAddressedStoreKeys),
-        symbolicallyAddressedStore(src.symbolicallyAddressedStore),
-        symbolicallyAddressedStoreKeys(src.symbolicallyAddressedStoreKeys) {}
+        symbolicallyAddressedStore(src.symbolicallyAddressedStore) {}
 
   ~TxStore() {
     // Delete the locally-constructed relations
     concretelyAddressedStore.clear();
-    concretelyAddressedStoreKeys.clear();
     symbolicallyAddressedStore.clear();
-    symbolicallyAddressedStoreKeys.clear();
   }
 
   StateStore::iterator concreteFind(ref<TxStateAddress> loc) {

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -749,8 +749,8 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
 
 bool SubsumptionTableEntry::subsumed(
     TimingSolver *solver, ExecutionState &state, double timeout,
-    Dependency::InterpolantStore &concretelyAddressedStore,
-    Dependency::InterpolantStore &symbolicallyAddressedStore,
+    TxStore::TopInterpolantStore &concretelyAddressedStore,
+    TxStore::TopInterpolantStore &symbolicallyAddressedStore,
     int debugSubsumptionLevel) {
 #ifdef ENABLE_Z3
   // Tell the solver implementation that we are checking for subsumption for
@@ -779,15 +779,15 @@ bool SubsumptionTableEntry::subsumed(
     TimerStatIncrementer t(concreteStoreExpressionBuildTime);
 
     // Build constraints from concrete-address interpolant store
-    for (Dependency::InterpolantStore::const_iterator
+    for (TxStore::TopInterpolantStore::const_iterator
              it1 = concreteAddressStore.begin(),
              ie1 = concreteAddressStore.end();
          it1 != ie1; ++it1) {
 
-      const Dependency::InterpolantStoreMap &tabledConcreteMap = it1->second;
-      const Dependency::InterpolantStoreMap &stateConcreteMap =
+      const TxStore::LowerInterpolantStore &tabledConcreteMap = it1->second;
+      const TxStore::LowerInterpolantStore &stateConcreteMap =
           concretelyAddressedStore[it1->first];
-      const Dependency::InterpolantStoreMap &stateSymbolicMap =
+      const TxStore::LowerInterpolantStore &stateSymbolicMap =
           symbolicallyAddressedStore[it1->first];
 
       // If the current state does not constrain the same base, subsumption
@@ -802,7 +802,7 @@ bool SubsumptionTableEntry::subsumed(
         return false;
       }
 
-      for (Dependency::InterpolantStoreMap::const_iterator
+      for (TxStore::LowerInterpolantStore::const_iterator
                it2 = tabledConcreteMap.begin(),
                ie2 = tabledConcreteMap.end();
            it2 != ie2; ++it2) {
@@ -952,7 +952,7 @@ bool SubsumptionTableEntry::subsumed(
           const ref<Expr> tabledConcreteOffset = it2->first->getOffset();
           ref<Expr> conjunction;
 
-          for (Dependency::InterpolantStoreMap::const_iterator
+          for (TxStore::LowerInterpolantStore::const_iterator
                    it3 = stateSymbolicMap.begin(),
                    ie3 = stateSymbolicMap.end();
                it3 != ie3; ++it3) {
@@ -1068,26 +1068,26 @@ bool SubsumptionTableEntry::subsumed(
   {
     TimerStatIncrementer t(symbolicStoreExpressionBuildTime);
     // Build constraints from symbolic-address interpolant store
-    for (Dependency::InterpolantStore::const_iterator
+    for (TxStore::TopInterpolantStore::const_iterator
              it1 = symbolicAddressStore.begin(),
              ie1 = symbolicAddressStore.end();
          it1 != ie1; ++it1) {
-      const Dependency::InterpolantStoreMap &tabledSymbolicMap = it1->second;
-      const Dependency::InterpolantStoreMap &stateConcreteMap =
+      const TxStore::LowerInterpolantStore &tabledSymbolicMap = it1->second;
+      const TxStore::LowerInterpolantStore &stateConcreteMap =
           concretelyAddressedStore[it1->first];
-      const Dependency::InterpolantStoreMap &stateSymbolicMap =
+      const TxStore::LowerInterpolantStore &stateSymbolicMap =
           symbolicallyAddressedStore[it1->first];
 
       ref<Expr> conjunction;
 
-      for (Dependency::InterpolantStoreMap::const_iterator
+      for (TxStore::LowerInterpolantStore::const_iterator
                it2 = tabledSymbolicMap.begin(),
                ie2 = tabledSymbolicMap.end();
            it2 != ie2; ++it2) {
         ref<Expr> tabledSymbolicOffset = it2->first->getOffset();
         ref<TxInterpolantValue> tabledValue = it2->second;
 
-        for (Dependency::InterpolantStoreMap::const_iterator
+        for (TxStore::LowerInterpolantStore::const_iterator
                  it3 = stateConcreteMap.begin(),
                  ie3 = stateConcreteMap.end();
              it3 != ie3; ++it3) {
@@ -1169,7 +1169,7 @@ bool SubsumptionTableEntry::subsumed(
           }
         }
 
-        for (Dependency::InterpolantStoreMap::const_iterator
+        for (TxStore::LowerInterpolantStore::const_iterator
                  it3 = stateSymbolicMap.begin(),
                  ie3 = stateSymbolicMap.end();
              it3 != ie3; ++it3) {
@@ -1585,11 +1585,11 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
 
   if (!concreteAddressStore.empty()) {
     stream << prefix << "concrete store = [\n";
-    for (Dependency::InterpolantStore::const_iterator
+    for (TxStore::TopInterpolantStore::const_iterator
              is1 = concreteAddressStore.begin(),
              ie1 = concreteAddressStore.end(), it1 = is1;
          it1 != ie1; ++it1) {
-      for (Dependency::InterpolantStoreMap::const_iterator
+      for (TxStore::LowerInterpolantStore::const_iterator
                is2 = it1->second.begin(),
                ie2 = it1->second.end(), it2 = is2;
            it2 != ie2; ++it2) {
@@ -1608,11 +1608,11 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
 
   if (!symbolicAddressStore.empty()) {
     stream << prefix << "symbolic store = [\n";
-    for (Dependency::InterpolantStore::const_iterator
+    for (TxStore::TopInterpolantStore::const_iterator
              is1 = symbolicAddressStore.begin(),
              ie1 = symbolicAddressStore.end(), it1 = is1;
          it1 != ie1; ++it1) {
-      for (Dependency::InterpolantStoreMap::const_iterator
+      for (TxStore::LowerInterpolantStore::const_iterator
                is2 = it1->second.begin(),
                ie2 = it1->second.end(), it2 = is2;
            it2 != ie2; ++it2) {
@@ -1839,8 +1839,8 @@ bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
 
   if (iterPair.first != iterPair.second) {
 
-    Dependency::InterpolantStore concretelyAddressedStore;
-    Dependency::InterpolantStore symbolicallyAddressedStore;
+    TxStore::TopInterpolantStore concretelyAddressedStore;
+    TxStore::TopInterpolantStore symbolicallyAddressedStore;
 
     txTreeNode->getStoredExpressions(txTreeNode->entryCallHistory,
                                      concretelyAddressedStore,
@@ -2319,8 +2319,8 @@ void TxTreeNode::bindReturnValue(llvm::CallInst *site, llvm::Instruction *inst,
 
 void TxTreeNode::getStoredExpressions(
     const std::vector<llvm::Instruction *> &_callHistory,
-    Dependency::InterpolantStore &concretelyAddressedStore,
-    Dependency::InterpolantStore &symbolicallyAddressedStore) const {
+    TxStore::TopInterpolantStore &concretelyAddressedStore,
+    TxStore::TopInterpolantStore &symbolicallyAddressedStore) const {
   TimerStatIncrementer t(getStoredExpressionsTime);
   std::set<const Array *> dummyReplacements;
 
@@ -2336,8 +2336,8 @@ void TxTreeNode::getStoredExpressions(
 void TxTreeNode::getStoredCoreExpressions(
     const std::vector<llvm::Instruction *> &_callHistory,
     std::set<const Array *> &replacements,
-    Dependency::InterpolantStore &concretelyAddressedStore,
-    Dependency::InterpolantStore &symbolicallyAddressedStore) const {
+    TxStore::TopInterpolantStore &concretelyAddressedStore,
+    TxStore::TopInterpolantStore &symbolicallyAddressedStore) const {
   TimerStatIncrementer t(getStoredCoreExpressionsTime);
 
   // Since a program point index is a first statement in a basic block,

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2105,21 +2105,8 @@ void TxTree::markPathCondition(ExecutionState &state, TimingSolver *solver,
                                                  unknownExpression, reason);
   }
 
-  PathCondition *pc = currentTxTreeNode->pathCondition;
-
-  if (pc != 0) {
-    for (std::vector<ref<Expr> >::const_iterator it = unsatCore.begin(),
-                                                 ie = unsatCore.end();
-         it != ie; ++it) {
-      for (; pc != 0; pc = pc->cdr()) {
-        if (pc->car().compare(it->get()) == 0) {
-          pc->setAsCore(debugSubsumptionLevel);
-          pc = pc->cdr();
-          break;
-        }
-      }
-    }
-  }
+  // We create path condition marking structure and mark core constraints
+  currentTxTreeNode->unsatCoreInterpolation(unsatCore);
 }
 
 void TxTree::execute(llvm::Instruction *instr) {

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -281,18 +281,18 @@ class SubsumptionTableEntry {
   ///
   /// \return false if there is contradictory equality constraints between state
   /// constraints and query expression, otherwise, return true.
-  static bool detectConflictPrimitives(ExecutionState &state, ref<Expr> query);
+  static bool detectConflictPrimitives(ExecutionState &state, ref<Expr> expr);
 
   /// \brief Get a conjunction of equalities that are top-level conjuncts in the
   /// query.
   ///
   /// \param conjunction The output conjunction of top-level conjuncts in the
   /// query expression.
-  /// \param query The query expression.
+  /// \param expr The query expression.
   /// \return false if there is an equality conjunct that is simplifiable to
   /// false, true otherwise.
-  static bool fetchQueryEqualityConjuncts(std::vector<ref<Expr> > &conjunction,
-                                          ref<Expr> query);
+  static bool fetchExprEqualityConjucts(std::vector<ref<Expr> > &conjunction,
+                                        ref<Expr> expr);
 
   static ref<Expr> simplifyArithmeticBody(ref<Expr> existsExpr,
                                           bool &hasExistentialsOnly);

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -227,9 +227,9 @@ class SubsumptionTableEntry {
 
   ref<Expr> interpolant;
 
-  Dependency::InterpolantStore concreteAddressStore;
+  TxStore::TopInterpolantStore concreteAddressStore;
 
-  Dependency::InterpolantStore symbolicAddressStore;
+  TxStore::TopInterpolantStore symbolicAddressStore;
 
   std::set<const Array *> existentials;
 
@@ -329,8 +329,8 @@ public:
   ~SubsumptionTableEntry();
 
   bool subsumed(TimingSolver *solver, ExecutionState &state, double timeout,
-                Dependency::InterpolantStore &concretelyAddressedStore,
-                Dependency::InterpolantStore &symbolicallyAddressedStore,
+                TxStore::TopInterpolantStore &concretelyAddressedStore,
+                TxStore::TopInterpolantStore &symbolicallyAddressedStore,
                 int debugSubsumptionLevel);
 
   /// Tests if the argument is a variable. A variable here is defined to be
@@ -497,8 +497,8 @@ public:
   /// part indexed by symbolic expressions.
   void getStoredExpressions(
       const std::vector<llvm::Instruction *> &callHistory,
-      Dependency::InterpolantStore &concretelyAddressedStore,
-      Dependency::InterpolantStore &symbolicallyAddressedStore) const;
+      TxStore::TopInterpolantStore &concretelyAddressedStore,
+      TxStore::TopInterpolantStore &symbolicallyAddressedStore) const;
 
   /// \brief This retrieves the allocations known at this state, and the
   /// expressions stored in the allocations, as long as the allocation is
@@ -514,8 +514,8 @@ public:
   void getStoredCoreExpressions(
       const std::vector<llvm::Instruction *> &callHistory,
       std::set<const Array *> &replacements,
-      Dependency::InterpolantStore &concretelyAddressedStore,
-      Dependency::InterpolantStore &symbolicallyAddressedStore) const;
+      TxStore::TopInterpolantStore &concretelyAddressedStore,
+      TxStore::TopInterpolantStore &symbolicallyAddressedStore) const;
 
   void incInstructionsDepth();
 

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -749,7 +749,8 @@ public:
 
   /// \brief Mark the path condition in the Tracer-X tree node associated
   /// with the given KLEE execution state.
-  void markPathCondition(ExecutionState &state, TimingSolver *solver);
+  void markPathCondition(ExecutionState &state, TimingSolver *solver,
+                         std::vector<ref<Expr> > &unsatCore);
 
   /// \brief Creates fresh interpolation data holder for the two given KLEE
   /// execution states.

--- a/lib/Expr/Constraints.cpp
+++ b/lib/Expr/Constraints.cpp
@@ -57,18 +57,34 @@ public:
 
 class ExprReplaceVisitor2 : public ExprVisitor {
 private:
-  const std::map< ref<Expr>, ref<Expr> > &replacements;
+  const std::map<ref<Expr>, std::pair<ref<Expr>, ref<Expr> > > &replacements;
+
+  std::set<ref<Expr> > usedEqualities;
 
 public:
-  ExprReplaceVisitor2(const std::map< ref<Expr>, ref<Expr> > &_replacements) 
-    : ExprVisitor(true),
-      replacements(_replacements) {}
+  ExprReplaceVisitor2(const std::map<
+      ref<Expr>, std::pair<ref<Expr>, ref<Expr> > > &_replacements)
+      : ExprVisitor(true), replacements(_replacements) {}
+
+  void getCore(std::vector<ref<Expr> > constraints,
+               std::vector<ref<Expr> > &core) {
+    core.clear();
+    for (ConstraintManager::iterator it = constraints.begin(),
+                                     itEnd = constraints.end();
+         it != itEnd; ++it) {
+      std::set<ref<Expr> >::iterator finder = usedEqualities.find(*it);
+      if (finder != usedEqualities.end()) {
+        core.push_back(*it);
+      }
+    }
+  }
 
   Action visitExprPost(const Expr &e) {
-    std::map< ref<Expr>, ref<Expr> >::const_iterator it =
-      replacements.find(ref<Expr>(const_cast<Expr*>(&e)));
+    std::map<ref<Expr>, std::pair<ref<Expr>, ref<Expr> > >::const_iterator it =
+        replacements.find(ref<Expr>(const_cast<Expr *>(&e)));
     if (it!=replacements.end()) {
-      return Action::changeTo(it->second);
+      usedEqualities.insert(it->second.second);
+      return Action::changeTo(it->second.first);
     } else {
       return Action::doChildren();
     }
@@ -101,28 +117,38 @@ void ConstraintManager::simplifyForValidConstraint(ref<Expr> e) {
 }
 
 ref<Expr> ConstraintManager::simplifyExpr(ref<Expr> e) const {
+  std::vector<ref<Expr> > simplificationCore;
+  return simplifyExpr(e, simplificationCore);
+}
+
+ref<Expr> ConstraintManager::simplifyExpr(ref<Expr> e,
+                                          std::vector<ref<Expr> > &core) const {
   if (isa<ConstantExpr>(e))
     return e;
 
-  std::map< ref<Expr>, ref<Expr> > equalities;
-  
+  std::map<ref<Expr>, std::pair<ref<Expr>, ref<Expr> > > equalities;
+
   for (ConstraintManager::constraints_ty::const_iterator 
          it = constraints.begin(), ie = constraints.end(); it != ie; ++it) {
     if (const EqExpr *ee = dyn_cast<EqExpr>(*it)) {
       if (isa<ConstantExpr>(ee->left)) {
-        equalities.insert(std::make_pair(ee->right,
-                                         ee->left));
+        equalities.insert(
+            std::make_pair(ee->right, std::make_pair(ee->left, *it)));
       } else {
-        equalities.insert(std::make_pair(*it,
-                                         ConstantExpr::alloc(1, Expr::Bool)));
+        equalities.insert(std::make_pair(
+            *it, std::make_pair(ConstantExpr::alloc(1, Expr::Bool), *it)));
       }
     } else {
-      equalities.insert(std::make_pair(*it,
-                                       ConstantExpr::alloc(1, Expr::Bool)));
+      equalities.insert(std::make_pair(
+          *it, std::make_pair(ConstantExpr::alloc(1, Expr::Bool), *it)));
     }
   }
 
-  return ExprReplaceVisitor2(equalities).visit(e);
+  ExprReplaceVisitor2 visitor(equalities);
+  ref<Expr> ret = visitor.visit(e);
+  visitor.getCore(constraints, core);
+
+  return ret;
 }
 
 void ConstraintManager::addConstraintInternal(ref<Expr> e) {

--- a/lib/Expr/Constraints.cpp
+++ b/lib/Expr/Constraints.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "klee/Constraints.h"
+#include "klee/CommandLine.h"
 
 #include "klee/util/ExprPPrinter.h"
 #include "klee/util/ExprVisitor.h"
@@ -142,7 +143,14 @@ ref<Expr> ConstraintManager::simplifyExpr(ref<Expr> e,
 
   ExprReplaceVisitor2 visitor(equalities);
   ref<Expr> ret = visitor.visit(e);
+#ifdef SUPPORT_Z3
+#ifdef SUPPORT_STP
+  if (SelectSolver == SOLVER_Z3)
+    visitor.getCore(core);
+#else
   visitor.getCore(core);
+#endif
+#endif
   return ret;
 }
 

--- a/lib/Expr/Constraints.cpp
+++ b/lib/Expr/Constraints.cpp
@@ -143,14 +143,8 @@ ref<Expr> ConstraintManager::simplifyExpr(ref<Expr> e,
 
   ExprReplaceVisitor2 visitor(equalities);
   ref<Expr> ret = visitor.visit(e);
-#ifdef SUPPORT_Z3
-#ifdef SUPPORT_STP
-  if (SelectSolver == SOLVER_Z3)
+  if (INTERPOLATION_ENABLED)
     visitor.getCore(core);
-#else
-  visitor.getCore(core);
-#endif
-#endif
   return ret;
 }
 

--- a/lib/Solver/DummySolver.cpp
+++ b/lib/Solver/DummySolver.cpp
@@ -14,31 +14,33 @@
 namespace klee {
 
 class DummySolverImpl : public SolverImpl {
-  std::vector<ref<Expr> > emptyUnsatCore;
-
 public:
   DummySolverImpl();
 
-  bool computeValidity(const Query &, Solver::Validity &result);
-  bool computeTruth(const Query &, bool &isValid);
+  bool computeValidity(const Query &, Solver::Validity &result,
+                       std::vector<ref<Expr> > &unsatCore);
+  bool computeTruth(const Query &, bool &isValid,
+                    std::vector<ref<Expr> > &unsatCore);
   bool computeValue(const Query &, ref<Expr> &result);
   bool computeInitialValues(const Query &,
                             const std::vector<const Array *> &objects,
                             std::vector<std::vector<unsigned char> > &values,
-                            bool &hasSolution);
+                            bool &hasSolution,
+                            std::vector<ref<Expr> > &unsatCore);
   SolverRunStatus getOperationStatusCode();
-  std::vector<ref<Expr> > &getUnsatCore() { return emptyUnsatCore; }
 };
 
 DummySolverImpl::DummySolverImpl() {}
 
-bool DummySolverImpl::computeValidity(const Query &, Solver::Validity &result) {
+bool DummySolverImpl::computeValidity(const Query &, Solver::Validity &result,
+                                      std::vector<ref<Expr> > &unsatCore) {
   ++stats::queries;
   // FIXME: We should have stats::queriesFail;
   return false;
 }
 
-bool DummySolverImpl::computeTruth(const Query &, bool &isValid) {
+bool DummySolverImpl::computeTruth(const Query &, bool &isValid,
+                                   std::vector<ref<Expr> > &unsatCore) {
   ++stats::queries;
   // FIXME: We should have stats::queriesFail;
   return false;
@@ -52,7 +54,8 @@ bool DummySolverImpl::computeValue(const Query &, ref<Expr> &result) {
 
 bool DummySolverImpl::computeInitialValues(
     const Query &, const std::vector<const Array *> &objects,
-    std::vector<std::vector<unsigned char> > &values, bool &hasSolution) {
+    std::vector<std::vector<unsigned char> > &values, bool &hasSolution,
+    std::vector<ref<Expr> > &unsatCore) {
   ++stats::queries;
   ++stats::queryCounterexamples;
   return false;

--- a/lib/Solver/QueryLoggingSolver.cpp
+++ b/lib/Solver/QueryLoggingSolver.cpp
@@ -124,10 +124,11 @@ void QueryLoggingSolver::flushBuffer() {
   flushBufferConditionally(writeToFile);
 }
 
-bool QueryLoggingSolver::computeTruth(const Query &query, bool &isValid) {
+bool QueryLoggingSolver::computeTruth(const Query &query, bool &isValid,
+                                      std::vector<ref<Expr> > &unsatCore) {
   startQuery(query, "Truth");
 
-  bool success = solver->impl->computeTruth(query, isValid);
+  bool success = solver->impl->computeTruth(query, isValid, unsatCore);
 
   finishQuery(success);
 
@@ -143,10 +144,11 @@ bool QueryLoggingSolver::computeTruth(const Query &query, bool &isValid) {
 }
 
 bool QueryLoggingSolver::computeValidity(const Query &query,
-                                         Solver::Validity &result) {
+                                         Solver::Validity &result,
+                                         std::vector<ref<Expr> > &unsatCore) {
   startQuery(query, "Validity");
 
-  bool success = solver->impl->computeValidity(query, result);
+  bool success = solver->impl->computeValidity(query, result, unsatCore);
 
   finishQuery(success);
 
@@ -180,11 +182,12 @@ bool QueryLoggingSolver::computeValue(const Query &query, ref<Expr> &result) {
 
 bool QueryLoggingSolver::computeInitialValues(
     const Query &query, const std::vector<const Array *> &objects,
-    std::vector<std::vector<unsigned char> > &values, bool &hasSolution) {
+    std::vector<std::vector<unsigned char> > &values, bool &hasSolution,
+    std::vector<ref<Expr> > &unsatCore) {
   startQuery(query, "InitialValues", 0, &objects);
 
-  bool success =
-      solver->impl->computeInitialValues(query, objects, values, hasSolution);
+  bool success = solver->impl->computeInitialValues(query, objects, values,
+                                                    hasSolution, unsatCore);
 
   finishQuery(success);
 

--- a/lib/Solver/QueryLoggingSolver.h
+++ b/lib/Solver/QueryLoggingSolver.h
@@ -64,17 +64,19 @@ public:
   virtual ~QueryLoggingSolver();
 
   /// implementation of the SolverImpl interface
-  bool computeTruth(const Query &query, bool &isValid);
-  bool computeValidity(const Query &query, Solver::Validity &result);
+  bool computeTruth(const Query &query, bool &isValid,
+                    std::vector<ref<Expr> > &unsatCore);
+  bool computeValidity(const Query &query, Solver::Validity &result,
+                       std::vector<ref<Expr> > &unsatCore);
   bool computeValue(const Query &query, ref<Expr> &result);
   bool computeInitialValues(const Query &query,
                             const std::vector<const Array *> &objects,
                             std::vector<std::vector<unsigned char> > &values,
-                            bool &hasSolution);
+                            bool &hasSolution,
+                            std::vector<ref<Expr> > &unsatCore);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query &);
   void setCoreSolverTimeout(double timeout);
-  std::vector<ref<Expr> > &getUnsatCore() { return solver->getUnsatCore(); }
 };
 
 #endif /* KLEE_QUERYLOGGINGSOLVER_H */

--- a/lib/Solver/SolverImpl.cpp
+++ b/lib/Solver/SolverImpl.cpp
@@ -14,14 +14,15 @@ using namespace klee;
 
 SolverImpl::~SolverImpl() {}
 
-bool SolverImpl::computeValidity(const Query &query, Solver::Validity &result) {
+bool SolverImpl::computeValidity(const Query &query, Solver::Validity &result,
+                                 std::vector<ref<Expr> > &unsatCore) {
   bool isTrue, isFalse;
-  if (!computeTruth(query, isTrue))
+  if (!computeTruth(query, isTrue, unsatCore))
     return false;
   if (isTrue) {
     result = Solver::True;
   } else {
-    if (!computeTruth(query.negateExpr(), isFalse))
+    if (!computeTruth(query.negateExpr(), isFalse, unsatCore))
       return false;
     result = isFalse ? Solver::False : Solver::Unknown;
   }
@@ -50,5 +51,3 @@ const char *SolverImpl::getOperationStatusString(SolverRunStatus statusCode) {
     return "UNRECOGNIZED OPERATION STATUS";
   }
 }
-
-std::vector<ref<Expr> > &SolverImpl::getUnsatCore() { return emptyUnsatCore; }

--- a/lib/Solver/ValidatingSolver.cpp
+++ b/lib/Solver/ValidatingSolver.cpp
@@ -22,25 +22,28 @@ public:
       : solver(_solver), oracle(_oracle) {}
   ~ValidatingSolver() { delete solver; }
 
-  bool computeValidity(const Query &, Solver::Validity &result);
-  bool computeTruth(const Query &, bool &isValid);
+  bool computeValidity(const Query &, Solver::Validity &result,
+                       std::vector<ref<Expr> > &unsatCore);
+  bool computeTruth(const Query &, bool &isValid,
+                    std::vector<ref<Expr> > &unsatCore);
   bool computeValue(const Query &, ref<Expr> &result);
   bool computeInitialValues(const Query &,
                             const std::vector<const Array *> &objects,
                             std::vector<std::vector<unsigned char> > &values,
-                            bool &hasSolution);
+                            bool &hasSolution,
+                            std::vector<ref<Expr> > &unsatCore);
   SolverRunStatus getOperationStatusCode();
   char *getConstraintLog(const Query &);
   void setCoreSolverTimeout(double timeout);
-  std::vector<ref<Expr> > &getUnsatCore() { return solver->getUnsatCore(); }
 };
 
-bool ValidatingSolver::computeTruth(const Query &query, bool &isValid) {
+bool ValidatingSolver::computeTruth(const Query &query, bool &isValid,
+                                    std::vector<ref<Expr> > &unsatCore) {
   bool answer;
 
-  if (!solver->impl->computeTruth(query, isValid))
+  if (!solver->impl->computeTruth(query, isValid, unsatCore))
     return false;
-  if (!oracle->impl->computeTruth(query, answer))
+  if (!oracle->impl->computeTruth(query, answer, unsatCore))
     return false;
 
   if (isValid != answer)
@@ -50,12 +53,13 @@ bool ValidatingSolver::computeTruth(const Query &query, bool &isValid) {
 }
 
 bool ValidatingSolver::computeValidity(const Query &query,
-                                       Solver::Validity &result) {
+                                       Solver::Validity &result,
+                                       std::vector<ref<Expr> > &unsatCore) {
   Solver::Validity answer;
 
-  if (!solver->impl->computeValidity(query, result))
+  if (!solver->impl->computeValidity(query, result, unsatCore))
     return false;
-  if (!oracle->impl->computeValidity(query, answer))
+  if (!oracle->impl->computeValidity(query, answer, unsatCore))
     return false;
 
   if (result != answer)
@@ -71,8 +75,10 @@ bool ValidatingSolver::computeValue(const Query &query, ref<Expr> &result) {
     return false;
   // We don't want to compare, but just make sure this is a legal
   // solution.
+  std::vector<ref<Expr> > unsatCore;
   if (!oracle->impl->computeTruth(
-           query.withExpr(NeExpr::create(query.expr, result)), answer))
+           query.withExpr(NeExpr::create(query.expr, result)), answer,
+           unsatCore))
     return false;
 
   if (answer)
@@ -83,10 +89,12 @@ bool ValidatingSolver::computeValue(const Query &query, ref<Expr> &result) {
 
 bool ValidatingSolver::computeInitialValues(
     const Query &query, const std::vector<const Array *> &objects,
-    std::vector<std::vector<unsigned char> > &values, bool &hasSolution) {
+    std::vector<std::vector<unsigned char> > &values, bool &hasSolution,
+    std::vector<ref<Expr> > &unsatCore) {
   bool answer;
 
-  if (!solver->impl->computeInitialValues(query, objects, values, hasSolution))
+  if (!solver->impl->computeInitialValues(query, objects, values, hasSolution,
+                                          unsatCore))
     return false;
 
   if (hasSolution) {
@@ -111,12 +119,12 @@ bool ValidatingSolver::computeInitialValues(
          it != ie; ++it)
       constraints = AndExpr::create(constraints, *it);
 
-    if (!oracle->impl->computeTruth(Query(tmp, constraints), answer))
+    if (!oracle->impl->computeTruth(Query(tmp, constraints), answer, unsatCore))
       return false;
     if (!answer)
       assert(0 && "invalid solver result (computeInitialValues)");
   } else {
-    if (!oracle->impl->computeTruth(query, answer))
+    if (!oracle->impl->computeTruth(query, answer, unsatCore))
       return false;
     if (!answer)
       assert(0 && "invalid solver result (computeInitialValues)");

--- a/tools/kleaver/main.cpp
+++ b/tools/kleaver/main.cpp
@@ -266,10 +266,10 @@ static bool EvaluateInputAST(const char *Filename,
         }
       } else {
         std::vector< std::vector<unsigned char> > result;
-        
-        if (S->getInitialValues(Query(ConstraintManager(QC->Constraints), 
-                                      QC->Query),
-                                QC->Objects, result)) {
+        std::vector<ref<Expr> > unsatCore;
+        if (S->getInitialValues(
+                Query(ConstraintManager(QC->Constraints), QC->Query),
+                QC->Objects, result, unsatCore)) {
           llvm::outs() << "INVALID\n";
 
           for (unsigned i = 0, e = result.size(); i != e; ++i) {


### PR DESCRIPTION
@rasoolmaghareh The over-subsumption issue that was mentioned in #260 is technically fixed with this PR. The `Regexp10.c` program of #260 terminates with `wcet` count 34 under bound size 29 and with `wcet` count 36 under bound size 32; so both terminated with memory error reported (using `-special-function-bound-interpolation` and `-exit-on-error` options).

**Please do not merge yet:** @rasoolmaghareh 

This is still a work in progress, as the fixes introduces heavy performance penalties. The next plan is to resolve #265 and then the issue with the simplification mentioned in #28 together in this PR. These are expected to improve performance. For #28, what we want to do is to copy the simplification procedure of KLEE (`ConstraintManager::simplifyExpr`), into a copy that returns an unsat core without calling the solver. The unsat core can be (over-) approximated by the equality contraints that are used to simplify the expression in `simplifyExpr`.

**EDIT** removed references to special commit within this PR.