### PR TITLE
Reimplementation of symbolic heap

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -71,19 +71,6 @@ public:
     return callHistory;
   }
 
-  bool isPrefixOf(const std::vector<llvm::Instruction *> &_callHistory) const {
-    for (std::vector<llvm::Instruction *>::const_iterator
-             it1 = callHistory.begin(),
-             ie1 = callHistory.end(), it2 = _callHistory.begin(),
-             ie2 = _callHistory.end();
-         it1 != ie1; ++it1, ++it2) {
-      if (it2 == ie2 || (*it1) != (*it2)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   int compare(const AllocationContext &other) const {
     if (value == other.value) {
       // Please note the use of reverse iterator here, which improves

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -301,13 +301,13 @@ private:
   /// This constitutes the weakest liberal precondition of the memory checks
   /// against which the offsets of the pointer values of the current state are
   /// to be checked.
-  std::map<ref<AllocationContext>, std::set<ref<Expr> > > allocationBounds;
+  std::map<ref<AllocationInfo>, std::set<ref<Expr> > > allocationBounds;
 
   /// \brief In case the stored value was a pointer, then this should be a
   /// non-empty map mapping of allocation sites to the set of offsets. This is
   /// the offset values of the current state to be checked against the offset
   /// bounds.
-  std::map<ref<AllocationContext>, std::set<ref<Expr> > > allocationOffsets;
+  std::map<ref<AllocationInfo>, std::set<ref<Expr> > > allocationOffsets;
 
   /// \brief The id of this object
   uint64_t id;

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -379,12 +379,15 @@ public:
 
   bool isPointer() const { return !allocationOffsets.empty(); }
 
-  ref<Expr> getBoundsCheck(ref<TxInterpolantValue> svalue,
-                           std::set<ref<Expr> > &bounds,
-                           int debugSubsumptionLevel) const;
+  ref<Expr> getBoundsCheck(
+      ref<TxInterpolantValue> svalue, std::set<ref<Expr> > &bounds,
+      std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
+      int debugSubsumptionLevel) const;
 
-  ref<Expr> getOffsetsCheck(ref<TxInterpolantValue> svalue,
-                            int debugSubsumptionLevel) const;
+  ref<Expr> getOffsetsCheck(
+      ref<TxInterpolantValue> svalue,
+      std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
+      int debugSubsumptionLevel) const;
 
   ref<Expr> getExpression() const { return expr; }
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -42,63 +42,6 @@ class TxStateAddress;
 
 class TxStateValue;
 
-class AllocationInfo {
-public:
-  unsigned refCount;
-
-private:
-  ref<Expr> base;
-
-  uint64_t size;
-
-  AllocationInfo(ref<Expr> _base, uint64_t _size)
-      : refCount(0), base(_base), size(_size) {}
-
-public:
-  ~AllocationInfo() {}
-
-  static ref<AllocationInfo> create(ref<Expr> base, uint64_t size) {
-    return ref<AllocationInfo>(new AllocationInfo(base, size));
-  }
-
-  ref<Expr> getBase() { return base; }
-
-  uint64_t getSize() { return size; }
-
-  /// \brief Translate this allocation info into another.
-  ///
-  /// \param other The other translation info to translate to
-  /// \param table The translation table. This table gets updated if this is a
-  /// new translation.
-  ///
-  /// \return true if the translation was successful, false otherwise.
-  bool
-  translate(ref<AllocationInfo> other,
-            std::map<ref<AllocationInfo>, ref<AllocationInfo> > &table) const;
-
-  int compare(const AllocationInfo &other) const;
-
-  /// \brief Print the content of the object to the LLVM error stream
-  void dump() const {
-    print(llvm::errs());
-    llvm::errs() << "\n";
-  }
-
-  /// \brief Print the content of the object into a stream.
-  ///
-  /// \param stream The stream to print the data to.
-  void print(llvm::raw_ostream &stream) const {
-    std::string emptyString;
-    print(stream, emptyString);
-  }
-
-  /// \brief Print the content of the object into a stream.
-  ///
-  /// \param stream The stream to print the data to.
-  /// \param prefix Padding spaces to print before the actual data.
-  void print(llvm::raw_ostream &stream, const std::string &prefix) const;
-};
-
 class AllocationContext {
 
 public:
@@ -173,6 +116,63 @@ public:
     }
     return 3;
   }
+
+  /// \brief Print the content of the object to the LLVM error stream
+  void dump() const {
+    print(llvm::errs());
+    llvm::errs() << "\n";
+  }
+
+  /// \brief Print the content of the object into a stream.
+  ///
+  /// \param stream The stream to print the data to.
+  void print(llvm::raw_ostream &stream) const {
+    std::string emptyString;
+    print(stream, emptyString);
+  }
+
+  /// \brief Print the content of the object into a stream.
+  ///
+  /// \param stream The stream to print the data to.
+  /// \param prefix Padding spaces to print before the actual data.
+  void print(llvm::raw_ostream &stream, const std::string &prefix) const;
+};
+
+class AllocationInfo {
+public:
+  unsigned refCount;
+
+private:
+  ref<Expr> base;
+
+  uint64_t size;
+
+  AllocationInfo(ref<Expr> _base, uint64_t _size)
+      : refCount(0), base(_base), size(_size) {}
+
+public:
+  ~AllocationInfo() {}
+
+  static ref<AllocationInfo> create(ref<Expr> base, uint64_t size) {
+    return ref<AllocationInfo>(new AllocationInfo(base, size));
+  }
+
+  ref<Expr> getBase() { return base; }
+
+  uint64_t getSize() { return size; }
+
+  /// \brief Translate this allocation info into another.
+  ///
+  /// \param other The other translation info to translate to
+  /// \param table The translation table. This table gets updated if this is a
+  /// new translation.
+  ///
+  /// \return true if the translation was successful, false otherwise.
+  bool
+  translate(ref<AllocationInfo> other,
+            std::map<ref<AllocationInfo>, ref<AllocationInfo> > &table) const;
+
+  int compare(const AllocationInfo &other) const;
 
   /// \brief Print the content of the object to the LLVM error stream
   void dump() const {

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -529,8 +529,6 @@ public:
 
   ref<TxVariable> &getAsVariable() { return variable; }
 
-  llvm::Value *getValue() const { return variable->getValue(); }
-
   int compare(const TxStateAddress &other) const {
     int res = variable->compare(*(other.variable.get()));
     if (res)

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -65,6 +65,17 @@ public:
 
   uint64_t getSize() { return size; }
 
+  /// \brief Translate this allocation info into another.
+  ///
+  /// \param other The other translation info to translate to
+  /// \param table The translation table. This table gets updated if this is a
+  /// new translation.
+  ///
+  /// \return true if the translation was successful, false otherwise.
+  bool
+  translate(ref<AllocationInfo> other,
+            std::map<ref<AllocationInfo>, ref<AllocationInfo> > &table) const;
+
   int compare(const AllocationInfo &other) const;
 
   /// \brief Print the content of the object to the LLVM error stream

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -410,8 +410,8 @@ public:
   unsigned refCount;
 
 private:
-  /// \brief Address for use in interpolants, with less information
-  ref<TxVariable> interpolantStyleAddress;
+  /// \brief This address as a variable, with less information
+  ref<TxVariable> variable;
 
   /// \brief The absolute address
   ref<Expr> address;
@@ -431,8 +431,7 @@ private:
 
   TxStateAddress(ref<AllocationContext> _context, ref<Expr> &_address,
                  ref<Expr> &_base, ref<Expr> &_offset, uint64_t _size)
-      : refCount(0),
-        interpolantStyleAddress(TxVariable::create(_context, _offset)),
+      : refCount(0), variable(TxVariable::create(_context, _offset)),
         concreteOffsetBound(_size), size(_size) {
     bool unknownBase = false;
 
@@ -512,15 +511,12 @@ public:
     return ret;
   }
 
-  ref<TxVariable> &getInterpolantStyleAddress() {
-    return interpolantStyleAddress;
-  }
+  ref<TxVariable> &getInterpolantStyleAddress() { return variable; }
 
-  llvm::Value *getValue() const { return interpolantStyleAddress->getBase(); }
+  llvm::Value *getValue() const { return variable->getBase(); }
 
   int compare(const TxStateAddress &other) const {
-    int res = interpolantStyleAddress->compare(
-        *(other.interpolantStyleAddress.get()));
+    int res = variable->compare(*(other.variable.get()));
     if (res)
       return res;
 
@@ -552,13 +548,11 @@ public:
     return symbolicOffsetBounds;
   }
 
-  ref<AllocationContext> getContext() const {
-    return interpolantStyleAddress->getContext();
-  }
+  ref<AllocationContext> getContext() const { return variable->getContext(); }
 
   uint64_t getConcreteOffsetBound() const { return concreteOffsetBound; }
 
-  ref<Expr> getOffset() const { return interpolantStyleAddress->getOffset(); }
+  ref<Expr> getOffset() const { return variable->getOffset(); }
 
   uint64_t getSize() const { return size; }
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -42,6 +42,52 @@ class TxStateAddress;
 
 class TxStateValue;
 
+class AllocationInfo {
+public:
+  unsigned refCount;
+
+private:
+  ref<Expr> base;
+
+  uint64_t size;
+
+  AllocationInfo(ref<Expr> _base, uint64_t _size)
+      : refCount(0), base(_base), size(_size) {}
+
+public:
+  ~AllocationInfo() {}
+
+  static ref<AllocationInfo> create(ref<Expr> base, uint64_t size) {
+    return ref<AllocationInfo>(new AllocationInfo(base, size));
+  }
+
+  ref<Expr> getBase() { return base; }
+
+  uint64_t getSize() { return size; }
+
+  int compare(const AllocationInfo &other) const;
+
+  /// \brief Print the content of the object to the LLVM error stream
+  void dump() const {
+    print(llvm::errs());
+    llvm::errs() << "\n";
+  }
+
+  /// \brief Print the content of the object into a stream.
+  ///
+  /// \param stream The stream to print the data to.
+  void print(llvm::raw_ostream &stream) const {
+    std::string emptyString;
+    print(stream, emptyString);
+  }
+
+  /// \brief Print the content of the object into a stream.
+  ///
+  /// \param stream The stream to print the data to.
+  /// \param prefix Padding spaces to print before the actual data.
+  void print(llvm::raw_ostream &stream, const std::string &prefix) const;
+};
+
 class AllocationContext {
 
 public:

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -390,7 +390,7 @@ public:
     return 1;
   }
 
-  bool useBound() { return !doNotUseBound; }
+  bool useBound() const { return !doNotUseBound; }
 
   bool isPointer() const { return !allocationOffsets.empty(); }
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -143,19 +143,25 @@ public:
   unsigned refCount;
 
 private:
+  ref<AllocationContext> context;
+
   ref<Expr> base;
 
   uint64_t size;
 
-  AllocationInfo(ref<Expr> _base, uint64_t _size)
-      : refCount(0), base(_base), size(_size) {}
+  AllocationInfo(ref<AllocationContext> &_context, ref<Expr> _base,
+                 uint64_t _size)
+      : refCount(0), context(_context), base(_base), size(_size) {}
 
 public:
   ~AllocationInfo() {}
 
-  static ref<AllocationInfo> create(ref<Expr> base, uint64_t size) {
-    return ref<AllocationInfo>(new AllocationInfo(base, size));
+  static ref<AllocationInfo> create(ref<AllocationContext> &context,
+                                    ref<Expr> base, uint64_t size) {
+    return ref<AllocationInfo>(new AllocationInfo(context, base, size));
   }
+
+  ref<AllocationContext> getContext() { return context; }
 
   ref<Expr> getBase() { return base; }
 
@@ -471,10 +477,10 @@ private:
     }
 
     if (_base->getWidth() < pointerWidth) {
-      allocInfo =
-          AllocationInfo::create(ZExtExpr::create(_base, pointerWidth), _size);
+      allocInfo = AllocationInfo::create(
+          _context, ZExtExpr::create(_base, pointerWidth), _size);
     } else {
-      allocInfo = AllocationInfo::create(_base, _size);
+      allocInfo = AllocationInfo::create(_context, _base, _size);
     }
 
     if (unknownBase) {
@@ -484,8 +490,8 @@ private:
       } else {
         tmpOffset = _offset;
       }
-      allocInfo =
-          AllocationInfo::create(SubExpr::create(address, tmpOffset), _size);
+      allocInfo = AllocationInfo::create(
+          _context, SubExpr::create(address, tmpOffset), _size);
     }
   }
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -511,7 +511,7 @@ public:
     return ret;
   }
 
-  ref<TxVariable> &getInterpolantStyleAddress() { return variable; }
+  ref<TxVariable> &getAsVariable() { return variable; }
 
   llvm::Value *getValue() const { return variable->getBase(); }
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -262,11 +262,6 @@ public:
 
   ref<Expr> getOffset() const { return offset; }
 
-  bool
-  contextIsPrefixOf(const std::vector<llvm::Instruction *> &callHistory) const {
-    return getContext()->isPrefixOf(callHistory);
-  }
-
   /// \brief The comparator of this class' objects. This member function checks
   /// for the equality of TxInterpolantAddress#indirectionCount member variables
   /// to

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -553,6 +553,8 @@ public:
 
   ref<AllocationContext> getContext() const { return variable->getContext(); }
 
+  ref<AllocationInfo> getAllocationInfo() const { return allocInfo; }
+
   uint64_t getConcreteOffsetBound() const { return concreteOffsetBound; }
 
   ref<Expr> getOffset() const { return variable->getOffset(); }

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -252,7 +252,9 @@ public:
     return ret;
   }
 
-  llvm::Value *getBase() const { return allocInfo->getContext()->getValue(); }
+  llvm::Value *getValue() const { return allocInfo->getContext()->getValue(); }
+
+  ref<Expr> getBase() const { return allocInfo->getBase(); }
 
   ref<AllocationContext> getContext() const { return allocInfo->getContext(); }
 
@@ -532,7 +534,7 @@ public:
 
   ref<TxVariable> &getAsVariable() { return variable; }
 
-  llvm::Value *getValue() const { return variable->getBase(); }
+  llvm::Value *getValue() const { return variable->getValue(); }
 
   int compare(const TxStateAddress &other) const {
     int res = variable->compare(*(other.variable.get()));

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1632,7 +1632,7 @@ void Dependency::print(llvm::raw_ostream &stream,
   store->print(stream, paddingAmount);
 
   if (parent) {
-    stream << tabs << "--------- Parent Dependencies ----------\n";
+    stream << tabs << "\n--------- Parent Dependencies ----------\n";
     parent->print(stream, paddingAmount);
   }
 }

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -736,7 +736,7 @@ void Dependency::execute(llvm::Instruction *instr,
           ref<TxStateAddress> loc = *(locations.begin());
 
           // Check the possible mismatch between Tracer-X and KLEE loaded value
-          TxStore::StateStore::iterator storeIt = store.concreteFind(loc);
+          TxStore::LowerStateStore::iterator storeIt = store.concreteFind(loc);
           ref<TxStoreEntry> target;
 
           if (storeIt == store.concreteEnd()) {
@@ -822,7 +822,7 @@ void Dependency::execute(llvm::Instruction *instr,
            li != le; ++li) {
         ref<TxStoreEntry> addressValuePair;
 
-        TxStore::StateStore::iterator storeIter;
+        TxStore::LowerStateStore::iterator storeIter;
         if ((*li)->hasConstantAddress()) {
           storeIter = store.concreteFind(*li);
           if (storeIter != store.concreteEnd()) {

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -348,23 +348,39 @@ namespace klee {
     /// of the store part indexed by constants, and the store part indexed by
     /// symbolic expressions.
     ///
+    /// \param callHistory The current call history context of the state
     /// \param replacements The replacement bound variables when
     /// retrieving state for creating subsumption table entry: As the
     /// resulting expression will be used for storing in the
     /// subsumption table, the variables need to be replaced with the
     /// bound ones.
-    /// \param coreOnly Indicate whether we are retrieving only data
+    /// \param coreOnly Indicates whether we are retrieving only data
     /// for locations relevant to an unsatisfiability core.
+    /// \param [out] concretelyAddressedStore The output concretely-addressed
+    /// store.
+    /// \param [out] symbolicallyAddressedStore The output
+    /// symbolically-addressed store.
+    /// \param [out] concretelyAddressedHistoricalStore The output
+    /// concretely-addressed historical store, whose domain consists of
+    /// historical concrete addresses that are no longer valid due to exiting of
+    /// scope.
+    /// \param [out] symbolicallyAddressedHistoricalStore The output
+    /// symbolically-addressed historical store, whose domain consists of
+    /// historical symbolic addresses that are no longer valid due to exiting of
+    /// scope.
     ///
     /// \sa TxStore#getStoredExpressions()
     void getStoredExpressions(
         const std::vector<llvm::Instruction *> &callHistory,
         std::set<const Array *> &replacements, bool coreOnly,
         TxStore::TopInterpolantStore &concretelyAddressedStore,
-        TxStore::TopInterpolantStore &symbolicallyAddressedStore) {
-      store.getStoredExpressions(callHistory, replacements, coreOnly,
-                                 concretelyAddressedStore,
-                                 symbolicallyAddressedStore);
+        TxStore::TopInterpolantStore &symbolicallyAddressedStore,
+        TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
+        TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
+      store.getStoredExpressions(
+          callHistory, replacements, coreOnly, concretelyAddressedStore,
+          symbolicallyAddressedStore, concretelyAddressedHistoricalStore,
+          symbolicallyAddressedHistoricalStore);
     }
 
     ref<TxStateValue>

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -167,7 +167,7 @@ namespace klee {
 
   private:
     /// The store
-    TxStore store;
+    TxStore *store;
 
     /// \brief Previous path condition
     Dependency *parent;
@@ -377,7 +377,7 @@ namespace klee {
         TxStore::TopInterpolantStore &symbolicallyAddressedStore,
         TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
         TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
-      store.getStoredExpressions(
+      store->getStoredExpressions(
           callHistory, replacements, coreOnly, concretelyAddressedStore,
           symbolicallyAddressedStore, concretelyAddressedHistoricalStore,
           symbolicallyAddressedHistoricalStore);

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -93,9 +93,8 @@ void TxStore::getSymbolicStore(
           symbolicStore[it->first->getContext()->getValue()];
 #ifdef ENABLE_Z3
       if (!NoExistential) {
-        ref<TxVariable> address =
-            TxStateAddress::create(it->second->getAddress(), replacements)
-                ->getInterpolantStyleAddress();
+        ref<TxVariable> address = TxStateAddress::create(
+            it->second->getAddress(), replacements)->getAsVariable();
         map[address] =
             it->second->getContent()->getInterpolantStyleValue(replacements);
       } else {
@@ -121,10 +120,10 @@ void TxStore::updateStoreWithLoadedValue(ref<TxStateAddress> loc,
 void TxStore::updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
                           ref<TxStateValue> value) {
   if (loc->hasConstantAddress()) {
-    concretelyAddressedStore[loc->getInterpolantStyleAddress()] =
+    concretelyAddressedStore[loc->getAsVariable()] =
         ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
   } else {
-    symbolicallyAddressedStore[loc->getInterpolantStyleAddress()] =
+    symbolicallyAddressedStore[loc->getAsVariable()] =
         ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
   }
 }

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -284,7 +284,8 @@ void TxStore::updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
 
   MiddleStateStore newMiddleStateStore(loc->getAllocationInfo());
   store[loc->getContext()] = newMiddleStateStore;
-  newMiddleStateStore.updateStore(loc, address, value);
+  MiddleStateStore &middleStateStore = store[loc->getContext()];
+  middleStateStore.updateStore(loc, address, value);
 }
 
 /// \brief Print the content of the object to the LLVM error stream

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -23,6 +23,38 @@ using namespace klee;
 
 namespace klee {
 
+ref<TxStoreEntry> TxStore::find(ref<TxStateAddress> loc) const {
+  ref<TxStoreEntry> ret;
+
+  if (loc->hasConstantAddress()) {
+    TopStateStore::const_iterator storeIter =
+        concretelyAddressedStore.find(loc->getContext());
+    if (storeIter != concretelyAddressedStore.end() &&
+        !storeIter->second.empty()) {
+      const TxStore::LowerStateStore &lowerStore = storeIter->second;
+      TxStore::LowerStateStore::const_iterator lowerStoreIter =
+          lowerStore.find(loc->getAsVariable());
+      if (lowerStoreIter != lowerStore.end()) {
+        ret = lowerStoreIter->second;
+      }
+    }
+  } else {
+    TopStateStore::const_iterator storeIter =
+        symbolicallyAddressedStore.find(loc->getContext());
+    if (storeIter != symbolicallyAddressedStore.end() &&
+        !storeIter->second.empty()) {
+      const TxStore::LowerStateStore &lowerStore = storeIter->second;
+      TxStore::LowerStateStore::const_iterator lowerStoreIter =
+          lowerStore.find(loc->getAsVariable());
+      if (lowerStoreIter != lowerStore.end()) {
+        ret = lowerStoreIter->second;
+      }
+    }
+  }
+
+  return ret;
+}
+
 void TxStore::getStoredExpressions(
     const std::vector<llvm::Instruction *> &callHistory,
     std::set<const Array *> &replacements, bool coreOnly,

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -173,9 +173,6 @@ void TxStore::getConcreteStore(
   for (LowerStateStore::const_iterator it = historicalStore.begin(),
                                        ie = historicalStore.end();
        it != ie; ++it) {
-    if (!it->first->contextIsPrefixOf(callHistory))
-      continue;
-
     concreteToInterpolant(it->first, it->second, replacements, coreOnly,
                           concretelyAddressedHistoricalStore);
   }
@@ -208,9 +205,6 @@ void TxStore::getSymbolicStore(
   for (LowerStateStore::const_iterator it = historicalStore.begin(),
                                        ie = historicalStore.end();
        it != ie; ++it) {
-    if (!it->first->contextIsPrefixOf(callHistory))
-      continue;
-
     symbolicToInterpolant(it->first, it->second, replacements, coreOnly,
                           symbolicallyAddressedHistoricalStore);
   }

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -170,16 +170,33 @@ void TxStore::getConcreteStore(
     if (!it->first->isPrefixOf(callHistory))
       continue;
 
-    LowerInterpolantStore &map =
-        concretelyAddressedStore[it->first->getValue()];
+    TopInterpolantStore::iterator storeIter =
+        concretelyAddressedStore.find(it->first->getValue());
 
     const MiddleStateStore &middleStore = it->second;
 
-    for (LowerStateStore::const_iterator it1 = middleStore.concreteBegin(),
-                                         ie1 = middleStore.concreteEnd();
-         it1 != ie1; ++it1) {
-      concreteToInterpolant(it1->first, it1->second, replacements, coreOnly,
-                            map);
+    if (storeIter == concretelyAddressedStore.end()) {
+      LowerInterpolantStore map;
+
+      for (LowerStateStore::const_iterator it1 = middleStore.concreteBegin(),
+                                           ie1 = middleStore.concreteEnd();
+           it1 != ie1; ++it1) {
+        concreteToInterpolant(it1->first, it1->second, replacements, coreOnly,
+                              map);
+      }
+
+      // The map is only added when it is not empty; this is to avoid entries
+      // mapped to empty structure in concretelyAddressedStore
+      if (!map.empty()) {
+        concretelyAddressedStore[it->first->getValue()] = map;
+      }
+    } else {
+      for (LowerStateStore::const_iterator it1 = middleStore.concreteBegin(),
+                                           ie1 = middleStore.concreteEnd();
+           it1 != ie1; ++it1) {
+        concreteToInterpolant(it1->first, it1->second, replacements, coreOnly,
+                              storeIter->second);
+      }
     }
   }
 
@@ -202,16 +219,33 @@ void TxStore::getSymbolicStore(
     if (!it->first->isPrefixOf(callHistory))
       continue;
 
-    LowerInterpolantStore &map =
-        symbolicallyAddressedStore[it->first->getValue()];
+    TopInterpolantStore::iterator storeIter =
+        symbolicallyAddressedStore.find(it->first->getValue());
 
     const MiddleStateStore &middleStore = it->second;
 
-    for (LowerStateStore::const_iterator it1 = middleStore.symbolicBegin(),
-                                         ie1 = middleStore.symbolicEnd();
-         it1 != ie1; ++it1) {
-      symbolicToInterpolant(it1->first, it1->second, replacements, coreOnly,
-                            map);
+    if (storeIter == symbolicallyAddressedStore.end()) {
+      LowerInterpolantStore map;
+
+      for (LowerStateStore::const_iterator it1 = middleStore.symbolicBegin(),
+                                           ie1 = middleStore.symbolicEnd();
+           it1 != ie1; ++it1) {
+        symbolicToInterpolant(it1->first, it1->second, replacements, coreOnly,
+                              map);
+      }
+
+      // The map is only added when it is not empty; this is to avoid entries
+      // mapped to empty structure in symbolicallyAddressedStore
+      if (!map.empty()) {
+        symbolicallyAddressedStore[it->first->getValue()] = map;
+      }
+    } else {
+      for (LowerStateStore::const_iterator it1 = middleStore.symbolicBegin(),
+                                           ie1 = middleStore.symbolicEnd();
+           it1 != ie1; ++it1) {
+        symbolicToInterpolant(it1->first, it1->second, replacements, coreOnly,
+                              storeIter->second);
+      }
     }
   }
 

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -34,12 +34,12 @@ void TxStore::getStoredExpressions(
                    coreOnly, _symbolicallyAddressedStore);
 }
 
-void TxStore::getConcreteStore(
-    const std::vector<llvm::Instruction *> &callHistory,
-    const StateStore &store,
-    std::set<const Array *> &replacements, bool coreOnly,
-    TopInterpolantStore &concreteStore) const {
-  for (StateStore::const_iterator it = store.begin(), ie = store.end();
+void
+TxStore::getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
+                          const LowerStateStore &store,
+                          std::set<const Array *> &replacements, bool coreOnly,
+                          TopInterpolantStore &concreteStore) const {
+  for (LowerStateStore::const_iterator it = store.begin(), ie = store.end();
        it != ie; ++it) {
     if (!it->first->contextIsPrefixOf(callHistory))
       continue;
@@ -70,12 +70,12 @@ void TxStore::getConcreteStore(
   }
 }
 
-void TxStore::getSymbolicStore(
-    const std::vector<llvm::Instruction *> &callHistory,
-    const StateStore &store,
-    std::set<const Array *> &replacements, bool coreOnly,
-    TopInterpolantStore &symbolicStore) const {
-  for (StateStore::const_iterator it = store.begin(), ie = store.end();
+void
+TxStore::getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
+                          const LowerStateStore &store,
+                          std::set<const Array *> &replacements, bool coreOnly,
+                          TopInterpolantStore &symbolicStore) const {
+  for (LowerStateStore::const_iterator it = store.begin(), ie = store.end();
        it != ie; ++it) {
     if (!it->first->contextIsPrefixOf(callHistory))
       continue;
@@ -141,9 +141,9 @@ void TxStore::print(llvm::raw_ostream &stream,
     stream << tabs << "concrete store = []\n";
   } else {
     stream << tabs << "concrete store = [\n";
-    for (StateStore::const_iterator is = concretelyAddressedStore.begin(),
-                                    ie = concretelyAddressedStore.end(),
-                                    it = is;
+    for (LowerStateStore::const_iterator is = concretelyAddressedStore.begin(),
+                                         ie = concretelyAddressedStore.end(),
+                                         it = is;
          it != ie; ++it) {
       if (it != is)
         stream << tabsNext << "------------------------------------------\n";
@@ -161,9 +161,9 @@ void TxStore::print(llvm::raw_ostream &stream,
     stream << tabs << "symbolic store = []\n";
   } else {
     stream << tabs << "symbolic store = [\n";
-    for (StateStore::const_iterator is = symbolicallyAddressedStore.begin(),
-                                    ie = symbolicallyAddressedStore.end(),
-                                    it = is;
+    for (LowerStateStore::const_iterator
+             is = symbolicallyAddressedStore.begin(),
+             ie = symbolicallyAddressedStore.end(), it = is;
          it != ie; ++it) {
       if (it != is)
         stream << tabsNext << "------------------------------------------\n";

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -23,6 +23,56 @@ using namespace klee;
 
 namespace klee {
 
+void TxStore::MiddleStateStore::print(llvm::raw_ostream &stream,
+                                      const std::string &prefix) const {
+  std::string tabsNext = appendTab(prefix);
+  std::string tabsNextNext = appendTab(tabsNext);
+
+  allocInfo->print(stream, prefix);
+  stream << ":\n";
+  if (concretelyAddressedStore.empty()) {
+    stream << prefix << "concretely-addressed store = []\n";
+  } else {
+    stream << prefix << "concretely-addressed store = [\n";
+    for (LowerStateStore::const_iterator
+             lowerIs = concretelyAddressedStore.begin(),
+             lowerIe = concretelyAddressedStore.end(), lowerIt = lowerIs;
+         lowerIt != lowerIe; ++lowerIt) {
+      if (lowerIt != lowerIs)
+        stream << tabsNext << "------------------------------------------\n";
+      stream << tabsNext << "address:\n";
+      lowerIt->second->getAddress()->print(stream, tabsNextNext);
+      stream << "\n";
+      stream << tabsNext << "content:\n";
+      lowerIt->second->getContent()->print(stream, tabsNextNext);
+      stream << "\n";
+    }
+    stream << prefix << "]\n";
+  }
+
+  if (symbolicallyAddressedStore.empty()) {
+    stream << prefix << "symbolically-addressed store = []";
+  } else {
+    stream << prefix << "symbolically-addressed store = [\n";
+    for (LowerStateStore::const_iterator
+             lowerIs = symbolicallyAddressedStore.begin(),
+             lowerIe = symbolicallyAddressedStore.end(), lowerIt = lowerIs;
+         lowerIt != lowerIe; ++lowerIt) {
+      if (lowerIt != lowerIs)
+        stream << tabsNext << "------------------------------------------\n";
+      stream << tabsNext << "address:\n";
+      lowerIt->second->getAddress()->print(stream, tabsNextNext);
+      stream << "\n";
+      stream << tabsNext << "content:\n";
+      lowerIt->second->getContent()->print(stream, tabsNextNext);
+      stream << "\n";
+    }
+    stream << prefix << "]";
+  }
+}
+
+/**/
+
 ref<TxStoreEntry> TxStore::find(ref<TxStateAddress> loc) const {
   ref<TxStoreEntry> ret;
 

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -88,10 +88,10 @@ void TxStore::getStoredExpressions(
     std::set<const Array *> &replacements, bool coreOnly,
     TopInterpolantStore &_concretelyAddressedStore,
     TopInterpolantStore &_symbolicallyAddressedStore) {
-  getConcreteStore(callHistory, store, concreteHistoricalStore, replacements,
-                   coreOnly, _concretelyAddressedStore);
-  getSymbolicStore(callHistory, store, symbolicHistoricalStore, replacements,
-                   coreOnly, _symbolicallyAddressedStore);
+  getConcreteStore(callHistory, store, concretelyAddressedHistoricalStore,
+                   replacements, coreOnly, _concretelyAddressedStore);
+  getSymbolicStore(callHistory, store, symbolicallyAddressedHistoricalStore,
+                   replacements, coreOnly, _symbolicallyAddressedStore);
 }
 
 inline void
@@ -147,13 +147,14 @@ TxStore::getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
                           const TopStateStore &store,
                           const LowerStateStore &historicalStore,
                           std::set<const Array *> &replacements, bool coreOnly,
-                          TopInterpolantStore &concreteStore) {
+                          TopInterpolantStore &concretelyAddressedStore) {
   for (TopStateStore::const_iterator it = store.begin(), ie = store.end();
        it != ie; ++it) {
     if (!it->first->isPrefixOf(callHistory))
       continue;
 
-    LowerInterpolantStore &map = concreteStore[it->first->getValue()];
+    LowerInterpolantStore &map =
+        concretelyAddressedStore[it->first->getValue()];
 
     ref<MiddleStateStore> middleStore = it->second;
 
@@ -171,7 +172,8 @@ TxStore::getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
     if (!it->first->contextIsPrefixOf(callHistory))
       continue;
 
-    LowerInterpolantStore &map = concreteStore[it->first->getValue()];
+    LowerInterpolantStore &map =
+        concretelyAddressedStore[it->first->getValue()];
 
     concreteToInterpolant(it->first, it->second, replacements, coreOnly, map);
   }
@@ -182,13 +184,14 @@ TxStore::getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
                           const TopStateStore &store,
                           const LowerStateStore &historicalStore,
                           std::set<const Array *> &replacements, bool coreOnly,
-                          TopInterpolantStore &symbolicStore) {
+                          TopInterpolantStore &symbolicallyAddressedStore) {
   for (TopStateStore::const_iterator it = store.begin(), ie = store.end();
        it != ie; ++it) {
     if (!it->first->isPrefixOf(callHistory))
       continue;
 
-    LowerInterpolantStore &map = symbolicStore[it->first->getValue()];
+    LowerInterpolantStore &map =
+        symbolicallyAddressedStore[it->first->getValue()];
 
     ref<MiddleStateStore> middleStore = it->second;
 
@@ -206,7 +209,8 @@ TxStore::getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
     if (!it->first->contextIsPrefixOf(callHistory))
       continue;
 
-    LowerInterpolantStore &map = symbolicStore[it->first->getValue()];
+    LowerInterpolantStore &map =
+        symbolicallyAddressedStore[it->first->getValue()];
 
     symbolicToInterpolant(it->first, it->second, replacements, coreOnly, map);
   }
@@ -231,10 +235,10 @@ void TxStore::updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
     }
 
     // Here we save the old store
-    concreteHistoricalStore.insert(middleStore->concreteBegin(),
-                                   middleStore->concreteEnd());
-    symbolicHistoricalStore.insert(middleStore->symbolicBegin(),
-                                   middleStore->symbolicEnd());
+    concretelyAddressedHistoricalStore.insert(middleStore->concreteBegin(),
+                                              middleStore->concreteEnd());
+    symbolicallyAddressedHistoricalStore.insert(middleStore->symbolicBegin(),
+                                                middleStore->symbolicEnd());
   }
 
   ref<MiddleStateStore> newMiddleStateStore =

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -205,9 +205,6 @@ void TxStore::getConcreteStore(
     LowerInterpolantStore &concretelyAddressedHistoricalStore) {
   for (TopStateStore::const_iterator it = store.begin(), ie = store.end();
        it != ie; ++it) {
-    if (!it->first->isPrefixOf(callHistory))
-      continue;
-
     TopInterpolantStore::iterator storeIter =
         concretelyAddressedStore.find(it->first);
 
@@ -254,9 +251,6 @@ void TxStore::getSymbolicStore(
     LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
   for (TopStateStore::const_iterator it = store.begin(), ie = store.end();
        it != ie; ++it) {
-    if (!it->first->isPrefixOf(callHistory))
-      continue;
-
     TopInterpolantStore::iterator storeIter =
         symbolicallyAddressedStore.find(it->first);
 

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -23,6 +23,19 @@ using namespace klee;
 
 namespace klee {
 
+void TxStoreEntry::print(llvm::raw_ostream &stream,
+                         const std::string &prefix) const {
+  std::string tabsNext = appendTab(prefix);
+
+  stream << prefix << "address:\n";
+  address->print(stream, tabsNext);
+  stream << "\n";
+  stream << prefix << "content:\n";
+  content->print(stream, tabsNext);
+}
+
+/**/
+
 void TxStore::MiddleStateStore::print(llvm::raw_ostream &stream,
                                       const std::string &prefix) const {
   std::string tabsNext = appendTab(prefix);

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -262,10 +262,9 @@ void TxStore::print(llvm::raw_ostream &stream,
   std::string tabsNext = appendTab(tabs);
   std::string tabsNextNext = appendTab(tabsNext);
 
-  if (store.empty()) {
-    stream << tabs << "store = []\n";
-  } else {
-    stream << tabs << "store = [\n";
+  stream << tabs << "store = [";
+  if (!store.empty()) {
+    stream << "\n";
     for (TopStateStore::const_iterator topIs = store.begin(),
                                        topIe = store.end(), topIt = topIs;
          topIt != topIe; ++topIt) {
@@ -273,7 +272,40 @@ void TxStore::print(llvm::raw_ostream &stream,
       stream << ":\n";
       topIt->second.print(stream, tabsNextNext);
     }
-    stream << tabs << "]\n";
+    stream << tabs;
   }
+  stream << "]";
+
+  stream << "\n" << tabs << "concretely-addressed historical store = [";
+  if (!concretelyAddressedHistoricalStore.empty()) {
+    stream << "\n";
+    for (TxStore::LowerStateStore::const_iterator
+             is1 = concretelyAddressedHistoricalStore.begin(),
+             ie1 = concretelyAddressedHistoricalStore.end(), it1 = is1;
+         it1 != ie1; ++it1) {
+      if (it1 != is1)
+        stream << tabsNext << "------------------------------------------\n";
+      it1->second->print(stream, tabsNext);
+      stream << "\n";
+    }
+    stream << tabs;
+  }
+  stream << "]";
+
+  stream << "\n" << tabs << "symbolically-addressed historical store = [";
+  if (!symbolicallyAddressedHistoricalStore.empty()) {
+    stream << "\n";
+    for (TxStore::LowerStateStore::const_iterator
+             is1 = symbolicallyAddressedHistoricalStore.begin(),
+             ie1 = symbolicallyAddressedHistoricalStore.end(), it1 = is1;
+         it1 != ie1; ++it1) {
+      if (it1 != is1)
+        stream << tabsNext << "------------------------------------------\n";
+      it1->second->print(stream, tabsNext);
+      stream << "\n";
+    }
+    stream << tabs;
+  }
+  stream << "]";
 }
 }

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -93,7 +93,7 @@ void TxStore::getSymbolicStore(
           symbolicStore[it->first->getContext()->getValue()];
 #ifdef ENABLE_Z3
       if (!NoExistential) {
-        ref<TxInterpolantAddress> address =
+        ref<TxVariable> address =
             TxStateAddress::create(it->second->getAddress(), replacements)
                 ->getInterpolantStyleAddress();
         map[address] =

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -36,6 +36,44 @@ void TxStoreEntry::print(llvm::raw_ostream &stream,
 
 /**/
 
+ref<TxStoreEntry>
+TxStore::MiddleStateStore::find(ref<TxStateAddress> loc) const {
+  ref<TxStoreEntry> ret;
+
+  if (loc->hasConstantAddress()) {
+    TxStore::LowerStateStore::const_iterator lowerStoreIter =
+        concretelyAddressedStore.find(loc->getAsVariable());
+
+    if (lowerStoreIter != concretelyAddressedStore.end()) {
+      ret = lowerStoreIter->second;
+    }
+  } else {
+    TxStore::LowerStateStore::const_iterator lowerStoreIter =
+        symbolicallyAddressedStore.find(loc->getAsVariable());
+    if (lowerStoreIter != symbolicallyAddressedStore.end()) {
+      ret = lowerStoreIter->second;
+    }
+  }
+
+  return ret;
+}
+
+bool TxStore::MiddleStateStore::updateStore(ref<TxStateAddress> loc,
+                                            ref<TxStateValue> address,
+                                            ref<TxStateValue> value) {
+  if (loc->getAllocationInfo() != allocInfo)
+    return false;
+
+  if (loc->hasConstantAddress()) {
+    concretelyAddressedStore[loc->getAsVariable()] =
+        ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
+  } else {
+    symbolicallyAddressedStore[loc->getAsVariable()] =
+        ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
+  }
+  return true;
+}
+
 void TxStore::MiddleStateStore::print(llvm::raw_ostream &stream,
                                       const std::string &prefix) const {
   std::string tabsNext = appendTab(prefix);

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -70,7 +70,7 @@ void
 TxStore::getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
                           const TopStateStore &store,
                           std::set<const Array *> &replacements, bool coreOnly,
-                          TopInterpolantStore &concreteStore) const {
+                          TopInterpolantStore &concreteStore) {
   for (TopStateStore::const_iterator it = store.begin(), ie = store.end();
        it != ie; ++it) {
     if (!it->first->isPrefixOf(callHistory))
@@ -109,7 +109,7 @@ void
 TxStore::getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
                           const TopStateStore &store,
                           std::set<const Array *> &replacements, bool coreOnly,
-                          TopInterpolantStore &symbolicStore) const {
+                          TopInterpolantStore &symbolicStore) {
   for (TopStateStore::const_iterator it = store.begin(), ie = store.end();
        it != ie; ++it) {
     if (!it->first->isPrefixOf(callHistory))

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -42,11 +42,10 @@ void TxStore::MiddleStateStore::print(llvm::raw_ostream &stream,
   std::string tabsNextNext = appendTab(tabsNext);
 
   allocInfo->print(stream, prefix);
-  stream << ":\n";
-  if (concretelyAddressedStore.empty()) {
-    stream << prefix << "concretely-addressed store = []\n";
-  } else {
-    stream << prefix << "concretely-addressed store = [\n";
+  stream << ":";
+  stream << "\n" << prefix << "concretely-addressed store = [";
+  if (!concretelyAddressedStore.empty()) {
+    stream << "\n";
     for (LowerStateStore::const_iterator
              lowerIs = concretelyAddressedStore.begin(),
              lowerIe = concretelyAddressedStore.end(), lowerIt = lowerIs;
@@ -60,13 +59,13 @@ void TxStore::MiddleStateStore::print(llvm::raw_ostream &stream,
       lowerIt->second->getContent()->print(stream, tabsNextNext);
       stream << "\n";
     }
-    stream << prefix << "]\n";
+    stream << prefix;
   }
+  stream << "]";
 
-  if (symbolicallyAddressedStore.empty()) {
-    stream << prefix << "symbolically-addressed store = []";
-  } else {
-    stream << prefix << "symbolically-addressed store = [\n";
+  stream << "\n" << prefix << "symbolically-addressed store = [";
+  if (!symbolicallyAddressedStore.empty()) {
+    stream << "\n";
     for (LowerStateStore::const_iterator
              lowerIs = symbolicallyAddressedStore.begin(),
              lowerIe = symbolicallyAddressedStore.end(), lowerIt = lowerIs;
@@ -80,8 +79,9 @@ void TxStore::MiddleStateStore::print(llvm::raw_ostream &stream,
       lowerIt->second->getContent()->print(stream, tabsNextNext);
       stream << "\n";
     }
-    stream << prefix << "]";
+    stream << prefix;
   }
+  stream << "]";
 }
 
 /**/

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -157,7 +157,7 @@ TxStore::concreteToInterpolant(ref<TxVariable> variable,
   if (!coreOnly) {
     map[variable] = entry->getContent()->getInterpolantStyleValue();
   } else if (entry->getContent()->isCore()) {
-// An address is in the core if it stores a value that is in the core
+    // An address is in the core if it stores a value that is in the core
 #ifdef ENABLE_Z3
     if (!NoExistential) {
       map[variable] =
@@ -179,7 +179,7 @@ TxStore::symbolicToInterpolant(ref<TxVariable> variable,
   if (!coreOnly) {
     map[variable] = entry->getContent()->getInterpolantStyleValue();
   } else if (entry->getContent()->isCore()) {
-// An address is in the core if it stores a value that is in the core
+    // An address is in the core if it stores a value that is in the core
 #ifdef ENABLE_Z3
     if (!NoExistential) {
       ref<TxVariable> address = TxStateAddress::create(

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -302,6 +302,9 @@ void TxStore::print(llvm::raw_ostream &stream,
     for (TopStateStore::const_iterator topIs = store.begin(),
                                        topIe = store.end(), topIt = topIs;
          topIt != topIe; ++topIt) {
+      if (topIt != topIs) {
+        stream << "\n";
+      }
       topIt->first->print(stream, tabsNext);
       stream << ":\n";
       topIt->second.print(stream, tabsNextNext);

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -87,7 +87,7 @@ void TxStore::getStoredExpressions(
     const std::vector<llvm::Instruction *> &callHistory,
     std::set<const Array *> &replacements, bool coreOnly,
     TopInterpolantStore &_concretelyAddressedStore,
-    TopInterpolantStore &_symbolicallyAddressedStore) {
+    TopInterpolantStore &_symbolicallyAddressedStore) const {
   getConcreteStore(callHistory, store, concretelyAddressedHistoricalStore,
                    replacements, coreOnly, _concretelyAddressedStore);
   getSymbolicStore(callHistory, store, symbolicallyAddressedHistoricalStore,

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -156,7 +156,7 @@ TxStore::concreteToInterpolant(ref<TxVariable> variable,
                                bool coreOnly, LowerInterpolantStore &map) {
   if (!coreOnly) {
     map[variable] = entry->getContent()->getInterpolantStyleValue();
-  } else {
+  } else if (entry->getContent()->isCore()) {
 // An address is in the core if it stores a value that is in the core
 #ifdef ENABLE_Z3
     if (!NoExistential) {

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -171,7 +171,7 @@ void TxStore::getConcreteStore(
       continue;
 
     TopInterpolantStore::iterator storeIter =
-        concretelyAddressedStore.find(it->first->getValue());
+        concretelyAddressedStore.find(it->first);
 
     const MiddleStateStore &middleStore = it->second;
 
@@ -188,7 +188,7 @@ void TxStore::getConcreteStore(
       // The map is only added when it is not empty; this is to avoid entries
       // mapped to empty structure in concretelyAddressedStore
       if (!map.empty()) {
-        concretelyAddressedStore[it->first->getValue()] = map;
+        concretelyAddressedStore[it->first] = map;
       }
     } else {
       for (LowerStateStore::const_iterator it1 = middleStore.concreteBegin(),
@@ -220,7 +220,7 @@ void TxStore::getSymbolicStore(
       continue;
 
     TopInterpolantStore::iterator storeIter =
-        symbolicallyAddressedStore.find(it->first->getValue());
+        symbolicallyAddressedStore.find(it->first);
 
     const MiddleStateStore &middleStore = it->second;
 
@@ -237,7 +237,7 @@ void TxStore::getSymbolicStore(
       // The map is only added when it is not empty; this is to avoid entries
       // mapped to empty structure in symbolicallyAddressedStore
       if (!map.empty()) {
-        symbolicallyAddressedStore[it->first->getValue()] = map;
+        symbolicallyAddressedStore[it->first] = map;
       }
     } else {
       for (LowerStateStore::const_iterator it1 = middleStore.symbolicBegin(),

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -43,7 +43,7 @@ public:
 
   ~TxStoreEntry() {}
 
-  ref<TxVariable> getIndex() { return address->getInterpolantStyleAddress(); }
+  ref<TxVariable> getIndex() { return address->getAsVariable(); }
 
   ref<TxStateAddress> getAddress() { return address; }
 
@@ -101,7 +101,7 @@ public:
   }
 
   StateStore::iterator concreteFind(ref<TxStateAddress> loc) {
-    return concretelyAddressedStore.find(loc->getInterpolantStyleAddress());
+    return concretelyAddressedStore.find(loc->getAsVariable());
   }
 
   StateStore::iterator concreteBegin() {
@@ -111,7 +111,7 @@ public:
   StateStore::iterator concreteEnd() { return concretelyAddressedStore.end(); }
 
   StateStore::iterator symbolicFind(ref<TxStateAddress> loc) {
-    return symbolicallyAddressedStore.find(loc->getInterpolantStyleAddress());
+    return symbolicallyAddressedStore.find(loc->getAsVariable());
   }
 
   StateStore::iterator symbolicBegin() {

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -43,9 +43,7 @@ public:
 
   ~TxStoreEntry() {}
 
-  ref<TxInterpolantAddress> getIndex() {
-    return address->getInterpolantStyleAddress();
-  }
+  ref<TxVariable> getIndex() { return address->getInterpolantStyleAddress(); }
 
   ref<TxStateAddress> getAddress() { return address; }
 
@@ -56,24 +54,24 @@ public:
 
 class TxStore {
 public:
-  typedef std::map<ref<TxInterpolantAddress>, ref<TxInterpolantValue> >
+  typedef std::map<ref<TxVariable>, ref<TxInterpolantValue> >
   LowerInterpolantStore;
   typedef std::map<const llvm::Value *, LowerInterpolantStore>
   TopInterpolantStore;
-  typedef std::map<ref<TxInterpolantAddress>, ref<TxStoreEntry> > StateStore;
+  typedef std::map<ref<TxVariable>, ref<TxStoreEntry> > StateStore;
 
 private:
   /// \brief The mapping of concrete locations to stored value
   StateStore concretelyAddressedStore;
 
   /// \brief Ordered keys of the concretely-addressed store.
-  std::vector<ref<TxInterpolantAddress> > concretelyAddressedStoreKeys;
+  std::vector<ref<TxVariable> > concretelyAddressedStoreKeys;
 
   /// \brief The mapping of symbolic locations to stored value
   StateStore symbolicallyAddressedStore;
 
   /// \brief Ordered keys of the symbolically-addressed store.
-  std::vector<ref<TxInterpolantAddress> > symbolicallyAddressedStoreKeys;
+  std::vector<ref<TxVariable> > symbolicallyAddressedStoreKeys;
 
   void getConcreteStore(
       const std::vector<llvm::Instruction *> &callHistory,

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -185,14 +185,16 @@ private:
                    const TopStateStore &store,
                    const LowerStateStore &historicalStore,
                    std::set<const Array *> &replacements, bool coreOnly,
-                   TopInterpolantStore &concreteStore);
+                   TopInterpolantStore &concretelyAddressedStore,
+                   LowerInterpolantStore &concretelyAddressedHistoricalStore);
 
   static void
   getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
                    const TopStateStore &store,
                    const LowerStateStore &historicalStore,
                    std::set<const Array *> &replacements, bool coreOnly,
-                   TopInterpolantStore &symbolicStore);
+                   TopInterpolantStore &symbolicallyAddressedStore,
+                   LowerInterpolantStore &symbolicallyAddressedHistoricalStore);
 
 public:
   /// \brief Constructor for an empty store.
@@ -228,11 +230,13 @@ public:
   /// bound ones.
   /// \param coreOnly Indicate whether we are retrieving only data
   /// for locations relevant to an unsatisfiability core.
-  void
-  getStoredExpressions(const std::vector<llvm::Instruction *> &callHistory,
-                       std::set<const Array *> &replacements, bool coreOnly,
-                       TopInterpolantStore &_concretelyAddressedStore,
-                       TopInterpolantStore &_symbolicallyAddressedStore) const;
+  void getStoredExpressions(
+      const std::vector<llvm::Instruction *> &callHistory,
+      std::set<const Array *> &replacements, bool coreOnly,
+      TopInterpolantStore &_concretelyAddressedStore,
+      TopInterpolantStore &_symbolicallyAddressedStore,
+      LowerInterpolantStore &_concretelyAddressedHistoricalStore,
+      LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const;
 
   /// \brief Newly relate a location with its stored value, when the value is
   /// loaded from the location

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -50,6 +50,15 @@ public:
   ref<TxStateValue> getAddressValue() { return addressValue; }
 
   ref<TxStateValue> getContent() { return content; }
+
+  void dump() const {
+    print(llvm::errs());
+    llvm::errs() << "\n";
+  }
+
+  void print(llvm::raw_ostream &stream) const { print(stream, ""); }
+
+  void print(llvm::raw_ostream &stream, const std::string &prefix) const;
 };
 
 class TxStore {

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -68,15 +68,17 @@ private:
   /// \brief The mapping of symbolic locations to stored value
   TopStateStore symbolicallyAddressedStore;
 
-  void getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
-                        const TopStateStore &store,
-                        std::set<const Array *> &replacements, bool coreOnly,
-                        TopInterpolantStore &concreteStore) const;
+  static void
+  getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
+                   const TopStateStore &store,
+                   std::set<const Array *> &replacements, bool coreOnly,
+                   TopInterpolantStore &concreteStore);
 
-  void getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
-                        const TopStateStore &store,
-                        std::set<const Array *> &replacements, bool coreOnly,
-                        TopInterpolantStore &symbolicStore) const;
+  static void
+  getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
+                   const TopStateStore &store,
+                   std::set<const Array *> &replacements, bool coreOnly,
+                   TopInterpolantStore &symbolicStore);
 
 public:
   /// \brief Constructor for an empty store.

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -196,23 +196,24 @@ private:
                    TopInterpolantStore &symbolicallyAddressedStore,
                    LowerInterpolantStore &symbolicallyAddressedHistoricalStore);
 
-public:
   /// \brief Constructor for an empty store.
   TxStore() {}
 
-  /// \brief The copy constructor of this class.
-  TxStore(const TxStore &src)
-      : concretelyAddressedHistoricalStore(
-            src.concretelyAddressedHistoricalStore),
-        symbolicallyAddressedHistoricalStore(
-            src.symbolicallyAddressedHistoricalStore),
-        store(src.store) {}
+public:
+  ~TxStore() {}
 
-  ~TxStore() {
-    // Delete the locally-constructed relations
-    concretelyAddressedHistoricalStore.clear();
-    symbolicallyAddressedHistoricalStore.clear();
-    store.clear();
+  /// \brief Copy from another object
+  static TxStore *create(TxStore *src) {
+    TxStore *ret = new TxStore();
+    if (!src) {
+      return ret;
+    }
+    ret->concretelyAddressedHistoricalStore =
+        src->concretelyAddressedHistoricalStore;
+    ret->symbolicallyAddressedHistoricalStore =
+        src->symbolicallyAddressedHistoricalStore;
+    ret->store = src->store;
+    return ret;
   }
 
   /// \brief Finds a store entry given an address

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -59,21 +59,22 @@ public:
   typedef std::map<const llvm::Value *, LowerInterpolantStore>
   TopInterpolantStore;
   typedef std::map<ref<TxVariable>, ref<TxStoreEntry> > LowerStateStore;
+  typedef std::map<ref<AllocationContext>, LowerStateStore> TopStateStore;
 
 private:
   /// \brief The mapping of concrete locations to stored value
-  LowerStateStore concretelyAddressedStore;
+  TopStateStore concretelyAddressedStore;
 
   /// \brief The mapping of symbolic locations to stored value
-  LowerStateStore symbolicallyAddressedStore;
+  TopStateStore symbolicallyAddressedStore;
 
   void getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
-                        const LowerStateStore &store,
+                        const TopStateStore &store,
                         std::set<const Array *> &replacements, bool coreOnly,
                         TopInterpolantStore &concreteStore) const;
 
   void getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
-                        const LowerStateStore &store,
+                        const TopStateStore &store,
                         std::set<const Array *> &replacements, bool coreOnly,
                         TopInterpolantStore &symbolicStore) const;
 
@@ -92,27 +93,35 @@ public:
     symbolicallyAddressedStore.clear();
   }
 
-  LowerStateStore::iterator concreteFind(ref<TxStateAddress> loc) {
-    return concretelyAddressedStore.find(loc->getAsVariable());
+  TopStateStore::iterator concreteFind(ref<TxStateAddress> loc) {
+    TopStateStore::iterator ret =
+        concretelyAddressedStore.find(loc->getContext());
+    if (ret != concretelyAddressedStore.end() && ret->second.empty())
+      return concretelyAddressedStore.end();
+    return ret;
   }
 
-  LowerStateStore::iterator concreteBegin() {
+  TopStateStore::iterator concreteBegin() {
     return concretelyAddressedStore.begin();
   }
 
-  LowerStateStore::iterator concreteEnd() {
+  TopStateStore::iterator concreteEnd() {
     return concretelyAddressedStore.end();
   }
 
-  LowerStateStore::iterator symbolicFind(ref<TxStateAddress> loc) {
-    return symbolicallyAddressedStore.find(loc->getAsVariable());
+  TopStateStore::iterator symbolicFind(ref<TxStateAddress> loc) {
+    TopStateStore::iterator ret =
+        symbolicallyAddressedStore.find(loc->getContext());
+    if (ret != symbolicallyAddressedStore.end() && ret->second.empty())
+      return symbolicallyAddressedStore.end();
+    return ret;
   }
 
-  LowerStateStore::iterator symbolicBegin() {
+  TopStateStore::iterator symbolicBegin() {
     return symbolicallyAddressedStore.begin();
   }
 
-  LowerStateStore::iterator symbolicEnd() {
+  TopStateStore::iterator symbolicEnd() {
     return symbolicallyAddressedStore.end();
   }
 

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -54,12 +54,15 @@ public:
 
 class TxStore {
 public:
+  class MiddleStateStore;
+
   typedef std::map<ref<TxVariable>, ref<TxInterpolantValue> >
   LowerInterpolantStore;
   typedef std::map<const llvm::Value *, LowerInterpolantStore>
   TopInterpolantStore;
   typedef std::map<ref<TxVariable>, ref<TxStoreEntry> > LowerStateStore;
-  typedef std::map<ref<AllocationContext>, LowerStateStore> TopStateStore;
+  typedef std::map<ref<AllocationContext>, ref<MiddleStateStore> >
+  TopStateStore;
 
   class MiddleStateStore {
   public:
@@ -156,11 +159,8 @@ public:
   };
 
 private:
-  /// \brief The mapping of concrete locations to stored value
-  TopStateStore concretelyAddressedStore;
-
-  /// \brief The mapping of symbolic locations to stored value
-  TopStateStore symbolicallyAddressedStore;
+  /// \brief The mapping of locations to stored value
+  TopStateStore store;
 
   static void
   getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
@@ -179,14 +179,11 @@ public:
   TxStore() {}
 
   /// \brief The copy constructor of this class.
-  TxStore(const TxStore &src)
-      : concretelyAddressedStore(src.concretelyAddressedStore),
-        symbolicallyAddressedStore(src.symbolicallyAddressedStore) {}
+  TxStore(const TxStore &src) : store(src.store) {}
 
   ~TxStore() {
     // Delete the locally-constructed relations
-    concretelyAddressedStore.clear();
-    symbolicallyAddressedStore.clear();
+    store.clear();
   }
 
   /// \brief Finds a store entry given an address

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -61,13 +61,9 @@ public:
   typedef std::map<const llvm::Value *, LowerInterpolantStore>
   TopInterpolantStore;
   typedef std::map<ref<TxVariable>, ref<TxStoreEntry> > LowerStateStore;
-  typedef std::map<ref<AllocationContext>, ref<MiddleStateStore> >
-  TopStateStore;
+  typedef std::map<ref<AllocationContext>, MiddleStateStore> TopStateStore;
 
   class MiddleStateStore {
-  public:
-    unsigned refCount;
-
   private:
     LowerStateStore concretelyAddressedStore;
 
@@ -75,12 +71,17 @@ public:
 
     ref<AllocationInfo> allocInfo;
 
-    MiddleStateStore(ref<AllocationInfo> _allocInfo)
-        : refCount(0), allocInfo(_allocInfo) {}
 
   public:
-    static ref<MiddleStateStore> create(ref<AllocationInfo> allocInfo) {
-      return ref<MiddleStateStore>(new MiddleStateStore(allocInfo));
+    MiddleStateStore() {}
+
+    MiddleStateStore(ref<AllocationInfo> _allocInfo) : allocInfo(_allocInfo) {}
+
+    /// \brief The copy constructor
+    MiddleStateStore(const MiddleStateStore &obj) {
+      concretelyAddressedStore = obj.concretelyAddressedStore;
+      symbolicallyAddressedStore = obj.symbolicallyAddressedStore;
+      allocInfo = obj.allocInfo;
     }
 
     LowerStateStore::const_iterator concreteBegin() const {

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -67,7 +67,7 @@ public:
 
   typedef std::map<ref<TxVariable>, ref<TxInterpolantValue> >
   LowerInterpolantStore;
-  typedef std::map<const llvm::Value *, LowerInterpolantStore>
+  typedef std::map<ref<AllocationContext>, LowerInterpolantStore>
   TopInterpolantStore;
   typedef std::map<ref<TxVariable>, ref<TxStoreEntry> > LowerStateStore;
   typedef std::map<ref<AllocationContext>, MiddleStateStore> TopStateStore;

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -93,37 +93,8 @@ public:
     symbolicallyAddressedStore.clear();
   }
 
-  TopStateStore::iterator concreteFind(ref<TxStateAddress> loc) {
-    TopStateStore::iterator ret =
-        concretelyAddressedStore.find(loc->getContext());
-    if (ret != concretelyAddressedStore.end() && ret->second.empty())
-      return concretelyAddressedStore.end();
-    return ret;
-  }
-
-  TopStateStore::iterator concreteBegin() {
-    return concretelyAddressedStore.begin();
-  }
-
-  TopStateStore::iterator concreteEnd() {
-    return concretelyAddressedStore.end();
-  }
-
-  TopStateStore::iterator symbolicFind(ref<TxStateAddress> loc) {
-    TopStateStore::iterator ret =
-        symbolicallyAddressedStore.find(loc->getContext());
-    if (ret != symbolicallyAddressedStore.end() && ret->second.empty())
-      return symbolicallyAddressedStore.end();
-    return ret;
-  }
-
-  TopStateStore::iterator symbolicBegin() {
-    return symbolicallyAddressedStore.begin();
-  }
-
-  TopStateStore::iterator symbolicEnd() {
-    return symbolicallyAddressedStore.end();
-  }
+  /// \brief Finds a store entry given an address
+  ref<TxStoreEntry> find(ref<TxStateAddress> loc) const;
 
   /// \brief This retrieves the locations known at this state, and the
   /// expressions stored in the locations. Returns as the last argument a pair

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -159,18 +159,38 @@ public:
   };
 
 private:
+  /// \brief A concretely-addressed store of the earlier versions of all
+  /// addresses
+  LowerStateStore concreteHistoricalStore;
+
+  /// \brief A symbolically-addressed store of the earlier versions of all
+  /// addresses
+  LowerStateStore symbolicHistoricalStore;
+
   /// \brief The mapping of locations to stored value
   TopStateStore store;
+
+  static void concreteToInterpolant(ref<TxVariable> variable,
+                                    ref<TxStoreEntry> entry,
+                                    std::set<const Array *> &replacements,
+                                    bool coreOnly, LowerInterpolantStore &map);
+
+  static void symbolicToInterpolant(ref<TxVariable> variable,
+                                    ref<TxStoreEntry> entry,
+                                    std::set<const Array *> &replacements,
+                                    bool coreOnly, LowerInterpolantStore &map);
 
   static void
   getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
                    const TopStateStore &store,
+                   const LowerStateStore &historicalStore,
                    std::set<const Array *> &replacements, bool coreOnly,
                    TopInterpolantStore &concreteStore);
 
   static void
   getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
                    const TopStateStore &store,
+                   const LowerStateStore &historicalStore,
                    std::set<const Array *> &replacements, bool coreOnly,
                    TopInterpolantStore &symbolicStore);
 
@@ -179,10 +199,15 @@ public:
   TxStore() {}
 
   /// \brief The copy constructor of this class.
-  TxStore(const TxStore &src) : store(src.store) {}
+  TxStore(const TxStore &src)
+      : concreteHistoricalStore(src.concreteHistoricalStore),
+        symbolicHistoricalStore(src.symbolicHistoricalStore), store(src.store) {
+  }
 
   ~TxStore() {
     // Delete the locally-constructed relations
+    concreteHistoricalStore.clear();
+    symbolicHistoricalStore.clear();
     store.clear();
   }
 

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -228,11 +228,11 @@ public:
   /// bound ones.
   /// \param coreOnly Indicate whether we are retrieving only data
   /// for locations relevant to an unsatisfiability core.
-  void getStoredExpressions(const std::vector<llvm::Instruction *> &callHistory,
-                            std::set<const Array *> &replacements,
-                            bool coreOnly,
-                            TopInterpolantStore &_concretelyAddressedStore,
-                            TopInterpolantStore &_symbolicallyAddressedStore);
+  void
+  getStoredExpressions(const std::vector<llvm::Instruction *> &callHistory,
+                       std::set<const Array *> &replacements, bool coreOnly,
+                       TopInterpolantStore &_concretelyAddressedStore,
+                       TopInterpolantStore &_symbolicallyAddressedStore) const;
 
   /// \brief Newly relate a location with its stored value, when the value is
   /// loaded from the location

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -113,41 +113,10 @@ public:
       return allocInfo == _allocInfo;
     }
 
-    ref<TxStoreEntry> find(ref<TxStateAddress> loc) const {
-      ref<TxStoreEntry> ret;
-
-      if (loc->hasConstantAddress()) {
-        TxStore::LowerStateStore::const_iterator lowerStoreIter =
-            concretelyAddressedStore.find(loc->getAsVariable());
-
-        if (lowerStoreIter != concretelyAddressedStore.end()) {
-          ret = lowerStoreIter->second;
-        }
-      } else {
-        TxStore::LowerStateStore::const_iterator lowerStoreIter =
-            symbolicallyAddressedStore.find(loc->getAsVariable());
-        if (lowerStoreIter != symbolicallyAddressedStore.end()) {
-          ret = lowerStoreIter->second;
-        }
-      }
-
-      return ret;
-    }
+    ref<TxStoreEntry> find(ref<TxStateAddress> loc) const;
 
     bool updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
-                     ref<TxStateValue> value) {
-      if (loc->getAllocationInfo() != allocInfo)
-        return false;
-
-      if (loc->hasConstantAddress()) {
-        concretelyAddressedStore[loc->getAsVariable()] =
-            ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
-      } else {
-        symbolicallyAddressedStore[loc->getAsVariable()] =
-            ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
-      }
-      return true;
-    }
+                     ref<TxStateValue> value);
 
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -161,11 +161,11 @@ public:
 private:
   /// \brief A concretely-addressed store of the earlier versions of all
   /// addresses
-  LowerStateStore concreteHistoricalStore;
+  LowerStateStore concretelyAddressedHistoricalStore;
 
   /// \brief A symbolically-addressed store of the earlier versions of all
   /// addresses
-  LowerStateStore symbolicHistoricalStore;
+  LowerStateStore symbolicallyAddressedHistoricalStore;
 
   /// \brief The mapping of locations to stored value
   TopStateStore store;
@@ -200,14 +200,16 @@ public:
 
   /// \brief The copy constructor of this class.
   TxStore(const TxStore &src)
-      : concreteHistoricalStore(src.concreteHistoricalStore),
-        symbolicHistoricalStore(src.symbolicHistoricalStore), store(src.store) {
-  }
+      : concretelyAddressedHistoricalStore(
+            src.concretelyAddressedHistoricalStore),
+        symbolicallyAddressedHistoricalStore(
+            src.symbolicallyAddressedHistoricalStore),
+        store(src.store) {}
 
   ~TxStore() {
     // Delete the locally-constructed relations
-    concreteHistoricalStore.clear();
-    symbolicHistoricalStore.clear();
+    concretelyAddressedHistoricalStore.clear();
+    symbolicallyAddressedHistoricalStore.clear();
     store.clear();
   }
 

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -64,14 +64,8 @@ private:
   /// \brief The mapping of concrete locations to stored value
   StateStore concretelyAddressedStore;
 
-  /// \brief Ordered keys of the concretely-addressed store.
-  std::vector<ref<TxVariable> > concretelyAddressedStoreKeys;
-
   /// \brief The mapping of symbolic locations to stored value
   StateStore symbolicallyAddressedStore;
-
-  /// \brief Ordered keys of the symbolically-addressed store.
-  std::vector<ref<TxVariable> > symbolicallyAddressedStoreKeys;
 
   void getConcreteStore(
       const std::vector<llvm::Instruction *> &callHistory,

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -58,26 +58,24 @@ public:
   LowerInterpolantStore;
   typedef std::map<const llvm::Value *, LowerInterpolantStore>
   TopInterpolantStore;
-  typedef std::map<ref<TxVariable>, ref<TxStoreEntry> > StateStore;
+  typedef std::map<ref<TxVariable>, ref<TxStoreEntry> > LowerStateStore;
 
 private:
   /// \brief The mapping of concrete locations to stored value
-  StateStore concretelyAddressedStore;
+  LowerStateStore concretelyAddressedStore;
 
   /// \brief The mapping of symbolic locations to stored value
-  StateStore symbolicallyAddressedStore;
+  LowerStateStore symbolicallyAddressedStore;
 
-  void getConcreteStore(
-      const std::vector<llvm::Instruction *> &callHistory,
-      const StateStore &store,
-      std::set<const Array *> &replacements, bool coreOnly,
-      TopInterpolantStore &concreteStore) const;
+  void getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
+                        const LowerStateStore &store,
+                        std::set<const Array *> &replacements, bool coreOnly,
+                        TopInterpolantStore &concreteStore) const;
 
-  void getSymbolicStore(
-      const std::vector<llvm::Instruction *> &callHistory,
-      const StateStore &store,
-      std::set<const Array *> &replacements, bool coreOnly,
-      TopInterpolantStore &symbolicStore) const;
+  void getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
+                        const LowerStateStore &store,
+                        std::set<const Array *> &replacements, bool coreOnly,
+                        TopInterpolantStore &symbolicStore) const;
 
 public:
   /// \brief Constructor for an empty store.
@@ -94,25 +92,27 @@ public:
     symbolicallyAddressedStore.clear();
   }
 
-  StateStore::iterator concreteFind(ref<TxStateAddress> loc) {
+  LowerStateStore::iterator concreteFind(ref<TxStateAddress> loc) {
     return concretelyAddressedStore.find(loc->getAsVariable());
   }
 
-  StateStore::iterator concreteBegin() {
+  LowerStateStore::iterator concreteBegin() {
     return concretelyAddressedStore.begin();
   }
 
-  StateStore::iterator concreteEnd() { return concretelyAddressedStore.end(); }
+  LowerStateStore::iterator concreteEnd() {
+    return concretelyAddressedStore.end();
+  }
 
-  StateStore::iterator symbolicFind(ref<TxStateAddress> loc) {
+  LowerStateStore::iterator symbolicFind(ref<TxStateAddress> loc) {
     return symbolicallyAddressedStore.find(loc->getAsVariable());
   }
 
-  StateStore::iterator symbolicBegin() {
+  LowerStateStore::iterator symbolicBegin() {
     return symbolicallyAddressedStore.begin();
   }
 
-  StateStore::iterator symbolicEnd() {
+  LowerStateStore::iterator symbolicEnd() {
     return symbolicallyAddressedStore.end();
   }
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -869,6 +869,7 @@ bool SubsumptionTableEntry::subsumed(
              it1 = concretelyAddressedStore.begin(),
              ie1 = concretelyAddressedStore.end();
          it1 != ie1; ++it1) {
+      assert(!it1->second.empty() && "empty table entry with real index");
 
       const TxStore::LowerInterpolantStore &tabledConcreteMap = it1->second;
       const TxStore::LowerInterpolantStore &stateConcreteMap =
@@ -1137,6 +1138,8 @@ bool SubsumptionTableEntry::subsumed(
              it1 = symbolicallyAddressedStore.begin(),
              ie1 = symbolicallyAddressedStore.end();
          it1 != ie1; ++it1) {
+      assert(!it1->second.empty() && "empty table entry with real index");
+
       const TxStore::LowerInterpolantStore &tabledSymbolicMap = it1->second;
       const TxStore::LowerInterpolantStore &stateConcreteMap =
           _concretelyAddressedStore[it1->first];

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -167,12 +167,7 @@ SubsumptionTableEntry::SubsumptionTableEntry(
       symbolicallyAddressedHistoricalStore);
 }
 
-SubsumptionTableEntry::~SubsumptionTableEntry() {
-  concretelyAddressedStore.clear();
-  symbolicallyAddressedStore.clear();
-  concretelyAddressedHistoricalStore.clear();
-  symbolicallyAddressedHistoricalStore.clear();
-}
+SubsumptionTableEntry::~SubsumptionTableEntry() {}
 
 ref<Expr> SubsumptionTableEntry::makeConstraint(
     ExecutionState &state, ref<TxInterpolantValue> tabledValue,

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1596,10 +1596,10 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
     interpolant->print(stream);
   else
     stream << "(empty)";
-  stream << "\n";
 
+  stream << "\n" << prefix << "concretely-addressed store = [";
   if (!concretelyAddressedStore.empty()) {
-    stream << prefix << "concretely-addressed store = [\n";
+    stream << "\n";
     for (TxStore::TopInterpolantStore::const_iterator
              is1 = concretelyAddressedStore.begin(),
              ie1 = concretelyAddressedStore.end(), it1 = is1;
@@ -1618,11 +1618,13 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
         stream << "\n";
       }
     }
-    stream << prefix << "]\n";
+    stream << prefix;
   }
+  stream << "]";
 
+  stream << "\n" << prefix << "symbolically-addressed store = [";
   if (!symbolicallyAddressedStore.empty()) {
-    stream << prefix << "symbolically-addressed store = [\n";
+    stream << "\n";
     for (TxStore::TopInterpolantStore::const_iterator
              is1 = symbolicallyAddressedStore.begin(),
              ie1 = symbolicallyAddressedStore.end(), it1 = is1;
@@ -1641,11 +1643,52 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
         stream << "\n";
       }
     }
-    stream << "]\n";
+    stream << prefix;
   }
+  stream << "]";
 
+  stream << "\n" << prefix << "concretely-addressed historical store = [";
+  if (!concretelyAddressedHistoricalStore.empty()) {
+    stream << "\n";
+    for (TxStore::LowerInterpolantStore::const_iterator
+             is1 = concretelyAddressedHistoricalStore.begin(),
+             ie1 = concretelyAddressedHistoricalStore.end(), it1 = is1;
+         it1 != ie1; ++it1) {
+      if (it1 != is1)
+        stream << tabsNext << "------------------------------------------\n";
+      stream << tabsNext << "address:\n";
+      it1->first->print(stream, tabsNextNext);
+      stream << "\n";
+      stream << tabsNext << "content:\n";
+      it1->second->print(stream, tabsNextNext);
+      stream << "\n";
+    }
+    stream << prefix;
+  }
+  stream << "]";
+
+  stream << "\n" << prefix << "symbolically-addressed historical store = [";
+  if (!symbolicallyAddressedHistoricalStore.empty()) {
+    stream << "\n";
+    for (TxStore::LowerInterpolantStore::const_iterator
+             is1 = symbolicallyAddressedHistoricalStore.begin(),
+             ie1 = symbolicallyAddressedHistoricalStore.end(), it1 = is1;
+         it1 != ie1; ++it1) {
+      if (it1 != is1)
+        stream << tabsNext << "------------------------------------------\n";
+      stream << tabsNext << "address:\n";
+      it1->first->print(stream, tabsNextNext);
+      stream << "\n";
+      stream << tabsNext << "content:\n";
+      it1->second->print(stream, tabsNextNext);
+      stream << "\n";
+    }
+    stream << prefix;
+  }
+  stream << "]";
+
+  stream << "\n" << prefix << "existentials = [";
   if (!existentials.empty()) {
-    stream << prefix << "existentials = [";
     for (std::set<const Array *>::const_iterator is = existentials.begin(),
                                                  ie = existentials.end(),
                                                  it = is;
@@ -1654,8 +1697,8 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
         stream << ", ";
       stream << (*it)->name;
     }
-    stream << "]\n";
   }
+  stream << "]";
 }
 
 void SubsumptionTableEntry::printStat(std::stringstream &stream) {

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -866,8 +866,8 @@ bool SubsumptionTableEntry::subsumed(
 
     // Build constraints from concrete-address interpolant store
     for (TxStore::TopInterpolantStore::const_iterator
-             it1 = _concretelyAddressedStore.begin(),
-             ie1 = _concretelyAddressedStore.end();
+             it1 = concretelyAddressedStore.begin(),
+             ie1 = concretelyAddressedStore.end();
          it1 != ie1; ++it1) {
 
       const TxStore::LowerInterpolantStore &tabledConcreteMap = it1->second;
@@ -1134,8 +1134,8 @@ bool SubsumptionTableEntry::subsumed(
     TimerStatIncrementer t(symbolicallyAddressedStoreExpressionBuildTime);
     // Build constraints from symbolic-address interpolant store
     for (TxStore::TopInterpolantStore::const_iterator
-             it1 = _symbolicallyAddressedStore.begin(),
-             ie1 = _symbolicallyAddressedStore.end();
+             it1 = symbolicallyAddressedStore.begin(),
+             ie1 = symbolicallyAddressedStore.end();
          it1 != ie1; ++it1) {
       const TxStore::LowerInterpolantStore &tabledSymbolicMap = it1->second;
       const TxStore::LowerInterpolantStore &stateConcreteMap =

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -147,10 +147,10 @@ void PathCondition::print(llvm::raw_ostream &stream) const {
 
 /**/
 
-Statistic SubsumptionTableEntry::concreteStoreExpressionBuildTime(
-    "concreteStoreExpressionBuildTime", "concreteStoreTime");
-Statistic SubsumptionTableEntry::symbolicStoreExpressionBuildTime(
-    "symbolicStoreExpressionBuildTime", "symbolicStoreTime");
+Statistic SubsumptionTableEntry::concretelyAddressedStoreExpressionBuildTime(
+    "concretelyAddressedStoreExpressionBuildTime", "concreteStoreTime");
+Statistic SubsumptionTableEntry::symbolicallyAddressedStoreExpressionBuildTime(
+    "symbolicallyAddressedStoreExpressionBuildTime", "symbolicStoreTime");
 Statistic SubsumptionTableEntry::solverAccessTime("solverAccessTime",
                                                   "solverAccessTime");
 
@@ -162,12 +162,13 @@ SubsumptionTableEntry::SubsumptionTableEntry(
   interpolant = node->getInterpolant(existentials);
 
   node->getStoredCoreExpressions(callHistory, existentials,
-                                 concreteAddressStore, symbolicAddressStore);
+                                 concretelyAddressedStore,
+                                 symbolicallyAddressedStore);
 }
 
 SubsumptionTableEntry::~SubsumptionTableEntry() {
-  concreteAddressStore.clear();
-  symbolicAddressStore.clear();
+  concretelyAddressedStore.clear();
+  symbolicallyAddressedStore.clear();
 }
 
 bool
@@ -783,12 +784,12 @@ bool SubsumptionTableEntry::subsumed(
   std::set<ref<TxInterpolantValue> > coreExactPointerValues;
 
   {
-    TimerStatIncrementer t(concreteStoreExpressionBuildTime);
+    TimerStatIncrementer t(concretelyAddressedStoreExpressionBuildTime);
 
     // Build constraints from concrete-address interpolant store
     for (TxStore::TopInterpolantStore::const_iterator
-             it1 = concreteAddressStore.begin(),
-             ie1 = concreteAddressStore.end();
+             it1 = concretelyAddressedStore.begin(),
+             ie1 = concretelyAddressedStore.end();
          it1 != ie1; ++it1) {
 
       const TxStore::LowerInterpolantStore &tabledConcreteMap = it1->second;
@@ -1072,11 +1073,11 @@ bool SubsumptionTableEntry::subsumed(
   }
 
   {
-    TimerStatIncrementer t(symbolicStoreExpressionBuildTime);
+    TimerStatIncrementer t(symbolicallyAddressedStoreExpressionBuildTime);
     // Build constraints from symbolic-address interpolant store
     for (TxStore::TopInterpolantStore::const_iterator
-             it1 = symbolicAddressStore.begin(),
-             ie1 = symbolicAddressStore.end();
+             it1 = symbolicallyAddressedStore.begin(),
+             ie1 = symbolicallyAddressedStore.end();
          it1 != ie1; ++it1) {
       const TxStore::LowerInterpolantStore &tabledSymbolicMap = it1->second;
       const TxStore::LowerInterpolantStore &stateConcreteMap =
@@ -1589,11 +1590,11 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
     stream << "(empty)";
   stream << "\n";
 
-  if (!concreteAddressStore.empty()) {
-    stream << prefix << "concrete store = [\n";
+  if (!concretelyAddressedStore.empty()) {
+    stream << prefix << "concretely-addressed store = [\n";
     for (TxStore::TopInterpolantStore::const_iterator
-             is1 = concreteAddressStore.begin(),
-             ie1 = concreteAddressStore.end(), it1 = is1;
+             is1 = concretelyAddressedStore.begin(),
+             ie1 = concretelyAddressedStore.end(), it1 = is1;
          it1 != ie1; ++it1) {
       for (TxStore::LowerInterpolantStore::const_iterator
                is2 = it1->second.begin(),
@@ -1612,11 +1613,11 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream,
     stream << prefix << "]\n";
   }
 
-  if (!symbolicAddressStore.empty()) {
-    stream << prefix << "symbolic store = [\n";
+  if (!symbolicallyAddressedStore.empty()) {
+    stream << prefix << "symbolically-addressed store = [\n";
     for (TxStore::TopInterpolantStore::const_iterator
-             is1 = symbolicAddressStore.begin(),
-             ie1 = symbolicAddressStore.end(), it1 = is1;
+             is1 = symbolicallyAddressedStore.begin(),
+             ie1 = symbolicallyAddressedStore.end(), it1 = is1;
          it1 != ie1; ++it1) {
       for (TxStore::LowerInterpolantStore::const_iterator
                is2 = it1->second.begin(),
@@ -1657,11 +1658,11 @@ void SubsumptionTableEntry::printStat(std::stringstream &stream) {
             "(failed) = " << stats::subsumptionQueryCount.getValue() << " ("
          << stats::subsumptionQueryFailureCount.getValue() << ")\n";
   stream << "KLEE: done:     Concrete store expression build time (ms) = "
-         << ((double)concreteStoreExpressionBuildTime.getValue()) / 1000
-         << "\n";
+         << ((double)concretelyAddressedStoreExpressionBuildTime.getValue()) /
+                1000 << "\n";
   stream << "KLEE: done:     Symbolic store expression build time (ms) = "
-         << ((double)symbolicStoreExpressionBuildTime.getValue()) / 1000
-         << "\n";
+         << ((double)symbolicallyAddressedStoreExpressionBuildTime.getValue()) /
+                1000 << "\n";
   stream << "KLEE: done:     Solver access time (ms) = "
          << ((double)solverAccessTime.getValue()) / 1000 << "\n";
 }

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -771,7 +771,12 @@ bool SubsumptionTableEntry::subsumed(
 
   ref<Expr> stateEqualityConstraints;
 
-  // Pointer values in the core for memory bounds interpolation
+  // Translation of allocation in the current state into an allocation in the
+  // tabled interpolant. This translation is used to equate absolute address
+  // values for allocations of matching sizes.
+  std::map<ref<AllocationInfo>, ref<AllocationInfo> > unifiedBases;
+
+  // Pointer values in the core for memory bounds interpolation.
   std::map<ref<TxInterpolantValue>, std::set<ref<Expr> > > corePointerValues;
 
   // Pointer values in the core for exact equality
@@ -849,7 +854,7 @@ bool SubsumptionTableEntry::subsumed(
             if (!ExactAddressInterpolant && tabledValue->useBound()) {
               std::set<ref<Expr> > bounds;
               ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
-                  stateValue, bounds, debugSubsumptionLevel);
+                  stateValue, bounds, unifiedBases, debugSubsumptionLevel);
               if (boundsCheck->isFalse()) {
                 if (debugSubsumptionLevel >= 1) {
                   std::string msg;
@@ -867,7 +872,7 @@ bool SubsumptionTableEntry::subsumed(
               corePointerValues[stateValue] = bounds;
             } else {
               ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
-                  stateValue, debugSubsumptionLevel);
+                  stateValue, unifiedBases, debugSubsumptionLevel);
 
               if (offsetsCheck->isFalse()) {
                 if (debugSubsumptionLevel >= 1) {
@@ -981,7 +986,7 @@ bool SubsumptionTableEntry::subsumed(
               if (!ExactAddressInterpolant && tabledValue->useBound()) {
                 std::set<ref<Expr> > bounds;
                 ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
-                    stateValue, bounds, debugSubsumptionLevel);
+                    stateValue, bounds, unifiedBases, debugSubsumptionLevel);
 
                 if (!boundsCheck->isTrue()) {
                   newTerm = EqExpr::create(ConstantExpr::create(0, Expr::Bool),
@@ -999,7 +1004,7 @@ bool SubsumptionTableEntry::subsumed(
                 corePointerValues[stateValue] = bounds;
               } else {
                 ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
-                    stateValue, debugSubsumptionLevel);
+                    stateValue, unifiedBases, debugSubsumptionLevel);
 
                 if (offsetsCheck->isFalse()) {
                   if (debugSubsumptionLevel >= 1) {
@@ -1114,7 +1119,7 @@ bool SubsumptionTableEntry::subsumed(
             if (!ExactAddressInterpolant && tabledValue->useBound()) {
               std::set<ref<Expr> > bounds;
               ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
-                  stateValue, bounds, debugSubsumptionLevel);
+                  stateValue, bounds, unifiedBases, debugSubsumptionLevel);
 
               if (!boundsCheck->isTrue()) {
                 newTerm = EqExpr::create(
@@ -1133,7 +1138,7 @@ bool SubsumptionTableEntry::subsumed(
               corePointerValues[stateValue] = bounds;
             } else {
               ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
-                  stateValue, debugSubsumptionLevel);
+                  stateValue, unifiedBases, debugSubsumptionLevel);
 
               if (!offsetsCheck->isTrue()) {
                 newTerm = EqExpr::create(
@@ -1196,7 +1201,7 @@ bool SubsumptionTableEntry::subsumed(
             if (!ExactAddressInterpolant && tabledValue->useBound()) {
               std::set<ref<Expr> > bounds;
               ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
-                  stateValue, bounds, debugSubsumptionLevel);
+                  stateValue, bounds, unifiedBases, debugSubsumptionLevel);
 
               if (!boundsCheck->isTrue()) {
                 newTerm = EqExpr::create(
@@ -1216,7 +1221,7 @@ bool SubsumptionTableEntry::subsumed(
             } else {
               std::set<ref<Expr> > bounds;
               ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
-                  stateValue, debugSubsumptionLevel);
+                  stateValue, unifiedBases, debugSubsumptionLevel);
 
               if (!offsetsCheck->isTrue()) {
                 newTerm = EqExpr::create(

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -238,6 +238,20 @@ class SubsumptionTableEntry {
 
   std::set<const Array *> existentials;
 
+  /// \brief A procedure for building subsumption check constraints using
+  /// symbolically-addressed store elements
+  ///
+  /// \return A null expression upon failure, otherwise the constructed
+  /// constraint
+  ref<Expr> makeConstraint(
+      ExecutionState &state, ref<TxInterpolantValue> tabledValue,
+      ref<TxInterpolantValue> stateValue, ref<Expr> tabledOffset,
+      ref<Expr> stateOffset, std::map<ref<TxInterpolantValue>,
+                                      std::set<ref<Expr> > > &corePointerValues,
+      std::set<ref<TxInterpolantValue> > &coreExactPointerValues,
+      std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
+      int debugSubsumptionLevel) const;
+
   /// \brief Test for the existence of a variable in a set in an expression.
   ///
   /// \param existentials A set of variables (KLEE arrays).

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -179,8 +179,9 @@ public:
 /// subset of the path condition (the SubsumptionTableEntry#interpolant
 /// field), plus the fragment of memory (allocations). They are components
 /// that are needed to ensure the previously-seen conclusions. The memory
-/// fragments are stored in either SubsumptionTableEntry#concreteAddressStore
-/// or SubsumptionTableEntry#symbolicAddressStore, depending on whether
+/// fragments are stored in either
+/// SubsumptionTableEntry#concretelyAddressedStore
+/// or SubsumptionTableEntry#symbolicallyAddressedStore, depending on whether
 /// the memory fragment is concretely addressed or symbolically addressed.
 /// Both fields are multi-level maps that are first indexed by the LLVM
 /// value that represents the allocation (e.g., the call to <b>malloc</b>,
@@ -221,15 +222,15 @@ class SubsumptionTableEntry {
   };
 #endif
 
-  static Statistic concreteStoreExpressionBuildTime;
-  static Statistic symbolicStoreExpressionBuildTime;
+  static Statistic concretelyAddressedStoreExpressionBuildTime;
+  static Statistic symbolicallyAddressedStoreExpressionBuildTime;
   static Statistic solverAccessTime;
 
   ref<Expr> interpolant;
 
-  TxStore::TopInterpolantStore concreteAddressStore;
+  TxStore::TopInterpolantStore concretelyAddressedStore;
 
-  TxStore::TopInterpolantStore symbolicAddressStore;
+  TxStore::TopInterpolantStore symbolicallyAddressedStore;
 
   std::set<const Array *> existentials;
 
@@ -311,8 +312,8 @@ class SubsumptionTableEntry {
                                        ref<Expr> equalities);
 
   bool empty() {
-    return interpolant.isNull() && concreteAddressStore.empty() &&
-           symbolicAddressStore.empty();
+    return interpolant.isNull() && concretelyAddressedStore.empty() &&
+           symbolicallyAddressedStore.empty();
   }
 
   /// \brief For printing member functions running time statistics,

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -228,6 +228,10 @@ class SubsumptionTableEntry {
 
   ref<Expr> interpolant;
 
+  TxStore::LowerInterpolantStore concretelyAddressedHistoricalStore;
+
+  TxStore::LowerInterpolantStore symbolicallyAddressedHistoricalStore;
+
   TxStore::TopInterpolantStore concretelyAddressedStore;
 
   TxStore::TopInterpolantStore symbolicallyAddressedStore;
@@ -329,10 +333,13 @@ public:
 
   ~SubsumptionTableEntry();
 
-  bool subsumed(TimingSolver *solver, ExecutionState &state, double timeout,
-                TxStore::TopInterpolantStore &concretelyAddressedStore,
-                TxStore::TopInterpolantStore &symbolicallyAddressedStore,
-                int debugSubsumptionLevel);
+  bool subsumed(
+      TimingSolver *solver, ExecutionState &state, double timeout,
+      TxStore::TopInterpolantStore &_concretelyAddressedStore,
+      TxStore::TopInterpolantStore &_symbolicallyAddressedStore,
+      TxStore::LowerInterpolantStore &_concretelyAddressedHistoricalStore,
+      TxStore::LowerInterpolantStore &_symbolicallyAddressedHistoricalStore,
+      int debugSubsumptionLevel);
 
   /// Tests if the argument is a variable. A variable here is defined to be
   /// either a symbolic concatenation or a symbolic read. A concatenation in
@@ -499,7 +506,10 @@ public:
   void getStoredExpressions(
       const std::vector<llvm::Instruction *> &callHistory,
       TxStore::TopInterpolantStore &concretelyAddressedStore,
-      TxStore::TopInterpolantStore &symbolicallyAddressedStore) const;
+      TxStore::TopInterpolantStore &symbolicallyAddressedStore,
+      TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
+      TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore)
+      const;
 
   /// \brief This retrieves the allocations known at this state, and the
   /// expressions stored in the allocations, as long as the allocation is
@@ -516,7 +526,10 @@ public:
       const std::vector<llvm::Instruction *> &callHistory,
       std::set<const Array *> &replacements,
       TxStore::TopInterpolantStore &concretelyAddressedStore,
-      TxStore::TopInterpolantStore &symbolicallyAddressedStore) const;
+      TxStore::TopInterpolantStore &symbolicallyAddressedStore,
+      TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
+      TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore)
+      const;
 
   void incInstructionsDepth();
 

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -253,6 +253,13 @@ ref<Expr> TxInterpolantValue::getBoundsCheck(
 
   assert(useBound() && "bounds check must be enabled for this pointer");
 
+  if (allocationBounds.empty()) {
+    assert(!allocationOffsets.empty() && "offsets should not be empty");
+
+    // This means there is no constraint on the bounds
+    return ConstantExpr::create(1, Expr::Bool);
+  }
+
   // In principle, for a state to be subsumed, the subsuming state must be
   // weaker, which in this case means that it should specify less allocations,
   // so all allocations in the subsuming (this), should be specified by the

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -124,15 +124,15 @@ void TxVariable::print(llvm::raw_ostream &stream,
   std::string tabsNext = appendTab(prefix);
 
   stream << prefix << "function/value: ";
-  if (outputFunctionName(context->getValue(), stream))
+  if (outputFunctionName(allocInfo->getContext()->getValue(), stream))
     stream << "/";
-  context->getValue()->print(stream);
+  allocInfo->getContext()->getValue()->print(stream);
   stream << "\n";
 
   stream << prefix << "stack:\n";
   for (std::vector<llvm::Instruction *>::const_reverse_iterator
-           it = context->getCallHistory().rbegin(),
-           ib = it, ie = context->getCallHistory().rend();
+           it = allocInfo->getContext()->getCallHistory().rbegin(),
+           ib = it, ie = allocInfo->getContext()->getCallHistory().rend();
        it != ie; ++it) {
     stream << tabsNext;
     (*it)->print(stream);

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -558,6 +558,12 @@ void TxInterpolantValue::print(llvm::raw_ostream &stream,
   std::string nextTabs = appendTab(prefix);
   bool offsetDisplayed = false;
 
+  stream << prefix << "function/value: ";
+  if (outputFunctionName(value, stream))
+      stream << "/";
+  value->print(stream);
+  stream << "\n";
+
   if (!doNotUseBound && !allocationBounds.empty()) {
     stream << prefix << "BOUNDS:";
     for (std::map<ref<AllocationInfo>, std::set<ref<Expr> > >::const_iterator

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -573,7 +573,7 @@ void TxStateAddress::print(llvm::raw_ostream &stream,
                            const std::string &prefix) const {
   std::string tabsNext = appendTab(prefix);
 
-  interpolantStyleAddress->print(stream, prefix);
+  variable->print(stream, prefix);
   stream << "\n";
   stream << prefix << "address";
   if (!llvm::isa<ConstantExpr>(address))

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -222,9 +222,10 @@ void TxInterpolantValue::init(llvm::Value *_value, ref<Expr> _expr,
   }
 }
 
-ref<Expr> TxInterpolantValue::getBoundsCheck(ref<TxInterpolantValue> stateValue,
-                                             std::set<ref<Expr> > &bounds,
-                                             int debugSubsumptionLevel) const {
+ref<Expr> TxInterpolantValue::getBoundsCheck(
+    ref<TxInterpolantValue> stateValue, std::set<ref<Expr> > &bounds,
+    std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
+    int debugSubsumptionLevel) const {
   ref<Expr> res;
 #ifdef ENABLE_Z3
 
@@ -323,9 +324,10 @@ ref<Expr> TxInterpolantValue::getBoundsCheck(ref<TxInterpolantValue> stateValue,
   return res;
 }
 
-ref<Expr>
-TxInterpolantValue::getOffsetsCheck(ref<TxInterpolantValue> stateValue,
-                                    int debugSubsumptionLevel) const {
+ref<Expr> TxInterpolantValue::getOffsetsCheck(
+    ref<TxInterpolantValue> stateValue,
+    std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
+    int debugSubsumptionLevel) const {
   ref<Expr> res;
 #ifdef ENABLE_Z3
 

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -32,6 +32,27 @@ using namespace klee;
 
 namespace klee {
 
+bool AllocationInfo::translate(
+    ref<AllocationInfo> other,
+    std::map<ref<AllocationInfo>, ref<AllocationInfo> > &table) const {
+  ref<AllocationInfo> self(new AllocationInfo(base, size));
+
+  if (self == other)
+    return true;
+
+  std::map<ref<AllocationInfo>, ref<AllocationInfo> >::const_iterator it =
+      table.find(self);
+  if (it != table.end()) {
+    if (it->second != other) {
+      return false;
+    }
+    return true;
+  }
+
+  table[self] = other;
+  return true;
+}
+
 int AllocationInfo::compare(const AllocationInfo &other) const {
   if (base == other.base) {
     if (size == other.size) {

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -59,8 +59,8 @@ void AllocationContext::print(llvm::raw_ostream &stream,
 
 /**/
 
-void TxInterpolantAddress::print(llvm::raw_ostream &stream,
-                                 const std::string &prefix) const {
+void TxVariable::print(llvm::raw_ostream &stream,
+                       const std::string &prefix) const {
   std::string tabsNext = appendTab(prefix);
 
   stream << prefix << "function/value: ";

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -23,8 +23,10 @@
 #include "klee/util/TxPrintUtil.h"
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
+#include <llvm/IR/Function.h>
 #include <llvm/IR/Type.h>
 #else
+#include <llvm/Function.h>
 #include <llvm/Type.h>
 #endif
 
@@ -103,6 +105,13 @@ void AllocationContext::print(llvm::raw_ostream &stream,
   std::string tabs = makeTabs(1);
   if (value) {
     stream << prefix << "Location: ";
+    if (llvm::Instruction *inst = llvm::dyn_cast<llvm::Instruction>(value)) {
+      if (llvm::BasicBlock *bb = inst->getParent()) {
+        if (llvm::Function *f = bb->getParent()) {
+          stream << f->getName().str() << "/";
+        }
+      }
+    }
     value->print(stream);
   }
   if (callHistory.size() > 0) {

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -562,7 +562,8 @@ TxStateAddress::create(ref<TxStateAddress> loc,
                        std::set<const Array *> &replacements) {
   ref<Expr> _address(
       ShadowArray::getShadowExpression(loc->address, replacements)),
-      _base(ShadowArray::getShadowExpression(loc->base, replacements)),
+      _base(ShadowArray::getShadowExpression(loc->allocInfo->getBase(),
+                                             replacements)),
       _offset(ShadowArray::getShadowExpression(loc->getOffset(), replacements));
   ref<TxStateAddress> ret(new TxStateAddress(loc->getContext(), _address, _base,
                                              _offset, loc->size));
@@ -582,10 +583,10 @@ void TxStateAddress::print(llvm::raw_ostream &stream,
   address->print(stream);
   stream << "\n";
   stream << prefix << "base: ";
-  if (!llvm::isa<ConstantExpr>(base))
+  if (!llvm::isa<ConstantExpr>(allocInfo->getBase()))
     stream << " (symbolic)";
   stream << ": ";
-  base->print(stream);
+  allocInfo->print(stream);
   stream << "\n";
   stream << prefix
          << "pointer to location object: " << reinterpret_cast<uintptr_t>(this);

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -700,7 +700,7 @@ TxStateAddress::create(ref<TxStateAddress> loc,
                        std::set<const Array *> &replacements) {
   ref<Expr> _address(
       ShadowArray::getShadowExpression(loc->address, replacements)),
-      _base(ShadowArray::getShadowExpression(loc->allocInfo->getBase(),
+      _base(ShadowArray::getShadowExpression(loc->variable->getBase(),
                                              replacements)),
       _offset(ShadowArray::getShadowExpression(loc->getOffset(), replacements));
   ref<TxStateAddress> ret(new TxStateAddress(loc->getContext(), _address, _base,
@@ -721,10 +721,10 @@ void TxStateAddress::print(llvm::raw_ostream &stream,
   address->print(stream);
   stream << "\n";
   stream << prefix << "base: ";
-  if (!llvm::isa<ConstantExpr>(allocInfo->getBase()))
+  if (!llvm::isa<ConstantExpr>(variable->getBase()))
     stream << " (symbolic)";
   stream << ": ";
-  allocInfo->print(stream);
+  variable->print(stream);
   stream << "\n";
   stream << prefix
          << "pointer to location object: " << reinterpret_cast<uintptr_t>(this);

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -129,14 +129,19 @@ void TxVariable::print(llvm::raw_ostream &stream,
   allocInfo->getContext()->getValue()->print(stream);
   stream << "\n";
 
-  stream << prefix << "stack:\n";
-  for (std::vector<llvm::Instruction *>::const_reverse_iterator
-           it = allocInfo->getContext()->getCallHistory().rbegin(),
-           ib = it, ie = allocInfo->getContext()->getCallHistory().rend();
-       it != ie; ++it) {
-    stream << tabsNext;
-    (*it)->print(stream);
+  stream << prefix << "stack:";
+  if (allocInfo->getContext()->getCallHistory().empty()) {
+    stream << " (empty)\n";
+  } else {
     stream << "\n";
+    for (std::vector<llvm::Instruction *>::const_reverse_iterator
+             it = allocInfo->getContext()->getCallHistory().rbegin(),
+             ib = it, ie = allocInfo->getContext()->getCallHistory().rend();
+         it != ie; ++it) {
+      stream << tabsNext;
+      (*it)->print(stream);
+      stream << "\n";
+    }
   }
   stream << prefix << "offset";
   if (!llvm::isa<ConstantExpr>(this->offset))

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -735,11 +735,11 @@ void TxStateAddress::print(llvm::raw_ostream &stream,
   stream << ": ";
   address->print(stream);
   stream << "\n";
-  stream << prefix << "base: ";
+  stream << prefix << "base";
   if (!llvm::isa<ConstantExpr>(variable->getBase()))
     stream << " (symbolic)";
   stream << ": ";
-  variable->print(stream);
+  variable->getBase()->print(stream);
   stream << "\n";
   stream << prefix
          << "pointer to location object: " << reinterpret_cast<uintptr_t>(this);

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -251,6 +251,8 @@ ref<Expr> TxInterpolantValue::getBoundsCheck(
   ref<Expr> res;
 #ifdef ENABLE_Z3
 
+  assert(useBound() && "bounds check must be enabled for this pointer");
+
   // In principle, for a state to be subsumed, the subsuming state must be
   // weaker, which in this case means that it should specify less allocations,
   // so all allocations in the subsuming (this), should be specified by the

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -35,7 +35,8 @@ namespace klee {
 bool AllocationInfo::translate(
     ref<AllocationInfo> other,
     std::map<ref<AllocationInfo>, ref<AllocationInfo> > &table) const {
-  ref<AllocationInfo> self(new AllocationInfo(base, size));
+  ref<AllocationContext> _context(context);
+  ref<AllocationInfo> self(new AllocationInfo(_context, base, size));
 
   if (self == other)
     return true;


### PR DESCRIPTION
For resolving issue #278. This one is ready for review and merging. `make check` has been successful. Also, `basic/malloc3.c` of `klee-examples` expectedly results in a lot of subsumptions making the tree very thin, and `basic/pointer_struct1.c` no longer hiding any error due to over-subsumption. This replaces #281 .

**EDIT: Mention of #281**