### PR TITLE
Added simplification of and expression in SubsumptionTableEntry::subs…

### DIFF
--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1308,6 +1308,10 @@ bool SubsumptionTableEntry::subsumed(
       expr = simplifyExistsExpr(existsExpr, exprHasNoFreeVariables);
     }
 
+    // We finally simplify the conjunction using create()
+    if (llvm::isa<AndExpr>(expr))
+      expr = AndExpr::create(expr->getKid(0), expr->getKid(1));
+
     // If query expression simplification result was false, we quickly fail
     // without calling the solver
     if (expr->isFalse()) {


### PR DESCRIPTION
…umed() to simplify `true and true` to just `true`. This results in reduced solving time from > 30s to about 24 s for the following example, as a single `true` as the expression (consequent) prevents query submission to the constraint solver.
```
/*
 * From Avgerinos et al.: Enhancing Symbolic Execution with
 * Veritesting, with modifications proposed by Chu Duc Hiep.
 *
 * In this example, Tracer-X KLEE over-subsumes and not able to
 * demonstrate the assertion violation, which can be demonstrated by
 * LLBMC. In this version, the variable start is also initialized to 0
 * to ease debugging.
 *
 * To run with LLBMC, compile with -DLLBMC, and execute LLBMC with the
 * options --ignore-missing-function-bodies -function-name=main
 * -no-overflow-checks -max-loop-iterations=0
 * -max-function-call-depth=0 -counterexample.
 *
 * Portions copyright 2017 National University of Singapore
 */
#ifdef LLBMC
#include <llbmc.h>
#else
#include <klee/klee.h>
#include <assert.h>
#endif

int main(int argc, char **argv)
{
  int counter, start;
  char input[100];
  
#ifdef LLBMC
  for (int i = 0; i < 100; ++i) {
    input[i] = __llbmc_nondef_int();
  }
#else
  klee_make_symbolic(input, 100 * sizeof(char), "input");
#endif

  start = 0;
  counter = start;
  
  for (int i = 0; i < 100; i++) {
      if (input[i] == 'B') {
	counter++;
      } else {
	counter += i;
      }
  }

#ifdef LLBMC
  __llbmc_assert(counter != start + 501);
#else
  klee_assert(counter != start + 501);
#endif
  
  return 0;
}
```