### PR TITLE
Skipping entries with depth larger than the current store

### DIFF
--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -364,10 +364,10 @@ void TxStore::markUsed(const std::set<ref<TxStoreEntry> > &entryList) {
        it != ie; ++it) {
     uint64_t entryDepth = (*it)->getDepth();
 
-    if (entryDepth == depth)
+    // Note that it is possible that entryDepth > depth, due to the association
+    // of values with newly-created entries in TxStore::updateStore().
+    if (entryDepth >= depth)
       continue;
-
-    assert(entryDepth < depth && "invalid depth");
 
     // We now register the used entry as used after it was instantiated in
     // previous depth levels


### PR DESCRIPTION
In `TxStore::markUsed()`, instead of triggering an assert. This resolves issue with Coreutils 6.10 `cut` run crashes due to the triggering of the assertion.