### PR TITLE
Subsumption interpolation accuracy correction

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -325,6 +325,10 @@ private:
   /// \brief Reason this was stored as needed value
   std::set<std::string> coreReasons;
 
+  /// \brief The original state value, which is used in subsumption check
+  /// interpolation to propagate this value to interpolation marking
+  ref<TxStateValue> originalValue;
+
   void init(llvm::Value *_value, ref<Expr> _expr, bool canInterpolateBound,
             const std::set<std::string> &_coreReasons,
             const std::set<ref<TxStateAddress> > _locations,
@@ -396,6 +400,10 @@ public:
   ref<Expr> getExpression() const { return expr; }
 
   llvm::Value *getValue() const { return value; }
+
+  void setOriginalValue(ref<TxStateValue> value) { originalValue = value; }
+
+  ref<TxStateValue> getOriginalValue() const { return originalValue; }
 
   void print(llvm::raw_ostream &stream) const;
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1153,9 +1153,9 @@ bool Dependency::executeMemoryOperation(
         stream.flush();
       }
       if (ExactAddressInterpolant) {
-        markAllValues(addressOperand, address, reason);
+        markAllValues(val, reason);
       } else {
-        ret = markAllPointerValues(addressOperand, address, reason);
+        ret = markAllPointerValues(val, reason);
       }
     }
   }
@@ -1217,10 +1217,8 @@ void Dependency::bindReturnValue(llvm::CallInst *site,
   }
 }
 
-void Dependency::markAllValues(llvm::Value *val, ref<Expr> expr,
+void Dependency::markAllValues(ref<TxStateValue> value,
                                const std::string &reason) {
-  ref<TxStateValue> value = getLatestValueForMarking(val, expr);
-
   if (value.isNull())
     return;
 
@@ -1228,11 +1226,9 @@ void Dependency::markAllValues(llvm::Value *val, ref<Expr> expr,
   store->markUsed(value->getEntryList());
 }
 
-bool Dependency::markAllPointerValues(llvm::Value *val, ref<Expr> address,
+bool Dependency::markAllPointerValues(ref<TxStateValue> value,
                                       std::set<ref<Expr> > &bounds,
                                       const std::string &reason) {
-  ref<TxStateValue> value = getLatestValueForMarking(val, address);
-
   if (value.isNull())
     return false;
 
@@ -1298,7 +1294,7 @@ void Dependency::memoryBoundViolationInterpolation(llvm::Instruction *inst,
       stream << "]";
       stream.flush();
     }
-    markAllValues(addressOperand, address, reason);
+    markAllValues(val, reason);
   }
 }
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -442,24 +442,31 @@ namespace klee {
                          std::vector<llvm::Instruction *> &callHistory,
                          llvm::Instruction *inst, ref<Expr> returnValue);
 
-    /// \brief Given an LLVM value, retrieve all its sources and mark them as in
-    /// the core.
+    /// \brief Given an LLVM value and the expression it is associated with,
+    /// retrieve all the sources and mark them as in the core
     void markAllValues(llvm::Value *value, ref<Expr> expr,
-                       const std::string &reason);
+                       const std::string &reason) {
+      ref<TxStateValue> stateValue = getLatestValueForMarking(value, expr);
+      markAllValues(stateValue, reason);
+    }
+
+    /// \brief Given a state value, retrieve all its sources and mark them as in
+    /// the core
+    void markAllValues(ref<TxStateValue> value, const std::string &reason);
 
     /// \brief Given an LLVM value which is used as an address, retrieve all its
     /// sources and mark them as in the core. Returns true if bounds error was
     /// detected; false otherwise.
-    bool markAllPointerValues(llvm::Value *val, ref<Expr> address,
+    bool markAllPointerValues(ref<TxStateValue> value,
                               const std::string &reason) {
       std::set<ref<Expr> > bounds;
-      return markAllPointerValues(val, address, bounds, reason);
+      return markAllPointerValues(value, bounds, reason);
     }
 
     /// \brief Given an LLVM value which is used as an address, retrieve all its
     /// sources and mark them as in the core. Returns true if bounds error was
     /// detected; false otherwise.
-    bool markAllPointerValues(llvm::Value *val, ref<Expr> address,
+    bool markAllPointerValues(ref<TxStateValue> value,
                               std::set<ref<Expr> > &bounds,
                               const std::string &reason);
 

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -145,7 +145,11 @@ inline void TxStore::concreteToInterpolant(
     std::set<const Array *> &replacements, bool coreOnly,
     LowerInterpolantStore &map, bool leftRetrieval) const {
   if (!coreOnly) {
-    map[variable] = entry->getContent()->getInterpolantStyleValue();
+    ref<TxStateValue> stateValue = entry->getContent();
+    ref<TxInterpolantValue> interpolantValue =
+        stateValue->getInterpolantStyleValue();
+    interpolantValue->setOriginalValue(stateValue);
+    map[variable] = interpolantValue;
   } else if (entry->getContent()->isCore()) {
     // Do not add to the map if entry is not used
     if (leftRetrieval) {
@@ -174,7 +178,11 @@ inline void TxStore::symbolicToInterpolant(
     std::set<const Array *> &replacements, bool coreOnly,
     LowerInterpolantStore &map, bool leftRetrieval) const {
   if (!coreOnly) {
-    map[variable] = entry->getContent()->getInterpolantStyleValue();
+    ref<TxStateValue> stateValue = entry->getContent();
+    ref<TxInterpolantValue> interpolantValue =
+        stateValue->getInterpolantStyleValue();
+    interpolantValue->setOriginalValue(stateValue);
+    map[variable] = interpolantValue;
   } else if (entry->getContent()->isCore()) {
     // Do not add to the map if entry is not used
     if (leftRetrieval) {

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -193,9 +193,8 @@ class SubsumptionTableEntry {
   ref<Expr> makeConstraint(
       ExecutionState &state, ref<TxInterpolantValue> tabledValue,
       ref<TxInterpolantValue> stateValue, ref<Expr> tabledOffset,
-      ref<Expr> stateOffset, std::set<ref<TxInterpolantValue> > &coreValues,
-      std::map<ref<TxInterpolantValue>, std::set<ref<Expr> > > &
-          corePointerValues,
+      ref<Expr> stateOffset, std::set<ref<TxStateValue> > &coreValues,
+      std::map<ref<TxStateValue>, std::set<ref<Expr> > > &corePointerValues,
       std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
       int debugSubsumptionLevel) const;
 
@@ -288,12 +287,10 @@ class SubsumptionTableEntry {
   static ref<Expr> removeUnsubstituted(std::set<const Array *> &variables,
                                        ref<Expr> equalities);
 
-  static void
-  interpolateValues(ExecutionState &state,
-                    std::set<ref<TxInterpolantValue> > &coreValues,
-                    std::map<ref<TxInterpolantValue>, std::set<ref<Expr> > > &
-                        corePointerValues,
-                    int debugSubsumptionLevel);
+  static void interpolateValues(
+      ExecutionState &state, std::set<ref<TxStateValue> > &coreValues,
+      std::map<ref<TxStateValue>, std::set<ref<Expr> > > &corePointerValues,
+      int debugSubsumptionLevel);
 
   bool empty() {
     return interpolant.isNull() && concretelyAddressedStore.empty() &&
@@ -537,10 +534,10 @@ public:
 
   /// \brief Memory bounds interpolation from a target address. Returns true if
   /// memory bounds check fails somehow.
-  bool pointerValuesInterpolation(llvm::Value *value, ref<Expr> address,
+  bool pointerValuesInterpolation(ref<TxStateValue> value,
                                   std::set<ref<Expr> > &bounds,
                                   const std::string &reason) {
-    return dependency->markAllPointerValues(value, address, bounds, reason);
+    return dependency->markAllPointerValues(value, bounds, reason);
   }
 
   /// \brief Interpolation for memory bound violation
@@ -550,9 +547,8 @@ public:
   }
 
   /// \brief Exact / non-pointer value interpolation
-  void valuesInterpolation(llvm::Value *value, ref<Expr> expr,
-                           const std::string &reason) {
-    dependency->markAllValues(value, expr, reason);
+  void valuesInterpolation(ref<TxStateValue> value, const std::string &reason) {
+    dependency->markAllValues(value, reason);
   }
 
   void setGenericEarlyTermination() { genericEarlyTermination = true; }


### PR DESCRIPTION
In this PR, we avoid the use of `Dependency::getLatestValueForMarking()` (called from `Dependency::markAllValues()`) when interpolating on subsumption check. The use of `getLatestValue()` here is inaccurate since the core values in the interpolant are sometimes historical (not the latest), for example, the contents of the allocated memory regions in a data structure which can no longer be traversed from the most recent value of an LLVM register. `make check` succeeds, and `make` in the `basic` directory results in different subsumption count for `pointer_struct6.c`, which is an example implementing a tree.