### PR TITLE
Prevent computing pointer bound when better bound already computed

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -536,7 +536,7 @@ public:
   /// \brief Adjust the offset bound for interpolation (a.k.a. slackening).
   /// Returns true if a memory bound violation is detected, and false if not.
   bool adjustOffsetBound(ref<TxStateValue> checkedAddress,
-                         std::set<ref<Expr> > &bounds);
+                         std::set<ref<Expr> > &bounds, bool &boundUpdated);
 
   bool hasConstantAddress() const { return llvm::isa<ConstantExpr>(address); }
 
@@ -623,7 +623,10 @@ private:
   /// \brief The addresses by which this loaded value was stored
   std::set<ref<TxStateValue> > storeAddresses;
 
-  /// \brief Reasons for this value to be in the core
+  /// \brief Reasons for this value to be in the core. This may not contain all
+  /// the reasons since values are no longer marked if they were already found
+  /// to be marked, therefore the reasons are not propagated to all the values
+  /// this value is dependent upon.
   std::set<std::string> coreReasons;
 
   /// \brief Direct use count of this value by another value in all interpolants

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -671,7 +671,8 @@ void TxInterpolantValue::print(llvm::raw_ostream &stream,
 /**/
 
 bool TxStateAddress::adjustOffsetBound(ref<TxStateValue> checkedAddress,
-                                       std::set<ref<Expr> > &_bounds) {
+                                       std::set<ref<Expr> > &_bounds,
+                                       bool &boundUpdated) {
   const std::set<ref<TxStateAddress> > &locations =
       checkedAddress->getLocations();
   std::set<ref<Expr> > bounds(_bounds);
@@ -706,6 +707,7 @@ bool TxStateAddress::adjustOffsetBound(ref<TxStateValue> checkedAddress,
                   if (!elementStructType->isLiteral() &&
                       elementType->getStructName() == "struct.dirent") {
                     concreteOffsetBound = newBound;
+                    boundUpdated = true;
                     continue;
                   }
                 }
@@ -713,6 +715,7 @@ bool TxStateAddress::adjustOffsetBound(ref<TxStateValue> checkedAddress,
 
               if (newBound > offsetInt) {
                 concreteOffsetBound = newBound;
+                boundUpdated = true;
               } else {
                 // Incorrect bounds would pass this assertion, as long as the
                 // value of the checked offset is reasonable (non-negative). We
@@ -734,6 +737,7 @@ bool TxStateAddress::adjustOffsetBound(ref<TxStateValue> checkedAddress,
 
       symbolicOffsetBounds.insert(
           SubExpr::create(*it1, SubExpr::create(checkedOffset, getOffset())));
+      boundUpdated = true;
     }
   }
   return false;


### PR DESCRIPTION
Replacement for #197 (the original source repository domainexpert/klee for the PR no longer exists). Again this results in significant performance gain (8.57s for `make check` compared to more than 100s previously), but there is currently an over-subsuming case for `basic/pointer_struct1.c`.

This PR is not ready to be merged.