### PR TITLE
Compression of dependency paths

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -616,12 +616,12 @@ private:
   /// pointer; instead, use exact address
   bool doNotInterpolateBound;
 
-  /// \brief The load address of this value, in case it was a load instruction
-  ref<TxStateValue> loadAddress;
+  /// \brief The load addresses of this value: These are the addresses the loads
+  /// that influence this value was executed on
+  std::set<ref<TxStateValue> > loadAddresses;
 
-  /// \brief The address by which the loaded value was stored, in case this
-  /// was a load instruction
-  ref<TxStateValue> storeAddress;
+  /// \brief The addresses by which this loaded value was stored
+  std::set<ref<TxStateValue> > storeAddresses;
 
   /// \brief Reasons for this value to be in the core
   std::set<std::string> coreReasons;
@@ -656,15 +656,15 @@ public:
 
   /// \brief Set the address this value was loaded from for inclusion in the
   /// interpolant
-  void setLoadAddress(ref<TxStateValue> _loadAddress);
+  void addLoadAddress(ref<TxStateValue> _loadAddress);
 
-  ref<TxStateValue> getLoadAddress() { return loadAddress; }
+  std::set<ref<TxStateValue> > &getLoadAddresses() { return loadAddresses; }
 
   /// \brief Set the address this value was stored into for inclusion in the
   /// interpolant
-  void setStoreAddress(ref<TxStateValue> _storeAddress);
+  void addStoreAddress(ref<TxStateValue> _storeAddress);
 
-  ref<TxStateValue> getStoreAddress() { return storeAddress; }
+  std::set<ref<TxStateValue> > &getStoreAddresses() { return storeAddresses; }
 
   /// \brief The core routine for adding flow dependency between source and
   /// target value

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -629,9 +629,6 @@ private:
   /// \brief Direct use count of this value by another value in all interpolants
   uint64_t directUseCount;
 
-  /// \brief All load addresses, transitively
-  std::set<ref<TxStateAddress> > allLoadAddresses;
-
   /// \brief Store entries this value is dependent upon
   std::set<ref<TxStoreEntry> > entryList;
 
@@ -686,8 +683,6 @@ public:
   const std::map<ref<TxStateValue>, ref<TxStateAddress> > &getSources() {
     return sources;
   }
-
-  std::set<ref<TxStateAddress> > getLoadLocations() { return allLoadAddresses; }
 
   int compare(const TxStateValue other) const {
     if (id == other.id)

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -298,7 +298,7 @@ namespace klee {
                                    ref<TxStateValue> target);
 
     /// \brief All values that flows to the target in one step
-    std::vector<ref<TxStateValue> >
+    std::set<ref<TxStateValue> >
     directFlowSources(ref<TxStateValue> target) const;
 
     /// \brief Mark as core all the values and locations that flows to the

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -302,7 +302,7 @@ void TxStore::updateStoreWithLoadedValue(ref<TxStateAddress> loc,
   std::set<ref<TxStateAddress> > locations;
   locations.insert(loc);
   updateStore(locations, address, value);
-  value->setLoadAddress(address);
+  value->addLoadAddress(address);
 }
 
 void TxStore::updateStore(const std::set<ref<TxStateAddress> > &locations,

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -790,7 +790,11 @@ void TxStateValue::setStoreAddress(ref<TxStateValue> _storeAddress) {
 
 void TxStateValue::addDependency(ref<TxStateValue> source,
                                  ref<TxStateAddress> via) {
-  sources[source] = via;
+  if (via.isNull()) {
+    sources.insert(source->sources.begin(), source->sources.end());
+  } else {
+    sources[source] = via;
+  }
   entryList.insert(source->entryList.begin(), source->entryList.end());
 }
 

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -776,16 +776,16 @@ void TxStateAddress::print(llvm::raw_ostream &stream,
 
 /**/
 
-void TxStateValue::setLoadAddress(ref<TxStateValue> _loadAddress) {
-  loadAddress = _loadAddress;
-  entryList.insert(_loadAddress->entryList.begin(),
-                   _loadAddress->entryList.end());
+void TxStateValue::addLoadAddress(ref<TxStateValue> loadAddress) {
+  loadAddresses.insert(loadAddress);
+  entryList.insert(loadAddress->entryList.begin(),
+                   loadAddress->entryList.end());
 }
 
-void TxStateValue::setStoreAddress(ref<TxStateValue> _storeAddress) {
-  storeAddress = _storeAddress;
-  entryList.insert(_storeAddress->entryList.begin(),
-                   _storeAddress->entryList.end());
+void TxStateValue::addStoreAddress(ref<TxStateValue> storeAddress) {
+  storeAddresses.insert(storeAddress);
+  entryList.insert(storeAddress->entryList.begin(),
+                   storeAddress->entryList.end());
 }
 
 void TxStateValue::addDependency(ref<TxStateValue> source,

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -791,6 +791,10 @@ void TxStateValue::addStoreAddress(ref<TxStateValue> storeAddress) {
 void TxStateValue::addDependency(ref<TxStateValue> source,
                                  ref<TxStateAddress> via) {
   if (via.isNull()) {
+    loadAddresses.insert(source->loadAddresses.begin(),
+                         source->loadAddresses.end());
+    storeAddresses.insert(source->storeAddresses.begin(),
+                          source->storeAddresses.end());
     sources.insert(source->sources.begin(), source->sources.end());
   } else {
     sources[source] = via;

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -778,16 +778,12 @@ void TxStateAddress::print(llvm::raw_ostream &stream,
 
 void TxStateValue::setLoadAddress(ref<TxStateValue> _loadAddress) {
   loadAddress = _loadAddress;
-  allLoadAddresses.insert(_loadAddress->locations.begin(),
-                          _loadAddress->locations.end());
   entryList.insert(_loadAddress->entryList.begin(),
                    _loadAddress->entryList.end());
 }
 
 void TxStateValue::setStoreAddress(ref<TxStateValue> _storeAddress) {
   storeAddress = _storeAddress;
-  allLoadAddresses.insert(_storeAddress->locations.begin(),
-                          _storeAddress->locations.end());
   entryList.insert(_storeAddress->entryList.begin(),
                    _storeAddress->entryList.end());
 }
@@ -795,10 +791,6 @@ void TxStateValue::setStoreAddress(ref<TxStateValue> _storeAddress) {
 void TxStateValue::addDependency(ref<TxStateValue> source,
                                  ref<TxStateAddress> via) {
   sources[source] = via;
-  if (via.isNull()) {
-    allLoadAddresses.insert(source->allLoadAddresses.begin(),
-                            source->allLoadAddresses.end());
-  }
   entryList.insert(source->entryList.begin(), source->entryList.end());
 }
 


### PR DESCRIPTION
This is an attempt to shorten dependency paths by shortcutting values in the dependency graph that is not loaded from the memory. After this fix, `make check` becomes siginficantly faster. Before the fix:
```
Passing extra KLEE command line args: -solver-backend=z3
Testing Time: 108.40s
  Expected Passes    : 181
  Expected Failures  : 2
  Unsupported Tests  : 2
```
After the fix:
```
Passing extra KLEE command line args: -solver-backend=z3
Testing Time: 63.15s
  Expected Passes    : 181
  Expected Failures  : 2
  Unsupported Tests  : 2
```
All tests in the `basic` directory of `klee-examples` ran without change in the number of subsumption and error report counts.