### PR TITLE
Remove quantification in case the body of a quantified query expression has no constraint with both bound and non-bound variables

### DIFF
--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1227,11 +1227,11 @@ bool SubsumptionTableEntry::subsumed(
           if (constraint.isNull())
             return false;
 
-            if (!conjunction.isNull()) {
-              conjunction = AndExpr::create(constraint, conjunction);
-            } else {
-              conjunction = constraint;
-            }
+          if (!conjunction.isNull()) {
+            conjunction = AndExpr::create(constraint, conjunction);
+          } else {
+            conjunction = constraint;
+          }
         }
       }
 
@@ -1471,7 +1471,6 @@ bool SubsumptionTableEntry::subsumed(
           }
         }
 
-
       } else {
         if (debugSubsumptionLevel >= 2) {
           klee_message("Querying for subsumption check:\n%s",
@@ -1550,55 +1549,55 @@ bool SubsumptionTableEntry::subsumed(
       return false;
     }
 
-      // State subsumed, we mark needed constraints on the
-      // path condition.
-      if (debugSubsumptionLevel >= 1) {
-        std::string msg = "";
-        if (!corePointerValues.empty()) {
-          msg += " (with successful memory bound checks)";
-        }
-        klee_message("#%lu=>#%lu: Check success as solver decided validity%s",
-                     state.txTreeNode->getNodeSequenceNumber(),
-                     nodeSequenceNumber, msg.c_str());
+    // State subsumed, we mark needed constraints on the
+    // path condition.
+    if (debugSubsumptionLevel >= 1) {
+      std::string msg = "";
+      if (!corePointerValues.empty()) {
+        msg += " (with successful memory bound checks)";
       }
+      klee_message("#%lu=>#%lu: Check success as solver decided validity%s",
+                   state.txTreeNode->getNodeSequenceNumber(),
+                   nodeSequenceNumber, msg.c_str());
+    }
 
-      // We create path condition marking structure and mark core constraints
-      state.txTreeNode->unsatCoreInterpolation(unsatCore);
+    // We create path condition marking structure and mark core constraints
+    state.txTreeNode->unsatCoreInterpolation(unsatCore);
 
-      if (Dependency::boundInterpolation() && !ExactAddressInterpolant) {
-        // We build memory bounds interpolants from pointer values
-        std::string reason = "";
-        if (debugSubsumptionLevel >= 1) {
-          llvm::raw_string_ostream stream(reason);
-          llvm::Instruction *instr = state.pc->inst;
-          stream << "interpolating memory bound for subsumption at ";
-          if (instr->getParent()->getParent()) {
-            std::string functionName(
-                instr->getParent()->getParent()->getName().str());
-            stream << functionName << ": ";
-            if (llvm::MDNode *n = instr->getMetadata("dbg")) {
-              llvm::DILocation loc(n);
-              stream << "Line " << loc.getLineNumber();
-            } else {
-              instr->print(stream);
-            }
+    if (Dependency::boundInterpolation() && !ExactAddressInterpolant) {
+      // We build memory bounds interpolants from pointer values
+      std::string reason = "";
+      if (debugSubsumptionLevel >= 1) {
+        llvm::raw_string_ostream stream(reason);
+        llvm::Instruction *instr = state.pc->inst;
+        stream << "interpolating memory bound for subsumption at ";
+        if (instr->getParent()->getParent()) {
+          std::string functionName(
+              instr->getParent()->getParent()->getName().str());
+          stream << functionName << ": ";
+          if (llvm::MDNode *n = instr->getMetadata("dbg")) {
+            llvm::DILocation loc(n);
+            stream << "Line " << loc.getLineNumber();
           } else {
             instr->print(stream);
           }
-        }
-        for (std::map<ref<TxInterpolantValue>, std::set<ref<Expr> > >::iterator
-                 it = corePointerValues.begin(),
-                 ie = corePointerValues.end();
-             it != ie; ++it) {
-          bool memoryError = state.txTreeNode->pointerValuesInterpolation(
-              it->first->getValue(), it->first->getExpression(), it->second,
-              reason);
-          assert(!memoryError &&
-                 "interpolation should not result in memory error");
+        } else {
+          instr->print(stream);
         }
       }
+      for (std::map<ref<TxInterpolantValue>, std::set<ref<Expr> > >::iterator
+               it = corePointerValues.begin(),
+               ie = corePointerValues.end();
+           it != ie; ++it) {
+        bool memoryError = state.txTreeNode->pointerValuesInterpolation(
+            it->first->getValue(), it->first->getExpression(), it->second,
+            reason);
+        assert(!memoryError &&
+               "interpolation should not result in memory error");
+      }
+    }
 
-      return true;
+    return true;
   }
 #endif /* ENABLE_Z3 */
   return false;

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -266,6 +266,33 @@ SubsumptionTableEntry::hasVariableInSet(std::set<const Array *> &existentials,
   return false;
 }
 
+ref<Expr> SubsumptionTableEntry::getBoundFreeConjunction(
+    std::set<const Array *> &existentials, ref<Expr> expr) {
+
+  if (llvm::isa<AndExpr>(expr)) {
+    ref<Expr> boundFree1 =
+        getBoundFreeConjunction(existentials, expr->getKid(0));
+    if (boundFree1.isNull())
+      return boundFree1;
+    ref<Expr> boundFree2 =
+        getBoundFreeConjunction(existentials, expr->getKid(1));
+    if (boundFree2.isNull())
+      return boundFree2;
+    return AndExpr::create(boundFree1, boundFree2);
+  }
+
+  if (hasVariableInSet(existentials, expr)) {
+    if (hasVariableNotInSet(existentials, expr)) {
+      ref<Expr> nullExpr;
+      return nullExpr;
+    }
+    return ConstantExpr::create(1, Expr::Bool);
+  }
+
+  // expr has no existentials, may even have no variables
+  return expr;
+}
+
 bool SubsumptionTableEntry::hasVariableNotInSet(
     std::set<const Array *> &existentials, ref<Expr> expr) {
   for (int i = 0, numKids = expr->getNumKids(); i < numKids; ++i) {
@@ -1441,24 +1468,40 @@ bool SubsumptionTableEntry::subsumed(
 
           return true;
         } else {
+          // Here we try to get bound-variables-free conjunction, if there is
+          // no constraint with both bound and non-bound variables
+          if (ExistsExpr *existsExpr = llvm::dyn_cast<ExistsExpr>(expr)) {
+            ref<Expr> boundFree(getBoundFreeConjunction(existsExpr->variables,
+                                                        existsExpr->getKid(0)));
+
+            if (!boundFree.isNull()) {
+              expr = boundFree;
+            }
+          }
+
           if (debugSubsumptionLevel >= 2) {
             klee_message("Querying for subsumption check:\n%s",
                          PrettyExpressionBuilder::constructQuery(
                              state.constraints, expr).c_str());
           }
 
-          // Instantiate a new Z3 solver to make sure we use Z3
-          // without pre-solving optimizations. It would be nice
-          // in the future to just run solver->evaluate so that
-          // the optimizations can be used, but this requires
-          // handling of quantified expressions by KLEE's pre-solving
-          // procedure, which does not exist currently.
-          Z3Solver *z3solver = new Z3Solver();
-          z3solver->setCoreSolverTimeout(timeout);
-          success = z3solver->directComputeValidity(
-              Query(state.constraints, expr), result, unsatCore);
-          z3solver->setCoreSolverTimeout(0);
-          delete z3solver;
+          if (llvm::isa<ExistsExpr>(expr)) {
+            // We instantiate a new Z3 solver to make sure that we use Z3
+            // without pre-solving optimizations. It would be nice in the future
+            // to just run solver->evaluate so that the optimizations can be
+            // used, but this requires handling of quantified expressions by
+            // KLEE's pre-solving procedure, which does not exist currently.
+            Z3Solver *z3solver = new Z3Solver();
+            z3solver->setCoreSolverTimeout(timeout);
+            success = z3solver->directComputeValidity(
+                Query(state.constraints, expr), result, unsatCore);
+            z3solver->setCoreSolverTimeout(0);
+            delete z3solver;
+          } else {
+            solver->setTimeout(timeout);
+            success = solver->evaluate(state, expr, result, unsatCore);
+            solver->setTimeout(0);
+          }
 
           if (!success || result != Solver::True) {
             if (debugSubsumptionLevel >= 1) {

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1460,8 +1460,15 @@ bool SubsumptionTableEntry::subsumed(
           z3solver->setCoreSolverTimeout(0);
           delete z3solver;
 
-          if (!success || result != Solver::True)
+          if (!success || result != Solver::True) {
+            if (debugSubsumptionLevel >= 1) {
+              klee_message("#%lu=>#%lu: Check failure as solved did not decide "
+                           "validity of existentially-quantified query",
+                           state.txTreeNode->getNodeSequenceNumber(),
+                           nodeSequenceNumber);
+            }
             return false;
+          }
         }
 
 
@@ -1477,8 +1484,14 @@ bool SubsumptionTableEntry::subsumed(
         success = solver->evaluate(state, expr, result, unsatCore);
         solver->setTimeout(0);
 
-        if (!success || result != Solver::True)
+        if (!success || result != Solver::True) {
+          if (debugSubsumptionLevel >= 1) {
+            klee_message(
+                "#%lu=>#%lu: Check failure as solved did not decide validity",
+                state.txTreeNode->getNodeSequenceNumber(), nodeSequenceNumber);
+          }
           return false;
+        }
       }
     } else {
       // expr is a constant expression

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -262,6 +262,18 @@ class SubsumptionTableEntry {
   static bool hasVariableInSet(std::set<const Array *> &existentials,
                                ref<Expr> expr);
 
+  /// \brief Here we try to get bound-variables-free conjunction, if there is no
+  /// constraints with both bound and non-bound variables.
+  ///
+  /// \param existentials A set of variables (KLEE arrays).
+  /// \param expr The original conjunction of constrains to test
+  /// \return a conjuction of constraints without bound variables, in case there
+  /// is no costraint with both bound and non-bound variables, otherwise a null
+  /// expression.
+  static ref<Expr>
+  getBoundFreeConjunction(std::set<const Array *> &existentials,
+                          ref<Expr> expr);
+
   /// \brief Test for the non-existence of a variable in a set in an expression.
   ///
   /// \param existentials A set of variables (KLEE arrays).


### PR DESCRIPTION
In `SubsumptionTableEntry::subsumed()` remove quantification in case the body of a quantified query expression has no constraint with both bound and non-bound variables.

This resolves #288. For `basic/arraysimple5.c` for `fp-examples`, there is a reduction in subsumption count from 17  with tracer-x/klee@bf6461a3edc074016f4173d72a3cea699352c841 to 14 with this PR, but the space traversed decreased from 307 instructions to only 195 instructions. There are increases in subsumption counts for `basic/regexp_iterative.c` and `basic/sp.c`.

`make check` succeeds.
