### PR TITLE
Reimplementation of memory domination

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -42,6 +42,8 @@ class TxStateAddress;
 
 class TxStateValue;
 
+class TxStoreEntry;
+
 class AllocationContext {
 
 public:
@@ -630,6 +632,9 @@ private:
   /// \brief All load addresses, transitively
   std::set<ref<TxStateAddress> > allLoadAddresses;
 
+  /// \brief Store entries this value is dependent upon
+  std::set<ref<TxStoreEntry> > entryList;
+
   TxStateValue(llvm::Value *value,
                const std::vector<llvm::Instruction *> &_callHistory,
                ref<Expr> _valueExpr)
@@ -669,31 +674,23 @@ public:
 
   void disableBoundInterpolation() { doNotInterpolateBound = true; }
 
-  void setLoadAddress(ref<TxStateValue> _loadAddress) {
-    loadAddress = _loadAddress;
-    allLoadAddresses.insert(_loadAddress->getLocations().begin(),
-                            _loadAddress->getLocations().end());
-  }
+  void setLoadAddress(ref<TxStateValue> _loadAddress);
 
   ref<TxStateValue> getLoadAddress() { return loadAddress; }
 
-  void setStoreAddress(ref<TxStateValue> _storeAddress) {
-    storeAddress = _storeAddress;
-    allLoadAddresses.insert(_storeAddress->getLocations().begin(),
-                            _storeAddress->getLocations().end());
-  }
+  void setStoreAddress(ref<TxStateValue> _storeAddress);
 
   ref<TxStateValue> getStoreAddress() { return storeAddress; }
 
   /// \brief The core routine for adding flow dependency between source and
   /// target value
-  void addDependency(ref<TxStateValue> source, ref<TxStateAddress> via) {
-    sources[source] = via;
-    if (via.isNull()) {
-      allLoadAddresses.insert(source->allLoadAddresses.begin(),
-                              source->allLoadAddresses.end());
-    }
-  }
+  void addDependency(ref<TxStateValue> source, ref<TxStateAddress> via);
+
+  /// \brief Add the store entry used to store the value used to compute this
+  /// value
+  void addStoreEntry(ref<TxStoreEntry> entry);
+
+  const std::set<ref<TxStoreEntry> > &getEntryList() const;
 
   const std::map<ref<TxStateValue>, ref<TxStateAddress> > &getSources() {
     return sources;

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -642,23 +642,6 @@ private:
         id(reinterpret_cast<uint64_t>(this)), callHistory(_callHistory),
         doNotInterpolateBound(false), directUseCount(0) {}
 
-  /// \brief Print the content of the object, but without showing its source
-  /// values.
-  ///
-  /// \param stream The stream to print the data to.
-  void printNoDependency(llvm::raw_ostream &stream) const {
-    std::string emptyString;
-    printNoDependency(stream, emptyString);
-  }
-
-  /// \brief Print the content of the object, but without showing its source
-  /// values.
-  ///
-  /// \param stream The stream to print the data to.
-  /// \param prefix Padding spaces to print before the actual data.
-  void printNoDependency(llvm::raw_ostream &stream,
-                         const std::string &prefix) const;
-
 public:
   ~TxStateValue() { locations.clear(); }
 
@@ -753,6 +736,20 @@ public:
     return TxInterpolantValue::create(value, valueExpr, canInterpolateBound(),
                                       coreReasons, locations, replacements);
   }
+
+  /// \brief Print minimal information about this object.
+  ///
+  /// \param stream The stream to print the data to.
+  void printMinimal(llvm::raw_ostream &stream) const {
+    std::string emptyString;
+    printMinimal(stream, emptyString);
+  }
+
+  /// \brief Print minimal information about this object.
+  ///
+  /// \param stream The stream to print the data to.
+  /// \param prefix Padding spaces to print before the actual data.
+  void printMinimal(llvm::raw_ostream &stream, const std::string &prefix) const;
 
   /// \brief Print the content of the object into a stream
   ///

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -674,10 +674,14 @@ public:
 
   void disableBoundInterpolation() { doNotInterpolateBound = true; }
 
+  /// \brief Set the address this value was loaded from for inclusion in the
+  /// interpolant
   void setLoadAddress(ref<TxStateValue> _loadAddress);
 
   ref<TxStateValue> getLoadAddress() { return loadAddress; }
 
+  /// \brief Set the address this value was stored into for inclusion in the
+  /// interpolant
   void setStoreAddress(ref<TxStateValue> _storeAddress);
 
   ref<TxStateValue> getStoreAddress() { return storeAddress; }

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -677,6 +677,10 @@ public:
   /// value
   void addStoreEntry(ref<TxStoreEntry> entry);
 
+  /// \brief Clear the contents of the list of entries this value was loaded
+  /// from
+  void resetStoreEntryList() { entryList.clear(); }
+
   const std::set<ref<TxStoreEntry> > &getEntryList() const;
 
   const std::map<ref<TxStateValue>, ref<TxStateAddress> > &getSources() {

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -431,7 +431,7 @@ void Dependency::populateArgumentValuesList(
 Dependency::Dependency(
     Dependency *parent, llvm::DataLayout *_targetData,
     std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *_globalAddresses)
-    : parent(parent), targetData(_targetData),
+    : parent(parent), left(0), right(0), targetData(_targetData),
       globalAddresses(_globalAddresses) {
   if (parent) {
     store = TxStore::create(parent->store);

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1197,6 +1197,7 @@ void Dependency::bindReturnValue(llvm::CallInst *site,
 void Dependency::markAllValues(ref<TxStateValue> value,
                                const std::string &reason) {
   markFlow(value, reason);
+  store->markUsed(value->getEntryList());
 }
 
 void Dependency::markAllValues(llvm::Value *val, ref<Expr> expr,
@@ -1207,6 +1208,7 @@ void Dependency::markAllValues(llvm::Value *val, ref<Expr> expr,
     return;
 
   markFlow(value, reason);
+  store->markUsed(value->getEntryList());
 }
 
 bool Dependency::markAllPointerValues(llvm::Value *val, ref<Expr> address,
@@ -1217,7 +1219,9 @@ bool Dependency::markAllPointerValues(llvm::Value *val, ref<Expr> address,
   if (value.isNull())
     return false;
 
-  return markPointerFlow(value, value, bounds, reason);
+  bool ret = markPointerFlow(value, value, bounds, reason);
+  store->markUsed(value->getEntryList());
+  return ret;
 }
 
 /// \brief Tests if bound interpolation shold be enabled

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -860,13 +860,8 @@ void Dependency::execute(llvm::Instruction *instr,
         }
       }
 
-      std::set<ref<TxStateAddress> > locations = addressValue->getLocations();
-
-      for (std::set<ref<TxStateAddress> >::iterator it = locations.begin(),
-                                                    ie = locations.end();
-           it != ie; ++it) {
-        store->updateStore(*it, addressValue, storedValue);
-      }
+      store->updateStore(addressValue->getLocations(), addressValue,
+                         storedValue);
       break;
     }
     case llvm::Instruction::Trunc:
@@ -1070,13 +1065,7 @@ void Dependency::executeMakeSymbolic(
     }
   }
 
-  std::set<ref<TxStateAddress> > locations = addressValue->getLocations();
-
-  for (std::set<ref<TxStateAddress> >::iterator it = locations.begin(),
-                                                ie = locations.end();
-       it != ie; ++it) {
-    store->updateStore(*it, addressValue, storedValue);
-  }
+  store->updateStore(addressValue->getLocations(), addressValue, storedValue);
 }
 
 void Dependency::executePHI(llvm::Instruction *instr,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -169,8 +169,8 @@ namespace klee {
     /// The store
     TxStore *store;
 
-    /// \brief Previous path condition
-    Dependency *parent;
+    /// \brief Parent and left and right children of the dependency information
+    Dependency *parent, *left, *right;
 
     /// \brief Argument values to be passed onto callee
     std::vector<ref<TxStateValue> > argumentValuesList;
@@ -341,6 +341,13 @@ namespace klee {
 
     ~Dependency();
 
+    static Dependency *
+    createRoot(llvm::DataLayout *targetData,
+               std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *
+                   globalAddresses) {
+      return new Dependency(0, targetData, globalAddresses);
+    }
+
     Dependency *cdr() const;
 
     /// \brief This retrieves the locations known at this state, and the
@@ -450,6 +457,12 @@ namespace klee {
 
     /// \brief Tests if bound interpolation shold be enabled
     static bool boundInterpolation(llvm::Value *val = 0);
+
+    /// \brief Set the left child
+    void setLeftChild(Dependency *child) { left = child; }
+
+    /// \brief Set the right child
+    void setRightChild(Dependency *child) { right = child; }
 
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -459,10 +459,16 @@ namespace klee {
     static bool boundInterpolation(llvm::Value *val = 0);
 
     /// \brief Set the left child
-    void setLeftChild(Dependency *child) { left = child; }
+    void setLeftChild(Dependency *child) {
+      left = child;
+      store->setLeftChild(child->store);
+    }
 
     /// \brief Set the right child
-    void setRightChild(Dependency *child) { right = child; }
+    void setRightChild(Dependency *child) {
+      right = child;
+      store->setRightChild(child->store);
+    }
 
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -181,8 +181,8 @@ namespace klee {
     /// \brief The data layout of the analysis target program
     llvm::DataLayout *targetData;
 
-    /// Map of globals to their bound address. This also includes
-    /// globals that have no representative object (i.e. functions). This member
+    /// \brief Map of globals to their bound address. This also includes globals
+    /// that have no representative object (i.e. functions). This member
     /// variable is just a pointer to the one in klee::Executor.
     std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *globalAddresses;
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -363,6 +363,9 @@ namespace klee {
     /// bound ones.
     /// \param coreOnly Indicates whether we are retrieving only data
     /// for locations relevant to an unsatisfiability core.
+    /// \param leftRetrieval Whether the retrieval is requested by the left
+    /// child of the store, otherwise, we assume it is requested by the right
+    /// child of the store.
     /// \param [out] concretelyAddressedStore The output concretely-addressed
     /// store.
     /// \param [out] symbolicallyAddressedStore The output
@@ -380,14 +383,16 @@ namespace klee {
     void getStoredExpressions(
         const std::vector<llvm::Instruction *> &callHistory,
         std::set<const Array *> &replacements, bool coreOnly,
+        bool leftRetrieval,
         TxStore::TopInterpolantStore &concretelyAddressedStore,
         TxStore::TopInterpolantStore &symbolicallyAddressedStore,
         TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
         TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
-      store->getStoredExpressions(
-          callHistory, replacements, coreOnly, concretelyAddressedStore,
-          symbolicallyAddressedStore, concretelyAddressedHistoricalStore,
-          symbolicallyAddressedHistoricalStore);
+      store->getStoredExpressions(callHistory, replacements, coreOnly,
+                                  leftRetrieval, concretelyAddressedStore,
+                                  symbolicallyAddressedStore,
+                                  concretelyAddressedHistoricalStore,
+                                  symbolicallyAddressedHistoricalStore);
     }
 
     ref<TxStateValue>

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -323,6 +323,10 @@ void TxStore::updateStore(const std::set<ref<TxStateAddress> > &locations,
   if (locations.empty())
     return;
 
+  // Here we also mark the entries used to build the value as used. Only used
+  // entries will be in the interpolant
+  markUsed(value->getEntryList());
+
   // We want to renew the table entry list, so we first remove the old ones
   value->resetStoreEntryList();
 
@@ -365,11 +369,6 @@ void TxStore::updateStore(const std::set<ref<TxStateAddress> > &locations,
       value->addStoreEntry(entry);
     }
   }
-
-  // Here we also mark the entries used to build the value and the address as
-  // used. Only used entries will be in the interpolant
-  markUsed(value->getEntryList());
-  markUsed(address->getEntryList());
 }
 
 void TxStore::markUsed(const std::set<ref<TxStoreEntry> > &entryList) {

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -60,16 +60,17 @@ TxStore::MiddleStateStore::find(ref<TxStateAddress> loc) const {
 
 bool TxStore::MiddleStateStore::updateStore(ref<TxStateAddress> loc,
                                             ref<TxStateValue> address,
-                                            ref<TxStateValue> value) {
+                                            ref<TxStateValue> value,
+                                            uint64_t _depth) {
   if (loc->getAllocationInfo() != allocInfo)
     return false;
 
   if (loc->hasConstantAddress()) {
     concretelyAddressedStore[loc->getAsVariable()] =
-        ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
+        ref<TxStoreEntry>(new TxStoreEntry(loc, address, value, _depth));
   } else {
     symbolicallyAddressedStore[loc->getAsVariable()] =
-        ref<TxStoreEntry>(new TxStoreEntry(loc, address, value));
+        ref<TxStoreEntry>(new TxStoreEntry(loc, address, value, _depth));
   }
   return true;
 }
@@ -303,7 +304,7 @@ void TxStore::updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
   if (middleStoreIter != store.end()) {
     MiddleStateStore &middleStore = middleStoreIter->second;
     if (middleStore.hasAllocationInfo(loc->getAllocationInfo())) {
-      middleStore.updateStore(loc, address, value);
+      middleStore.updateStore(loc, address, value, depth);
       return;
     }
 
@@ -317,7 +318,7 @@ void TxStore::updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
   MiddleStateStore newMiddleStateStore(loc->getAllocationInfo());
   store[loc->getContext()] = newMiddleStateStore;
   MiddleStateStore &middleStateStore = store[loc->getContext()];
-  middleStateStore.updateStore(loc, address, value);
+  middleStateStore.updateStore(loc, address, value, depth);
 }
 
 /// \brief Print the content of the object to the LLVM error stream

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -138,15 +138,15 @@ ref<TxStoreEntry> TxStore::find(ref<TxStateAddress> loc) const {
 
 void TxStore::getStoredExpressions(
     const std::vector<llvm::Instruction *> &callHistory,
-    std::set<const Array *> &replacements, bool coreOnly,
+    std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
     TopInterpolantStore &_concretelyAddressedStore,
     TopInterpolantStore &_symbolicallyAddressedStore,
     LowerInterpolantStore &_concretelyAddressedHistoricalStore,
     LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const {
-  getConcreteStore(callHistory, replacements, coreOnly,
+  getConcreteStore(callHistory, replacements, coreOnly, leftRetrieval,
                    _concretelyAddressedStore,
                    _concretelyAddressedHistoricalStore);
-  getSymbolicStore(callHistory, replacements, coreOnly,
+  getSymbolicStore(callHistory, replacements, coreOnly, leftRetrieval,
                    _symbolicallyAddressedStore,
                    _symbolicallyAddressedHistoricalStore);
 }
@@ -201,7 +201,7 @@ TxStore::symbolicToInterpolant(ref<TxVariable> variable,
 
 void TxStore::getConcreteStore(
     const std::vector<llvm::Instruction *> &callHistory,
-    std::set<const Array *> &replacements, bool coreOnly,
+    std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
     TopInterpolantStore &_concretelyAddressedStore,
     LowerInterpolantStore &_concretelyAddressedHistoricalStore) const {
   for (TopStateStore::const_iterator it = internalStore.begin(),
@@ -248,7 +248,7 @@ void TxStore::getConcreteStore(
 
 void TxStore::getSymbolicStore(
     const std::vector<llvm::Instruction *> &callHistory,
-    std::set<const Array *> &replacements, bool coreOnly,
+    std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
     TopInterpolantStore &_symbolicallyAddressedStore,
     LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const {
   for (TopStateStore::const_iterator it = internalStore.begin(),

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -27,6 +27,7 @@ void TxStoreEntry::print(llvm::raw_ostream &stream,
                          const std::string &prefix) const {
   std::string tabsNext = appendTab(prefix);
 
+  stream << prefix << "creation depth: " << depth << "\n";
   stream << prefix << "address:\n";
   address->print(stream, tabsNext);
   stream << "\n";

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -359,45 +359,40 @@ void TxStore::markUsed(const std::set<ref<TxStoreEntry> > &entryList) {
                                                     ie = entryList.end();
        it != ie; ++it) {
     uint64_t entryDepth = (*it)->getDepth();
-    if (entryDepth == depth) {
-      usedByLeftPath.insert(*it);
-      usedByRightPath.insert(*it);
-      continue;
-    } else {
-      assert(entryDepth < depth && "invalid depth");
 
-      // We now register the used entry as used after it was instantiated in
-      // previous depth levels
-      TxStore *prev = 0, *current = parent;
-      while (current && entryDepth <= current->depth) {
-        const TxStore *constPrev;
-        if (!prev) {
-          constPrev = this;
-        } else {
-          constPrev = prev;
-        }
-        if (current->left == constPrev) {
-          std::set<ref<TxStoreEntry> >::iterator usedEntryIter =
-              current->usedByLeftPath.find(*it);
-          if (usedEntryIter == current->usedByLeftPath.end()) {
-            current->usedByLeftPath.insert(*it);
-          } else {
-            break;
-          }
-        } else if (current->right == constPrev) {
-          std::set<ref<TxStoreEntry> >::iterator usedEntryIter =
-              current->usedByRightPath.find(*it);
-          if (usedEntryIter == current->usedByRightPath.end()) {
-            current->usedByRightPath.insert(*it);
-          } else {
-            break;
-          }
-        } else {
-          assert(!"child is neither left not right");
-        }
-        prev = current;
-        current = current->parent;
+    assert(entryDepth <= depth && "invalid depth");
+
+    // We now register the used entry as used after it was instantiated in
+    // previous depth levels
+    TxStore *prev = 0, *current = parent;
+    while (current && entryDepth <= current->depth) {
+      const TxStore *constPrev;
+      if (!prev) {
+        constPrev = this;
+      } else {
+        constPrev = prev;
       }
+      if (current->left == constPrev) {
+        std::set<ref<TxStoreEntry> >::iterator usedEntryIter =
+            current->usedByLeftPath.find(*it);
+        if (usedEntryIter == current->usedByLeftPath.end()) {
+          current->usedByLeftPath.insert(*it);
+        } else {
+          break;
+        }
+      } else if (current->right == constPrev) {
+        std::set<ref<TxStoreEntry> >::iterator usedEntryIter =
+            current->usedByRightPath.find(*it);
+        if (usedEntryIter == current->usedByRightPath.end()) {
+          current->usedByRightPath.insert(*it);
+        } else {
+          break;
+        }
+      } else {
+        assert(!"child is neither left not right");
+      }
+      prev = current;
+      current = current->parent;
     }
   }
 }

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -59,25 +59,27 @@ TxStore::MiddleStateStore::find(ref<TxStateAddress> loc) const {
   return ret;
 }
 
-bool TxStore::MiddleStateStore::updateStore(ref<TxStateAddress> loc,
-                                            ref<TxStateValue> address,
-                                            ref<TxStateValue> value,
-                                            uint64_t _depth) {
-  if (loc->getAllocationInfo() != allocInfo)
-    return false;
+ref<TxStoreEntry> TxStore::MiddleStateStore::updateStore(
+    ref<TxStateAddress> loc, ref<TxStateValue> address, ref<TxStateValue> value,
+    uint64_t _depth) {
+  ref<TxStoreEntry> ret;
 
-  ref<TxStoreEntry> entry(new TxStoreEntry(loc, address, value, _depth));
+  // Return null entry in case allocation info do not match
+  if (loc->getAllocationInfo() != allocInfo)
+    return ret;
+
+  ret = ref<TxStoreEntry>(new TxStoreEntry(loc, address, value, _depth));
 
   // We associate this value with the store entry, signifying that the entry is
   // important whenever the value is used. This is used for computing the
   // interpolant.
-  value->addStoreEntry(entry);
+  value->addStoreEntry(ret);
   if (loc->hasConstantAddress()) {
-    concretelyAddressedStore[loc->getAsVariable()] = entry;
+    concretelyAddressedStore[loc->getAsVariable()] = ret;
   } else {
-    symbolicallyAddressedStore[loc->getAsVariable()] = entry;
+    symbolicallyAddressedStore[loc->getAsVariable()] = ret;
   }
-  return true;
+  return ret;
 }
 
 void TxStore::MiddleStateStore::print(llvm::raw_ostream &stream,

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -378,7 +378,10 @@ void TxStore::markUsed(const std::set<ref<TxStoreEntry> > &entryList) {
        it != ie; ++it) {
     uint64_t entryDepth = (*it)->getDepth();
 
-    assert(entryDepth <= depth && "invalid depth");
+    if (entryDepth == depth)
+      continue;
+
+    assert(entryDepth < depth && "invalid depth");
 
     // We now register the used entry as used after it was instantiated in
     // previous depth levels

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -143,12 +143,10 @@ void TxStore::getStoredExpressions(
     TopInterpolantStore &_symbolicallyAddressedStore,
     LowerInterpolantStore &_concretelyAddressedHistoricalStore,
     LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const {
-  getConcreteStore(callHistory, internalStore,
-                   concretelyAddressedHistoricalStore, replacements, coreOnly,
+  getConcreteStore(callHistory, replacements, coreOnly,
                    _concretelyAddressedStore,
                    _concretelyAddressedHistoricalStore);
-  getSymbolicStore(callHistory, internalStore,
-                   symbolicallyAddressedHistoricalStore, replacements, coreOnly,
+  getSymbolicStore(callHistory, replacements, coreOnly,
                    _symbolicallyAddressedStore,
                    _symbolicallyAddressedHistoricalStore);
 }
@@ -203,18 +201,18 @@ TxStore::symbolicToInterpolant(ref<TxVariable> variable,
 
 void TxStore::getConcreteStore(
     const std::vector<llvm::Instruction *> &callHistory,
-    const TopStateStore &store, const LowerStateStore &historicalStore,
     std::set<const Array *> &replacements, bool coreOnly,
-    TopInterpolantStore &concretelyAddressedStore,
-    LowerInterpolantStore &concretelyAddressedHistoricalStore) {
-  for (TopStateStore::const_iterator it = store.begin(), ie = store.end();
+    TopInterpolantStore &_concretelyAddressedStore,
+    LowerInterpolantStore &_concretelyAddressedHistoricalStore) const {
+  for (TopStateStore::const_iterator it = internalStore.begin(),
+                                     ie = internalStore.end();
        it != ie; ++it) {
     TopInterpolantStore::iterator storeIter =
-        concretelyAddressedStore.find(it->first);
+        _concretelyAddressedStore.find(it->first);
 
     const MiddleStateStore &middleStore = it->second;
 
-    if (storeIter == concretelyAddressedStore.end()) {
+    if (storeIter == _concretelyAddressedStore.end()) {
       LowerInterpolantStore map;
 
       for (LowerStateStore::const_iterator it1 = middleStore.concreteBegin(),
@@ -227,7 +225,7 @@ void TxStore::getConcreteStore(
       // The map is only added when it is not empty; this is to avoid entries
       // mapped to empty structure in concretelyAddressedStore
       if (!map.empty()) {
-        concretelyAddressedStore[it->first] = map;
+        _concretelyAddressedStore[it->first] = map;
       }
     } else {
       for (LowerStateStore::const_iterator it1 = middleStore.concreteBegin(),
@@ -239,28 +237,29 @@ void TxStore::getConcreteStore(
     }
   }
 
-  for (LowerStateStore::const_iterator it = historicalStore.begin(),
-                                       ie = historicalStore.end();
+  for (LowerStateStore::const_iterator
+           it = concretelyAddressedHistoricalStore.begin(),
+           ie = concretelyAddressedHistoricalStore.end();
        it != ie; ++it) {
     concreteToInterpolant(it->first, it->second, replacements, coreOnly,
-                          concretelyAddressedHistoricalStore);
+                          _concretelyAddressedHistoricalStore);
   }
 }
 
 void TxStore::getSymbolicStore(
     const std::vector<llvm::Instruction *> &callHistory,
-    const TopStateStore &store, const LowerStateStore &historicalStore,
     std::set<const Array *> &replacements, bool coreOnly,
-    TopInterpolantStore &symbolicallyAddressedStore,
-    LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
-  for (TopStateStore::const_iterator it = store.begin(), ie = store.end();
+    TopInterpolantStore &_symbolicallyAddressedStore,
+    LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const {
+  for (TopStateStore::const_iterator it = internalStore.begin(),
+                                     ie = internalStore.end();
        it != ie; ++it) {
     TopInterpolantStore::iterator storeIter =
-        symbolicallyAddressedStore.find(it->first);
+        _symbolicallyAddressedStore.find(it->first);
 
     const MiddleStateStore &middleStore = it->second;
 
-    if (storeIter == symbolicallyAddressedStore.end()) {
+    if (storeIter == _symbolicallyAddressedStore.end()) {
       LowerInterpolantStore map;
 
       for (LowerStateStore::const_iterator it1 = middleStore.symbolicBegin(),
@@ -273,7 +272,7 @@ void TxStore::getSymbolicStore(
       // The map is only added when it is not empty; this is to avoid entries
       // mapped to empty structure in symbolicallyAddressedStore
       if (!map.empty()) {
-        symbolicallyAddressedStore[it->first] = map;
+        _symbolicallyAddressedStore[it->first] = map;
       }
     } else {
       for (LowerStateStore::const_iterator it1 = middleStore.symbolicBegin(),
@@ -285,11 +284,12 @@ void TxStore::getSymbolicStore(
     }
   }
 
-  for (LowerStateStore::const_iterator it = historicalStore.begin(),
-                                       ie = historicalStore.end();
+  for (LowerStateStore::const_iterator
+           it = symbolicallyAddressedHistoricalStore.begin(),
+           ie = symbolicallyAddressedHistoricalStore.end();
        it != ie; ++it) {
     symbolicToInterpolant(it->first, it->second, replacements, coreOnly,
-                          symbolicallyAddressedHistoricalStore);
+                          _symbolicallyAddressedHistoricalStore);
   }
 }
 

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -17,6 +17,7 @@
 #include "TxStore.h"
 
 #include "klee/CommandLine.h"
+#include "klee/Internal/Module/TxValues.h"
 #include "klee/util/TxPrintUtil.h"
 
 using namespace klee;

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -31,7 +31,7 @@ void TxStoreEntry::print(llvm::raw_ostream &stream,
   address->print(stream, tabsNext);
   stream << "\n";
   stream << prefix << "content:\n";
-  content->print(stream, tabsNext);
+  content->printMinimal(stream, tabsNext);
 }
 
 /**/

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -65,12 +65,16 @@ bool TxStore::MiddleStateStore::updateStore(ref<TxStateAddress> loc,
   if (loc->getAllocationInfo() != allocInfo)
     return false;
 
+  ref<TxStoreEntry> entry(new TxStoreEntry(loc, address, value, _depth));
+
+  // We associate this value with the store entry, signifying that the entry is
+  // important whenever the value is used. This is used for computing the
+  // interpolant.
+  value->addStoreEntry(entry);
   if (loc->hasConstantAddress()) {
-    concretelyAddressedStore[loc->getAsVariable()] =
-        ref<TxStoreEntry>(new TxStoreEntry(loc, address, value, _depth));
+    concretelyAddressedStore[loc->getAsVariable()] = entry;
   } else {
-    symbolicallyAddressedStore[loc->getAsVariable()] =
-        ref<TxStoreEntry>(new TxStoreEntry(loc, address, value, _depth));
+    symbolicallyAddressedStore[loc->getAsVariable()] = entry;
   }
   return true;
 }

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -129,8 +129,9 @@ public:
 
     ref<TxStoreEntry> find(ref<TxStateAddress> loc) const;
 
-    bool updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
-                     ref<TxStateValue> value, uint64_t depth);
+    ref<TxStoreEntry> updateStore(ref<TxStateAddress> loc,
+                                  ref<TxStateValue> address,
+                                  ref<TxStateValue> value, uint64_t depth);
 
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -175,15 +175,15 @@ private:
   /// \brief The parent and left and right children of this store
   TxStore *parent, *left, *right;
 
-  static void concreteToInterpolant(ref<TxVariable> variable,
-                                    ref<TxStoreEntry> entry,
-                                    std::set<const Array *> &replacements,
-                                    bool coreOnly, LowerInterpolantStore &map);
+  void concreteToInterpolant(ref<TxVariable> variable, ref<TxStoreEntry> entry,
+                             std::set<const Array *> &replacements,
+                             bool coreOnly, LowerInterpolantStore &map,
+                             bool leftRetrieval) const;
 
-  static void symbolicToInterpolant(ref<TxVariable> variable,
-                                    ref<TxStoreEntry> entry,
-                                    std::set<const Array *> &replacements,
-                                    bool coreOnly, LowerInterpolantStore &map);
+  void symbolicToInterpolant(ref<TxVariable> variable, ref<TxStoreEntry> entry,
+                             std::set<const Array *> &replacements,
+                             bool coreOnly, LowerInterpolantStore &map,
+                             bool leftRetrieval) const;
 
   void getConcreteStore(
       const std::vector<llvm::Instruction *> &callHistory,

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -157,6 +157,9 @@ private:
   /// \brief The depth level of this store
   uint64_t depth;
 
+  /// \brief The parent of this store
+  TxStore *parent;
+
   static void concreteToInterpolant(ref<TxVariable> variable,
                                     ref<TxStoreEntry> entry,
                                     std::set<const Array *> &replacements,
@@ -184,7 +187,7 @@ private:
                    LowerInterpolantStore &symbolicallyAddressedHistoricalStore);
 
   /// \brief Constructor for an empty store.
-  TxStore() : depth(0) {}
+  TxStore() : depth(0), parent(0) {}
 
 public:
   ~TxStore() {}
@@ -201,6 +204,7 @@ public:
         src->symbolicallyAddressedHistoricalStore;
     ret->internalStore = src->internalStore;
     ret->depth = src->depth + 1;
+    ret->parent = src;
     return ret;
   }
 

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -35,11 +35,14 @@ private:
 
   ref<TxStateValue> content;
 
+  /// \brief The creation depth of this entry
+  uint64_t depth;
+
 public:
   TxStoreEntry(ref<TxStateAddress> _address, ref<TxStateValue> _addressValue,
-               ref<TxStateValue> _content)
+               ref<TxStateValue> _content, uint64_t _depth)
       : refCount(0), address(_address), addressValue(_addressValue),
-        content(_content) {}
+        content(_content), depth(_depth) {}
 
   ~TxStoreEntry() {}
 
@@ -50,6 +53,8 @@ public:
   ref<TxStateValue> getAddressValue() { return addressValue; }
 
   ref<TxStateValue> getContent() { return content; }
+
+  uint64_t getDepth() { return depth; }
 
   void dump() const {
     print(llvm::errs());
@@ -116,7 +121,7 @@ public:
     ref<TxStoreEntry> find(ref<TxStateAddress> loc) const;
 
     bool updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
-                     ref<TxStateValue> value);
+                     ref<TxStateValue> value, uint64_t depth);
 
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -152,7 +152,7 @@ private:
   LowerStateStore symbolicallyAddressedHistoricalStore;
 
   /// \brief The mapping of locations to stored value
-  TopStateStore store;
+  TopStateStore internalStore;
 
   /// \brief The depth level of this store
   uint64_t depth;
@@ -199,7 +199,7 @@ public:
         src->concretelyAddressedHistoricalStore;
     ret->symbolicallyAddressedHistoricalStore =
         src->symbolicallyAddressedHistoricalStore;
-    ret->store = src->store;
+    ret->internalStore = src->internalStore;
     ret->depth = src->depth + 1;
     return ret;
   }

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -56,6 +56,15 @@ public:
 
   uint64_t getDepth() { return depth; }
 
+  /// \brief A simple pointer comparison
+  int compare(const TxStoreEntry &other) const {
+    if (this < &other)
+      return -1;
+    if (this > &other)
+      return 1;
+    return 0;
+  }
+
   void dump() const {
     print(llvm::errs());
     llvm::errs() << "\n";

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -185,21 +185,17 @@ private:
                                     std::set<const Array *> &replacements,
                                     bool coreOnly, LowerInterpolantStore &map);
 
-  static void
-  getConcreteStore(const std::vector<llvm::Instruction *> &callHistory,
-                   const TopStateStore &store,
-                   const LowerStateStore &historicalStore,
-                   std::set<const Array *> &replacements, bool coreOnly,
-                   TopInterpolantStore &concretelyAddressedStore,
-                   LowerInterpolantStore &concretelyAddressedHistoricalStore);
+  void getConcreteStore(
+      const std::vector<llvm::Instruction *> &callHistory,
+      std::set<const Array *> &replacements, bool coreOnly,
+      TopInterpolantStore &_concretelyAddressedStore,
+      LowerInterpolantStore &_concretelyAddressedHistoricalStore) const;
 
-  static void
-  getSymbolicStore(const std::vector<llvm::Instruction *> &callHistory,
-                   const TopStateStore &store,
-                   const LowerStateStore &historicalStore,
-                   std::set<const Array *> &replacements, bool coreOnly,
-                   TopInterpolantStore &symbolicallyAddressedStore,
-                   LowerInterpolantStore &symbolicallyAddressedHistoricalStore);
+  void getSymbolicStore(
+      const std::vector<llvm::Instruction *> &callHistory,
+      std::set<const Array *> &replacements, bool coreOnly,
+      TopInterpolantStore &_symbolicallyAddressedStore,
+      LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const;
 
   /// \brief Constructor for an empty store.
   TxStore() : depth(0), parent(0), left(0), right(0) {}

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -187,13 +187,13 @@ private:
 
   void getConcreteStore(
       const std::vector<llvm::Instruction *> &callHistory,
-      std::set<const Array *> &replacements, bool coreOnly,
+      std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
       TopInterpolantStore &_concretelyAddressedStore,
       LowerInterpolantStore &_concretelyAddressedHistoricalStore) const;
 
   void getSymbolicStore(
       const std::vector<llvm::Instruction *> &callHistory,
-      std::set<const Array *> &replacements, bool coreOnly,
+      std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
       TopInterpolantStore &_symbolicallyAddressedStore,
       LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const;
 
@@ -237,9 +237,12 @@ public:
   /// bound ones.
   /// \param coreOnly Indicate whether we are retrieving only data
   /// for locations relevant to an unsatisfiability core.
+  /// \param leftRetrieval Whether the retrieval is requested by the left child
+  /// of the store, otherwise, we assume it is requested by the right child of
+  /// the store.
   void getStoredExpressions(
       const std::vector<llvm::Instruction *> &callHistory,
-      std::set<const Array *> &replacements, bool coreOnly,
+      std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
       TopInterpolantStore &_concretelyAddressedStore,
       TopInterpolantStore &_symbolicallyAddressedStore,
       LowerInterpolantStore &_concretelyAddressedHistoricalStore,

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -255,8 +255,8 @@ public:
                                   ref<TxStateValue> value);
 
   /// \brief Newly relate an location with its stored value
-  void updateStore(ref<TxStateAddress> loc, ref<TxStateValue> address,
-                   ref<TxStateValue> value);
+  void updateStore(const std::set<ref<TxStateAddress> > &locations,
+                   ref<TxStateValue> address, ref<TxStateValue> value);
 
   /// \brief Print the content of the object to the LLVM error stream
   void dump() const {

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -258,6 +258,9 @@ public:
   void updateStore(const std::set<ref<TxStateAddress> > &locations,
                    ref<TxStateValue> address, ref<TxStateValue> value);
 
+  /// \brief Register the entries in the entry list as used
+  void markUsed(const std::set<ref<TxStoreEntry> > &entryList);
+
   /// \brief Print the content of the object to the LLVM error stream
   void dump() const {
     this->print(llvm::errs());

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -154,6 +154,12 @@ private:
   /// \brief The mapping of locations to stored value
   TopStateStore internalStore;
 
+  /// \brief Store elements used by left path
+  std::set<ref<TxStoreEntry> > usedByLeftPath;
+
+  /// \brief Store elements used by right path
+  std::set<ref<TxStoreEntry> > usedByRightPath;
+
   /// \brief The depth level of this store
   uint64_t depth;
 

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -157,8 +157,8 @@ private:
   /// \brief The depth level of this store
   uint64_t depth;
 
-  /// \brief The parent of this store
-  TxStore *parent;
+  /// \brief The parent and left and right children of this store
+  TxStore *parent, *left, *right;
 
   static void concreteToInterpolant(ref<TxVariable> variable,
                                     ref<TxStoreEntry> entry,
@@ -187,12 +187,11 @@ private:
                    LowerInterpolantStore &symbolicallyAddressedHistoricalStore);
 
   /// \brief Constructor for an empty store.
-  TxStore() : depth(0), parent(0) {}
+  TxStore() : depth(0), parent(0), left(0), right(0) {}
 
 public:
   ~TxStore() {}
 
-  /// \brief Copy from another object
   static TxStore *create(TxStore *src) {
     TxStore *ret = new TxStore();
     if (!src) {
@@ -207,6 +206,10 @@ public:
     ret->parent = src;
     return ret;
   }
+
+  void setLeftChild(TxStore *child) { left = child; }
+
+  void setRightChild(TxStore *child) { right = child; }
 
   /// \brief Finds a store entry given an address
   ref<TxStoreEntry> find(ref<TxStateAddress> loc) const;

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -149,6 +149,9 @@ private:
   /// \brief The mapping of locations to stored value
   TopStateStore store;
 
+  /// \brief The depth level of this store
+  uint64_t depth;
+
   static void concreteToInterpolant(ref<TxVariable> variable,
                                     ref<TxStoreEntry> entry,
                                     std::set<const Array *> &replacements,
@@ -176,7 +179,7 @@ private:
                    LowerInterpolantStore &symbolicallyAddressedHistoricalStore);
 
   /// \brief Constructor for an empty store.
-  TxStore() {}
+  TxStore() : depth(0) {}
 
 public:
   ~TxStore() {}
@@ -192,6 +195,7 @@ public:
     ret->symbolicallyAddressedHistoricalStore =
         src->symbolicallyAddressedHistoricalStore;
     ret->store = src->store;
+    ret->depth = src->depth + 1;
     return ret;
   }
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2048,7 +2048,7 @@ TxTree::TxTree(
   currentTxTreeNode = 0;
   assert(_targetData && "target data layout not provided");
   if (!_root->txTreeNode) {
-    currentTxTreeNode = new TxTreeNode(0, _targetData, _globalAddresses);
+    currentTxTreeNode = TxTreeNode::createRoot(_targetData, _globalAddresses);
   }
   root = currentTxTreeNode;
 }
@@ -2372,10 +2372,8 @@ void TxTreeNode::addConstraint(ref<Expr> &constraint, llvm::Value *condition) {
 void TxTreeNode::split(ExecutionState *leftData, ExecutionState *rightData) {
   TimerStatIncrementer t(splitTime);
   assert(left == 0 && right == 0);
-  leftData->txTreeNode = left =
-      new TxTreeNode(this, targetData, globalAddresses);
-  rightData->txTreeNode = right =
-      new TxTreeNode(this, targetData, globalAddresses);
+  leftData->txTreeNode = createLeftChild();
+  rightData->txTreeNode = createRightChild();
 }
 
 void TxTreeNode::execute(llvm::Instruction *instr,

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2410,11 +2410,20 @@ void TxTreeNode::getStoredExpressions(
   // Since a program point index is a first statement in a basic block,
   // the allocations to be stored in subsumption table should be obtained
   // from the parent node.
-  if (parent)
+  if (parent) {
+    bool leftRetrieval = false;
+
+    if (parent->left == this)
+      leftRetrieval = true;
+    else
+      assert(parent->right == this && "mismatched tree edge");
+
     parent->dependency->getStoredExpressions(
-        _callHistory, dummyReplacements, false, concretelyAddressedStore,
-        symbolicallyAddressedStore, concretelyAddressedHistoricalStore,
+        _callHistory, dummyReplacements, false, leftRetrieval,
+        concretelyAddressedStore, symbolicallyAddressedStore,
+        concretelyAddressedHistoricalStore,
         symbolicallyAddressedHistoricalStore);
+  }
 }
 
 void TxTreeNode::getStoredCoreExpressions(
@@ -2430,11 +2439,20 @@ void TxTreeNode::getStoredCoreExpressions(
   // Since a program point index is a first statement in a basic block,
   // the allocations to be stored in subsumption table should be obtained
   // from the parent node.
-  if (parent)
+  if (parent) {
+    bool leftRetrieval = false;
+
+    if (parent->left == this)
+      leftRetrieval = true;
+    else
+      assert(parent->right == this && "mismatched tree edge");
+
     parent->dependency->getStoredExpressions(
-        _callHistory, replacements, true, concretelyAddressedStore,
-        symbolicallyAddressedStore, concretelyAddressedHistoricalStore,
+        _callHistory, replacements, true, leftRetrieval,
+        concretelyAddressedStore, symbolicallyAddressedStore,
+        concretelyAddressedHistoricalStore,
         symbolicallyAddressedHistoricalStore);
+  }
 }
 
 uint64_t TxTreeNode::getInstructionsDepth() { return instructionsDepth; }

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -474,6 +474,22 @@ class TxTreeNode {
 
   ~TxTreeNode();
 
+  static TxTreeNode *createRoot(llvm::DataLayout *targetData,
+                                std::map<const llvm::GlobalValue *,
+                                         ref<ConstantExpr> > *globalAddresses) {
+    return new TxTreeNode(0, targetData, globalAddresses);
+  }
+
+  TxTreeNode *createLeftChild() {
+    left = new TxTreeNode(this, targetData, globalAddresses);
+    return left;
+  }
+
+  TxTreeNode *createRightChild() {
+    right = new TxTreeNode(this, targetData, globalAddresses);
+    return right;
+  }
+
 public:
   bool isSubsumed;
 

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -446,9 +446,9 @@ private:
   /// \brief The data layout of the analysis target
   llvm::DataLayout *targetData;
 
-  /// Map of globals to their bound address. This also includes
-  /// globals that have no representative object (i.e. functions). This member
-  /// variable is just a pointer to the one in klee::Executor.
+  /// \brief Map of globals to their bound address. This also includes globals
+  /// that have no representative object (i.e. functions). This member variable
+  /// is just a pointer to the one in klee::Executor.
   std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *globalAddresses;
 
 public:

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -422,7 +422,6 @@ class TxTreeNode {
   /// purposes
   static uint64_t nextNodeSequenceNumber;
 
-private:
   /// \brief The path condition
   PathCondition *pathCondition;
 
@@ -451,16 +450,6 @@ private:
   /// is just a pointer to the one in klee::Executor.
   std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *globalAddresses;
 
-public:
-  bool isSubsumed;
-
-  /// \brief The entry call history
-  std::vector<llvm::Instruction *> entryCallHistory;
-
-  /// \brief The current call history
-  std::vector<llvm::Instruction *> callHistory;
-
-private:
   void setProgramPoint(llvm::Instruction *instr) {
     if (!programPoint)
       programPoint = reinterpret_cast<uintptr_t>(instr);
@@ -477,7 +466,23 @@ private:
   void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args,
                bool symbolicExecutionError);
 
+  void print(llvm::raw_ostream &stream, const unsigned paddingAmount) const;
+
+  TxTreeNode(TxTreeNode *_parent, llvm::DataLayout *_targetData,
+             std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *
+                 _globalAddresses);
+
+  ~TxTreeNode();
+
 public:
+  bool isSubsumed;
+
+  /// \brief The entry call history
+  std::vector<llvm::Instruction *> entryCallHistory;
+
+  /// \brief The current call history
+  std::vector<llvm::Instruction *> callHistory;
+
   uintptr_t getProgramPoint() { return programPoint; }
 
   uint64_t getNodeSequenceNumber() { return nodeSequenceNumber; }
@@ -574,15 +579,6 @@ public:
   ///
   /// \param stream The stream to print the data to.
   void print(llvm::raw_ostream &stream) const;
-
-private:
-  TxTreeNode(TxTreeNode *_parent, llvm::DataLayout *_targetData,
-             std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *
-                 _globalAddresses);
-
-  ~TxTreeNode();
-
-  void print(llvm::raw_ostream &stream, const unsigned paddingAmount) const;
 };
 
 /// \brief The top-level structure that implements abstraction learning.

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -482,11 +482,13 @@ class TxTreeNode {
 
   TxTreeNode *createLeftChild() {
     left = new TxTreeNode(this, targetData, globalAddresses);
+    dependency->setLeftChild(left->dependency);
     return left;
   }
 
   TxTreeNode *createRightChild() {
     right = new TxTreeNode(this, targetData, globalAddresses);
+    dependency->setRightChild(right->dependency);
     return right;
   }
 

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -17,7 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ShadowArray.h"
-#include "TxStore.cpp"
+#include "TxStore.h"
 
 #include "klee/Internal/Module/TxValues.h"
 #include "klee/Internal/Support/ErrorHandling.h"
@@ -788,7 +788,7 @@ void TxStateValue::addDependency(ref<TxStateValue> source,
   entryList.insert(source->entryList.begin(), source->entryList.end());
 }
 
-inline void TxStateValue::addStoreEntry(ref<TxStoreEntry> entry) {
+void TxStateValue::addStoreEntry(ref<TxStoreEntry> entry) {
   entryList.insert(entry);
 }
 

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -800,7 +800,19 @@ void TxStateValue::print(llvm::raw_ostream &stream,
                          const std::string &prefix) const {
   std::string tabsNext = appendTab(prefix);
 
-  printNoDependency(stream, prefix);
+  printMinimal(stream, prefix);
+
+  if (entryList.empty()) {
+    stream << prefix << "not dependent on store\n";
+  } else {
+    stream << prefix << "loaded from store entries:";
+    for (std::set<ref<TxStoreEntry> >::const_iterator it = entryList.begin(),
+                                                      ie = entryList.end();
+         it != ie; ++it) {
+      stream << "\n";
+      (*it)->print(stream, tabsNext);
+    }
+  }
 
   stream << "\n";
   if (sources.empty()) {
@@ -814,7 +826,7 @@ void TxStateValue::print(llvm::raw_ostream &stream,
       stream << "\n";
       if (it != is)
         stream << tabsNext << "------------------------------------------\n";
-      (*it->first).printNoDependency(stream, tabsNext);
+      (*it->first).printMinimal(stream, tabsNext);
       if (!it->second.isNull()) {
         stream << " via\n";
         (*it->second).print(stream, tabsNext);
@@ -823,8 +835,8 @@ void TxStateValue::print(llvm::raw_ostream &stream,
   }
 }
 
-void TxStateValue::printNoDependency(llvm::raw_ostream &stream,
-                                     const std::string &prefix) const {
+void TxStateValue::printMinimal(llvm::raw_ostream &stream,
+                                const std::string &prefix) const {
   std::string tabsNext = appendTab(prefix);
 
   if (core) {
@@ -853,14 +865,5 @@ void TxStateValue::printNoDependency(llvm::raw_ostream &stream,
   stream << "\n";
   stream << prefix
          << "pointer to location object: " << reinterpret_cast<uintptr_t>(this);
-  if (!entryList.empty()) {
-    stream << prefix << "loaded from store entries:";
-    for (std::set<ref<TxStoreEntry> >::const_iterator it = entryList.begin(),
-                                                      ie = entryList.end();
-         it != ie; ++it) {
-      stream << "\n";
-      (*it)->print(stream, tabsNext);
-    }
-  }
 }
 }

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -764,16 +764,16 @@ void TxStateAddress::print(llvm::raw_ostream &stream,
 
 void TxStateValue::setLoadAddress(ref<TxStateValue> _loadAddress) {
   loadAddress = _loadAddress;
-  allLoadAddresses.insert(_loadAddress->getLocations().begin(),
-                          _loadAddress->getLocations().end());
+  allLoadAddresses.insert(_loadAddress->locations.begin(),
+                          _loadAddress->locations.end());
   entryList.insert(_loadAddress->entryList.begin(),
                    _loadAddress->entryList.end());
 }
 
 void TxStateValue::setStoreAddress(ref<TxStateValue> _storeAddress) {
   storeAddress = _storeAddress;
-  allLoadAddresses.insert(_storeAddress->getLocations().begin(),
-                          _storeAddress->getLocations().end());
+  allLoadAddresses.insert(_storeAddress->locations.begin(),
+                          _storeAddress->locations.end());
   entryList.insert(_storeAddress->entryList.begin(),
                    _storeAddress->entryList.end());
 }

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -853,5 +853,14 @@ void TxStateValue::printNoDependency(llvm::raw_ostream &stream,
   stream << "\n";
   stream << prefix
          << "pointer to location object: " << reinterpret_cast<uintptr_t>(this);
+  if (!entryList.empty()) {
+    stream << prefix << "loaded from store entries:";
+    for (std::set<ref<TxStoreEntry> >::const_iterator it = entryList.begin(),
+                                                      ie = entryList.end();
+         it != ie; ++it) {
+      stream << "\n";
+      (*it)->print(stream, tabsNext);
+    }
+  }
 }
 }

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -784,8 +784,8 @@ void TxStateValue::addDependency(ref<TxStateValue> source,
   if (via.isNull()) {
     allLoadAddresses.insert(source->allLoadAddresses.begin(),
                             source->allLoadAddresses.end());
-    entryList.insert(source->entryList.begin(), source->entryList.end());
   }
+  entryList.insert(source->entryList.begin(), source->entryList.end());
 }
 
 inline void TxStateValue::addStoreEntry(ref<TxStoreEntry> entry) {

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ShadowArray.h"
+#include "TxStore.cpp"
 
 #include "klee/Internal/Module/TxValues.h"
 #include "klee/Internal/Support/ErrorHandling.h"
@@ -760,6 +761,40 @@ void TxStateAddress::print(llvm::raw_ostream &stream,
 }
 
 /**/
+
+void TxStateValue::setLoadAddress(ref<TxStateValue> _loadAddress) {
+  loadAddress = _loadAddress;
+  allLoadAddresses.insert(_loadAddress->getLocations().begin(),
+                          _loadAddress->getLocations().end());
+  entryList.insert(_loadAddress->entryList.begin(),
+                   _loadAddress->entryList.end());
+}
+
+void TxStateValue::setStoreAddress(ref<TxStateValue> _storeAddress) {
+  storeAddress = _storeAddress;
+  allLoadAddresses.insert(_storeAddress->getLocations().begin(),
+                          _storeAddress->getLocations().end());
+  entryList.insert(_storeAddress->entryList.begin(),
+                   _storeAddress->entryList.end());
+}
+
+void TxStateValue::addDependency(ref<TxStateValue> source,
+                                 ref<TxStateAddress> via) {
+  sources[source] = via;
+  if (via.isNull()) {
+    allLoadAddresses.insert(source->allLoadAddresses.begin(),
+                            source->allLoadAddresses.end());
+    entryList.insert(source->entryList.begin(), source->entryList.end());
+  }
+}
+
+inline void TxStateValue::addStoreEntry(ref<TxStoreEntry> entry) {
+  entryList.insert(entry);
+}
+
+const std::set<ref<TxStoreEntry> > &TxStateValue::getEntryList() const {
+  return entryList;
+}
 
 void TxStateValue::print(llvm::raw_ostream &stream,
                          const std::string &prefix) const {

--- a/test/Runtime/POSIX/FD_Fail2.c
+++ b/test/Runtime/POSIX/FD_Fail2.c
@@ -1,6 +1,6 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --output-dir=%t.klee-out --libc=uclibc --posix-runtime --search=dfs %t1.bc --sym-files 1 10 --max-fail 2
+// RUN: %klee --no-interpolation --output-dir=%t.klee-out --libc=uclibc --posix-runtime --search=dfs %t1.bc --sym-files 1 10 --max-fail 2
 //
 // Check that generated assembly doesn't use puts to output strings
 // RUN: FileCheck -input-file=%t.klee-out/assembly.ll %s


### PR DESCRIPTION
Resolves #265. `make check` succeeds and subsumption counts increase significantly for the test cases in `klee-examples/basic`, without any loss of error report. However, `validation.c` and `regexp_iterative.c` times out after 1 minute. If this PR is merged, a new issue to resolve the slowdown has to be opened.