### PR TITLE
Resolution to masked error problem

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -629,9 +629,6 @@ private:
   /// this value is dependent upon.
   std::set<std::string> coreReasons;
 
-  /// \brief Direct use count of this value by another value in all interpolants
-  uint64_t directUseCount;
-
   /// \brief Store entries this value is dependent upon
   std::set<ref<TxStoreEntry> > entryList;
 
@@ -640,7 +637,7 @@ private:
                ref<Expr> _valueExpr)
       : refCount(0), value(value), valueExpr(_valueExpr), core(false),
         id(reinterpret_cast<uint64_t>(this)), callHistory(_callHistory),
-        doNotInterpolateBound(false), directUseCount(0) {}
+        doNotInterpolateBound(false) {}
 
 public:
   ~TxStateValue() { locations.clear(); }
@@ -713,10 +710,6 @@ public:
     if (!reason.empty())
       coreReasons.insert(reason);
   }
-
-  void incrementDirectUseCount() { ++directUseCount; }
-
-  uint64_t getDirectUseCount() { return directUseCount; }
 
   bool isCore() const { return core; }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -313,19 +313,14 @@ Dependency::directFlowSources(ref<TxStateValue> target) const {
   return ret;
 }
 
-void Dependency::markFlow(ref<TxStateValue> target, const std::string &reason,
-                          bool incrementDirectUseCount) const {
+void Dependency::markFlow(ref<TxStateValue> target,
+                          const std::string &reason) const {
   if (target.isNull())
     return;
-
-  if (incrementDirectUseCount)
-    target->incrementDirectUseCount();
 
   if (target->isCore()) {
     if (!target->canInterpolateBound())
       return;
-
-    incrementDirectUseCount = false;
   }
 
   target->setAsCore(reason);
@@ -335,26 +330,19 @@ void Dependency::markFlow(ref<TxStateValue> target, const std::string &reason,
   for (std::set<ref<TxStateValue> >::iterator it = stepSources.begin(),
                                               ie = stepSources.end();
        it != ie; ++it) {
-    markFlow(*it, reason, incrementDirectUseCount);
+    markFlow(*it, reason);
   }
 }
 
 bool Dependency::markPointerFlow(ref<TxStateValue> target,
                                  ref<TxStateValue> checkedAddress,
                                  std::set<ref<Expr> > &bounds,
-                                 const std::string &reason,
-                                 bool incrementDirectUseCount) const {
+                                 const std::string &reason) const {
   bool memoryError = false;
   bool boundUpdated = false;
 
   if (target.isNull())
     return memoryError;
-
-  if (incrementDirectUseCount)
-    target->incrementDirectUseCount();
-
-  if (target->isCore())
-    incrementDirectUseCount = false;
 
   if (target->canInterpolateBound()) {
     //  checkedAddress->dump();
@@ -387,7 +375,7 @@ bool Dependency::markPointerFlow(ref<TxStateValue> target,
              it = sources.begin(),
              ie = sources.end();
          it != ie; ++it) {
-      markFlow(it->first, reason, incrementDirectUseCount);
+      markFlow(it->first, reason);
     }
   } else {
     // Bound was updated, this means we need to update further up
@@ -396,8 +384,7 @@ bool Dependency::markPointerFlow(ref<TxStateValue> target,
                it = sources.begin(),
                ie = sources.end();
            it != ie; ++it) {
-        memoryError = markPointerFlow(it->first, checkedAddress, bounds, reason,
-                                      incrementDirectUseCount)
+        memoryError = markPointerFlow(it->first, checkedAddress, bounds, reason)
                           ? true
                           : memoryError;
       }
@@ -409,13 +396,13 @@ bool Dependency::markPointerFlow(ref<TxStateValue> target,
            it = target->getLoadAddresses().begin(),
            ie = target->getLoadAddresses().end();
        it != ie; ++it) {
-    markFlow(*it, reason, incrementDirectUseCount);
+    markFlow(*it, reason);
   }
   for (std::set<ref<TxStateValue> >::iterator
            it = target->getStoreAddresses().begin(),
            ie = target->getStoreAddresses().end();
        it != ie; ++it) {
-    markFlow(*it, reason, incrementDirectUseCount);
+    markFlow(*it, reason);
   }
 
   return memoryError;

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1120,9 +1120,7 @@ bool Dependency::executeMemoryOperation(
 #ifdef ENABLE_Z3
   if (boundInterpolation(instr) && inBounds) {
     // The bounds check has been proven valid, we keep the dependency on the
-    // address. Calling va_start within a variadic function also triggers memory
-    // operation, but we ignored it here as this method is only called when load
-    // / store instruction is processed.
+    // address.
     llvm::Value *addressOperand;
     ref<Expr> address(args.at(1));
     switch (instr->getOpcode()) {

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1115,7 +1115,8 @@ bool Dependency::executeMemoryOperation(
     const std::vector<llvm::Instruction *> &callHistory,
     std::vector<ref<Expr> > &args, bool inBounds, bool symbolicExecutionError) {
   bool ret = false;
-  execute(instr, callHistory, args, symbolicExecutionError);
+  if (inBounds)
+    execute(instr, callHistory, args, symbolicExecutionError);
 #ifdef ENABLE_Z3
   if (boundInterpolation(instr) && inBounds) {
     // The bounds check has been proven valid, we keep the dependency on the

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -303,8 +303,7 @@ namespace klee {
 
     /// \brief Mark as core all the values and locations that flows to the
     /// target
-    void markFlow(ref<TxStateValue> target, const std::string &reason,
-                  bool incrementDirectUseCount = true) const;
+    void markFlow(ref<TxStateValue> target, const std::string &reason) const;
 
     /// \brief Mark as core all the pointer values and that flows to the target;
     /// and adjust its offset bound for memory bounds interpolation (a.k.a.
@@ -323,8 +322,7 @@ namespace klee {
     bool markPointerFlow(ref<TxStateValue> target,
                          ref<TxStateValue> checkedOffset,
                          std::set<ref<Expr> > &bounds,
-                         const std::string &reason,
-                         bool incrementUseCount = true) const;
+                         const std::string &reason) const;
 
     /// \brief Record the expressions of a call's arguments
     void populateArgumentValuesList(

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -421,6 +421,10 @@ namespace klee {
 
     /// \brief Execute memory operation (load/store). Returns true if memory
     /// bounds violation was detected, false otherwise.
+    ///
+    /// Calling va_start within a variadic function also triggers memory
+    /// operation, but we ignored it here as this method is only called when
+    /// load / store instruction is processed.
     bool
     executeMemoryOperation(llvm::Instruction *instr,
                            const std::vector<llvm::Instruction *> &callHistory,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -495,6 +495,10 @@ namespace klee {
       pathCondition->unsatCoreInterpolation(unsatCore);
     }
 
+    /// \brief Interpolation for memory bound violation
+    void memoryBoundViolationInterpolation(llvm::Instruction *inst,
+                                           ref<Expr> address);
+
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {
       this->print(llvm::errs());

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3303,6 +3303,9 @@ void Executor::terminateStateOnError(ExecutionState &state,
         state.txTreeNode->getInstructionsDepth());
     if (termReason == Executor::Assert) {
       TxTreeGraph::setError(state, TxTreeGraph::ASSERTION);
+    } else if (termReason == Executor::Ptr &&
+               messaget.str() == "memory error: out of bound pointer") {
+      TxTreeGraph::setError(state, TxTreeGraph::MEMORY);
     } else {
       TxTreeGraph::setError(state, TxTreeGraph::GENERIC);
     }
@@ -3753,7 +3756,6 @@ void Executor::executeMemoryOperation(ExecutionState &state, bool isWrite,
             // Memory error according to Tracer-X
             terminateStateOnError(state, "memory error: out of bound pointer",
                                   Ptr, NULL, getAddressInfo(state, address));
-            TxTreeGraph::setError(state, TxTreeGraph::MEMORY);
           }
         }          
       } else {
@@ -3771,7 +3773,6 @@ void Executor::executeMemoryOperation(ExecutionState &state, bool isWrite,
           // Memory error according to Tracer-X
           terminateStateOnError(state, "memory error: out of bound pointer",
                                 Ptr, NULL, getAddressInfo(state, address));
-          TxTreeGraph::setError(state, TxTreeGraph::MEMORY);
         }
       }
 
@@ -3844,8 +3845,6 @@ void Executor::executeMemoryOperation(ExecutionState &state, bool isWrite,
     } else {
       terminateStateOnError(*unbound, "memory error: out of bound pointer", Ptr,
                             NULL, getAddressInfo(*unbound, address));
-
-      TxTreeGraph::setError(*unbound, TxTreeGraph::MEMORY);
     }
   }
 }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3297,12 +3297,14 @@ void Executor::terminateStateOnError(ExecutionState &state,
     interpreterHandler->incBranchingDepthOnErrorTermination(state.depth);
     interpreterHandler->incInstructionsDepthOnErrorTermination(
         state.txTreeNode->getInstructionsDepth());
+
     if (termReason == Executor::Assert) {
       TxTreeGraph::setError(state, TxTreeGraph::ASSERTION);
     } else if (termReason == Executor::Ptr &&
                messaget.str() == "memory error: out of bound pointer") {
       TxTreeGraph::setError(state, TxTreeGraph::MEMORY);
     } else {
+      state.txTreeNode->setGenericError();
       TxTreeGraph::setError(state, TxTreeGraph::GENERIC);
     }
   }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3206,6 +3206,7 @@ void Executor::terminateStateEarly(ExecutionState &state,
     interpreterHandler->incBranchingDepthOnEarlyTermination(state.depth);
     interpreterHandler->incInstructionsDepthOnEarlyTermination(
         state.txTreeNode->getInstructionsDepth());
+    state.txTreeNode->setGenericEarlyTermination();
   }
 
   if (!OnlyOutputStatesCoveringNew || state.coveredNew ||

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3304,7 +3304,7 @@ void Executor::terminateStateOnError(ExecutionState &state,
                messaget.str() == "memory error: out of bound pointer") {
       TxTreeGraph::setError(state, TxTreeGraph::MEMORY);
     } else {
-      state.txTreeNode->setGenericError();
+      state.txTreeNode->setGenericEarlyTermination();
       TxTreeGraph::setError(state, TxTreeGraph::GENERIC);
     }
   }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1230,12 +1230,8 @@ void Executor::executeGetValue(ExecutionState &state,
       ExecutionState *es = *bit;
       if (es)
         bindLocal(target, *es, *vit);
-      if (INTERPOLATION_ENABLED) {
-        std::vector<ref<Expr> > args;
-        args.push_back(e);
-        args.push_back(*vit);
-        TxTree::executeOnNode(es->txTreeNode, target->inst, args);
-      }
+      if (INTERPOLATION_ENABLED)
+        TxTree::executeOnNode(es->txTreeNode, target->inst, e, *vit);
       ++bit;
     }
   }

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2057,7 +2057,12 @@ void TxTree::remove(TxTreeNode *node, bool dumping) {
 
     // As the node is about to be deleted, it must have been completely
     // traversed, hence the correct time to table the interpolant.
-    if (!dumping && !node->isSubsumed && node->storable) {
+    //
+    // We don't create an interpolant for an error node of generic error type:
+    // This is because a generic error returns no information (true), which
+    // should not be used for subsuming.
+    if (!dumping && !node->isSubsumed && node->storable &&
+        !node->genericError) {
       int debugSubsumptionLevel = node->dependency->debugSubsumptionLevel;
 
       if (debugSubsumptionLevel >= 2) {
@@ -2084,8 +2089,9 @@ void TxTree::remove(TxTreeNode *node, bool dumping) {
       }
     }
 
-    delete node;
     if (p) {
+      if (!p->genericError)
+        p->genericError = node->genericError;
       if (node == p->left) {
         p->left = 0;
       } else {
@@ -2093,6 +2099,7 @@ void TxTree::remove(TxTreeNode *node, bool dumping) {
         p->right = 0;
       }
     }
+    delete node;
     node = p;
   } while (node && !node->left && !node->right);
 #endif

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2244,7 +2244,7 @@ TxTreeNode::TxTreeNode(
       graph(_parent ? _parent->graph : 0),
       instructionsDepth(_parent ? _parent->instructionsDepth : 0),
       targetData(_targetData), globalAddresses(_globalAddresses),
-      isSubsumed(false) {
+      genericError(false), isSubsumed(false) {
   if (_parent) {
     entryCallHistory = _parent->callHistory;
     callHistory = _parent->callHistory;

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2062,7 +2062,7 @@ void TxTree::remove(TxTreeNode *node, bool dumping) {
     // This is because a generic error returns no information (true), which
     // should not be used for subsuming.
     if (!dumping && !node->isSubsumed && node->storable &&
-        !node->genericError) {
+        !node->genericEarlyTermination) {
       int debugSubsumptionLevel = node->dependency->debugSubsumptionLevel;
 
       if (debugSubsumptionLevel >= 2) {
@@ -2090,8 +2090,8 @@ void TxTree::remove(TxTreeNode *node, bool dumping) {
     }
 
     if (p) {
-      if (!p->genericError)
-        p->genericError = node->genericError;
+      if (!p->genericEarlyTermination)
+        p->genericEarlyTermination = node->genericEarlyTermination;
       if (node == p->left) {
         p->left = 0;
       } else {
@@ -2251,7 +2251,7 @@ TxTreeNode::TxTreeNode(
       graph(_parent ? _parent->graph : 0),
       instructionsDepth(_parent ? _parent->instructionsDepth : 0),
       targetData(_targetData), globalAddresses(_globalAddresses),
-      genericError(false), isSubsumed(false) {
+      genericEarlyTermination(false), isSubsumed(false) {
   if (_parent) {
     entryCallHistory = _parent->callHistory;
     callHistory = _parent->callHistory;

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2141,37 +2141,6 @@ void TxTree::markPathCondition(ExecutionState &state, TimingSolver *solver,
   currentTxTreeNode->unsatCoreInterpolation(unsatCore);
 }
 
-void TxTree::execute(llvm::Instruction *instr) {
-  std::vector<ref<Expr> > dummyArgs;
-  executeOnNode(currentTxTreeNode, instr, dummyArgs);
-}
-
-void TxTree::execute(llvm::Instruction *instr, ref<Expr> arg1) {
-  std::vector<ref<Expr> > args;
-  args.push_back(arg1);
-  executeOnNode(currentTxTreeNode, instr, args);
-}
-
-void TxTree::execute(llvm::Instruction *instr, ref<Expr> arg1, ref<Expr> arg2) {
-  std::vector<ref<Expr> > args;
-  args.push_back(arg1);
-  args.push_back(arg2);
-  executeOnNode(currentTxTreeNode, instr, args);
-}
-
-void TxTree::execute(llvm::Instruction *instr, ref<Expr> arg1, ref<Expr> arg2,
-                     ref<Expr> arg3) {
-  std::vector<ref<Expr> > args;
-  args.push_back(arg1);
-  args.push_back(arg2);
-  args.push_back(arg3);
-  executeOnNode(currentTxTreeNode, instr, args);
-}
-
-void TxTree::execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args) {
-  executeOnNode(currentTxTreeNode, instr, args);
-}
-
 void TxTree::executePHI(llvm::Instruction *instr, unsigned incomingBlock,
                         ref<Expr> valueExpr) {
   currentTxTreeNode->dependency->executePHI(instr, incomingBlock,

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -399,6 +399,9 @@ class TxTreeNode {
   /// is just a pointer to the one in klee::Executor.
   std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *globalAddresses;
 
+  /// \brief Indicates that a generic error was encountered in this node
+  bool genericError;
+
   void setProgramPoint(llvm::Instruction *instr) {
     if (!programPoint)
       programPoint = reinterpret_cast<uintptr_t>(instr);
@@ -538,6 +541,8 @@ public:
                                        const std::string &reason) {
     dependency->markAllValues(value, address, reason);
   }
+
+  void setGenericError() { genericError = true; }
 
   /// \brief Print the content of the tree node object to the LLVM error stream.
   void dump() const;

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -400,7 +400,7 @@ class TxTreeNode {
   std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *globalAddresses;
 
   /// \brief Indicates that a generic error was encountered in this node
-  bool genericError;
+  bool genericEarlyTermination;
 
   void setProgramPoint(llvm::Instruction *instr) {
     if (!programPoint)
@@ -548,7 +548,7 @@ public:
     dependency->markAllValues(value, address, reason);
   }
 
-  void setGenericError() { genericError = true; }
+  void setGenericEarlyTermination() { genericEarlyTermination = true; }
 
   /// \brief Print the content of the tree node object to the LLVM error stream.
   void dump() const;

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -754,26 +754,36 @@ public:
   std::pair<TxTreeNode *, TxTreeNode *>
   split(TxTreeNode *parent, ExecutionState *left, ExecutionState *right);
 
-  /// \brief Abstractly execute an instruction of no argument for building
-  /// dependency information.
-  void execute(llvm::Instruction *instr);
+  /// \brief Execute an instruction of no argument for building dependency
+  /// information.
+  void execute(llvm::Instruction *instr) {
+    executeOnNode(currentTxTreeNode, instr);
+  }
 
-  /// \brief Abstractly execute an instruction of one argument for building
-  /// dependency information.
-  void execute(llvm::Instruction *instr, ref<Expr> arg1);
+  /// \brief Execute an instruction of one argument for building dependency
+  /// information.
+  void execute(llvm::Instruction *instr, ref<Expr> arg1) {
+    executeOnNode(currentTxTreeNode, instr, arg1);
+  }
 
-  /// \brief Abstractly execute an instruction of two arguments for building
-  /// dependency information.
-  void execute(llvm::Instruction *instr, ref<Expr> arg1, ref<Expr> arg2);
+  /// \brief Execute an instruction of two arguments for building dependency
+  /// information.
+  void execute(llvm::Instruction *instr, ref<Expr> arg1, ref<Expr> arg2) {
+    executeOnNode(currentTxTreeNode, instr, arg1, arg2);
+  }
 
-  /// \brief Abstractly execute an instruction of three arguments for building
-  /// dependency information.
+  /// \brief Execute an instruction of three arguments for building dependency
+  /// information.
   void execute(llvm::Instruction *instr, ref<Expr> arg1, ref<Expr> arg2,
-               ref<Expr> arg3);
+               ref<Expr> arg3) {
+    executeOnNode(currentTxTreeNode, instr, arg1, arg2, arg3);
+  }
 
-  /// \brief Abstractly execute an instruction of a number of arguments for
-  /// building dependency information.
-  void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
+  /// \brief Execute an instruction of a number of arguments for building
+  /// dependency information.
+  void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args) {
+    executeOnNode(currentTxTreeNode, instr, args);
+  }
 
   /// \brief Execution of klee_make_symbolic
   void executeMakeSymbolic(llvm::Instruction *instr, ref<Expr> address,
@@ -812,9 +822,45 @@ public:
     return ret;
   }
 
+  /// \brief Execute an instruction of no argument for building dependency
+  /// information, given a particular interpolation tree node.
+  static void executeOnNode(TxTreeNode *node, llvm::Instruction *instr) {
+    std::vector<ref<Expr> > dummyArgs;
+    executeOnNode(node, instr, dummyArgs);
+  }
+
+  /// \brief Execute an instruction of one argument for building dependency
+  /// information, given a particular interpolation tree node.
+  static void executeOnNode(TxTreeNode *node, llvm::Instruction *instr,
+                            ref<Expr> arg1) {
+    std::vector<ref<Expr> > args;
+    args.push_back(arg1);
+    executeOnNode(node, instr, args);
+  }
+
+  /// \brief Execute an instruction of two arguments for building dependency
+  /// information, given a particular interpolation tree node.
+  static void executeOnNode(TxTreeNode *node, llvm::Instruction *instr,
+                            ref<Expr> arg1, ref<Expr> arg2) {
+    std::vector<ref<Expr> > args;
+    args.push_back(arg1);
+    args.push_back(arg2);
+    executeOnNode(node, instr, args);
+  }
+
+  /// \brief Execute an instruction of three arguments for building dependency
+  /// information, given a particular interpolation tree node.
+  static void executeOnNode(TxTreeNode *node, llvm::Instruction *instr,
+                            ref<Expr> arg1, ref<Expr> arg2, ref<Expr> arg3) {
+    std::vector<ref<Expr> > args;
+    args.push_back(arg1);
+    args.push_back(arg2);
+    args.push_back(arg3);
+    executeOnNode(node, instr, args);
+  }
+
   /// \brief General member function for executing an instruction for building
-  /// dependency
-  /// information, given a particular Tracer-X tree node.
+  /// dependency information, given a particular interpolation tree node.
   static void executeOnNode(TxTreeNode *node, llvm::Instruction *instr,
                             std::vector<ref<Expr> > &args);
 

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -536,6 +536,12 @@ public:
     return dependency->markAllPointerValues(value, address, bounds, reason);
   }
 
+  /// \brief Interpolation for memory bound violation
+  void memoryBoundViolationInterpolation(llvm::Instruction *inst,
+                                         ref<Expr> address) {
+    dependency->memoryBoundViolationInterpolation(inst, address);
+  }
+
   /// \brief Exact pointer value interpolation from a target address
   void exactPointerValuesInterpolation(llvm::Value *value, ref<Expr> address,
                                        const std::string &reason) {

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -880,7 +880,10 @@ void TxStateValue::printMinimal(llvm::raw_ostream &stream,
   value->print(stream);
   stream << "\n";
   stream << prefix << "expression: ";
-  valueExpr->print(stream);
+  if (!valueExpr.isNull())
+    valueExpr->print(stream);
+  else
+    stream << "NULL";
   stream << "\n";
   stream << prefix
          << "pointer to location object: " << reinterpret_cast<uintptr_t>(this);


### PR DESCRIPTION
In Tracer-X KLEE, a error can be masked by another error, since we generate TRUE interpolant from an error, which would subsume anything. If an error potentially exists further in the execution, due to this premature termination of the symbolic execution, coupled with the TRUE interpolant, the error would not be found. The example that shows this problem is `masked_error.c` in tracer-x/klee-examples#142.