### PR TITLE
Solver simplification fix

### DIFF
--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -229,8 +229,10 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
     return body;
 
   // We only simplify a conjunction of interpolant and equalities
-  if (!llvm::isa<AndExpr>(body))
+  if (!llvm::isa<AndExpr>(body)) {
+    hasExistentialsOnly = !hasVariableNotInSet(expr->variables, body);
     return existsExpr;
+  }
 
   // The equality constraint is only a single disjunctive clause
   // of a CNF formula. In this case we simplify nothing.

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -224,13 +224,13 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
   // which may contain both normal and shadow variables.
   ref<Expr> body = expr->body;
 
-  // We only simplify a conjunction of interpolant and equalities
-  if (!llvm::isa<AndExpr>(body))
-    return existsExpr;
-
   // If the post-simplified body was a constant, simply return the body;
   if (llvm::isa<ConstantExpr>(body))
     return body;
+
+  // We only simplify a conjunction of interpolant and equalities
+  if (!llvm::isa<AndExpr>(body))
+    return existsExpr;
 
   // The equality constraint is only a single disjunctive clause
   // of a CNF formula. In this case we simplify nothing.


### PR DESCRIPTION
@rasoolmaghareh Some fixes to Tracer-X's own solver. At least as at tracer-x/klee@bbb6f6a1d2b09bf7a32681dc1be909235a9154a5 of #281, this reduces the number of queries with existential quantification, which is observable with `basic/malloc3.c` in `klee-examples`.

**EDIT: Corrected mentioned commit hash**