### PR TITLE
Correction to the construction of existentially-quantified formula for Z3

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -387,6 +387,18 @@ public:
 
   bool isPointer() const { return !allocationOffsets.empty(); }
 
+  /// \brief Get bounds check expression.
+  ///
+  /// \param svalue The value that comes from the program state to be checked
+  /// for subsumption.
+  /// \param [out] bounds The checked bounds to be used in bounds interpolation.
+  /// \param [out] unifiedBases The mapping between base addresses to be
+  /// considered the same in subsumption check.
+  /// \param debugSubsumptionLevel The verbosity level of debug information
+  /// display.
+  ///
+  /// \return Null expression when a symbolic bound exists in the interpolant,
+  /// the bound checking constraint otherwise.
   ref<Expr> getBoundsCheck(
       ref<TxInterpolantValue> svalue, std::set<ref<Expr> > &bounds,
       std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -927,26 +927,31 @@ bool SubsumptionTableEntry::subsumed(
             return false;
           } else if (Dependency::boundInterpolation() &&
                      tabledValue->isPointer() && stateValue->isPointer()) {
+            ref<Expr> boundsCheck;
             if (!ExactAddressInterpolant && tabledValue->useBound()) {
               std::set<ref<Expr> > bounds;
-              ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
+              boundsCheck = tabledValue->getBoundsCheck(
                   stateValue, bounds, unifiedBases, debugSubsumptionLevel);
-              if (boundsCheck->isFalse()) {
-                if (debugSubsumptionLevel >= 1) {
-                  std::string msg;
-                  klee_message("#%lu=>#%lu: Check failure due to failure in "
-                               "memory bounds check%s",
-                               state.txTreeNode->getNodeSequenceNumber(),
-                               nodeSequenceNumber, msg.c_str());
+              if (!boundsCheck.isNull()) {
+                if (boundsCheck->isFalse()) {
+                  if (debugSubsumptionLevel >= 1) {
+                    std::string msg;
+                    klee_message("#%lu=>#%lu: Check failure due to failure in "
+                                 "memory bounds check%s",
+                                 state.txTreeNode->getNodeSequenceNumber(),
+                                 nodeSequenceNumber, msg.c_str());
+                  }
+                  return false;
                 }
-                return false;
-              }
-              if (!boundsCheck->isTrue())
-                res = boundsCheck;
+                if (!boundsCheck->isTrue())
+                  res = boundsCheck;
 
-              // We record the LLVM value of the pointer
-              corePointerValues[stateValue->getOriginalValue()] = bounds;
-            } else {
+                // We record the LLVM value of the pointer
+                corePointerValues[stateValue->getOriginalValue()] = bounds;
+              }
+            }
+
+            if (boundsCheck.isNull()) {
               ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
                   stateValue, unifiedBases, debugSubsumptionLevel);
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -83,60 +83,63 @@ ref<Expr> SubsumptionTableEntry::makeConstraint(
       ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
           stateValue, bounds, unifiedBases, debugSubsumptionLevel);
 
-      if (!boundsCheck->isTrue()) {
-        if (!boundsCheck->isFalse()) {
-          // Implication: if tabled (interpolant)'s address == state address
-          // then bounds check must hold
-          constraint =
-              EqExpr::create(ConstantExpr::create(0, Expr::Bool),
-                             EqExpr::create(tabledOffset, stateOffset));
-          constraint = OrExpr::create(constraint, boundsCheck);
-        } else {
-          if (debugSubsumptionLevel >= 1) {
-            std::string msg;
-            klee_message("#%lu=>#%lu: Check failure due to failure in "
-                         "memory bounds check%s",
-                         state.txTreeNode->getNodeSequenceNumber(),
-                         nodeSequenceNumber, msg.c_str());
+      if (!boundsCheck.isNull()) {
+        if (!boundsCheck->isTrue()) {
+          if (!boundsCheck->isFalse()) {
+            // Implication: if tabled (interpolant)'s address == state address
+            // then bounds check must hold
+            constraint =
+                EqExpr::create(ConstantExpr::create(0, Expr::Bool),
+                               EqExpr::create(tabledOffset, stateOffset));
+            constraint = OrExpr::create(constraint, boundsCheck);
+          } else {
+            if (debugSubsumptionLevel >= 1) {
+              std::string msg;
+              klee_message("#%lu=>#%lu: Check failure due to failure in "
+                           "memory bounds check%s",
+                           state.txTreeNode->getNodeSequenceNumber(),
+                           nodeSequenceNumber, msg.c_str());
+            }
+
+            assert(constraint.isNull() && "must return a null constraint");
+            return constraint;
           }
-
-          assert(constraint.isNull() && "must return a null constraint");
-          return constraint;
         }
-      }
 
-      // We record the LLVM value of the pointer
-      corePointerValues[stateValue->getOriginalValue()] = bounds;
-    } else {
-      ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
-          stateValue, unifiedBases, debugSubsumptionLevel);
-      if (offsetsCheck->isFalse()) {
-        if (debugSubsumptionLevel >= 1) {
-          klee_message("#%lu=>#%lu: Check failure due to failure in "
-                       "offset equality check",
-                       state.txTreeNode->getNodeSequenceNumber(),
-                       nodeSequenceNumber);
-        }
+        // We record the LLVM value of the pointer
+        corePointerValues[stateValue->getOriginalValue()] = bounds;
         return constraint;
       }
-      if (!offsetsCheck->isTrue())
-        constraint = offsetsCheck;
-
-      // We record the value of the pointer for interpolation marking
-      coreValues.insert(stateValue->getOriginalValue());
     }
-  } else {
-    // Implication: if tabledConcreteAddress == stateSymbolicAddress,
-    // then tabledValue->getExpression() ==
-    // stateValue->getExpression()
-    constraint = OrExpr::create(
-        EqExpr::create(ConstantExpr::create(0, Expr::Bool),
-                       EqExpr::create(tabledOffset, stateOffset)),
-        EqExpr::create(tabledValue->getExpression(),
-                       stateValue->getExpression()));
 
+    ref<Expr> offsetsCheck = tabledValue->getOffsetsCheck(
+        stateValue, unifiedBases, debugSubsumptionLevel);
+    if (offsetsCheck->isFalse()) {
+      if (debugSubsumptionLevel >= 1) {
+        klee_message("#%lu=>#%lu: Check failure due to failure in "
+                     "offset equality check",
+                     state.txTreeNode->getNodeSequenceNumber(),
+                     nodeSequenceNumber);
+      }
+      return constraint;
+    }
+    if (!offsetsCheck->isTrue())
+      constraint = offsetsCheck;
+
+    // We record the value of the pointer for interpolation marking
     coreValues.insert(stateValue->getOriginalValue());
+    return constraint;
   }
+
+  // Implication: if tabledConcreteAddress == stateSymbolicAddress, then
+  // tabledValue->getExpression() == stateValue->getExpression()
+  constraint =
+      OrExpr::create(EqExpr::create(ConstantExpr::create(0, Expr::Bool),
+                                    EqExpr::create(tabledOffset, stateOffset)),
+                     EqExpr::create(tabledValue->getExpression(),
+                                    stateValue->getExpression()));
+
+  coreValues.insert(stateValue->getOriginalValue());
   return constraint;
 }
 

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -367,14 +367,12 @@ ref<Expr> TxInterpolantValue::getBoundsCheck(
           }
           continue;
         }
-        // Create constraints for symbolic bounds
-        if (res.isNull()) {
-          res = UltExpr::create(*otherOffsetsIt, *selfBoundsIt);
-        } else {
-          res = AndExpr::create(UltExpr::create(*otherOffsetsIt, *selfBoundsIt),
-                                res);
-        }
-        bounds.insert(*selfBoundsIt);
+
+        // We return a null expression signaling that we have encountered a
+        // symbolic bound. In this case, the caller should switch to checking
+        // the exact offset.
+        ref<Expr> nullExpression;
+        return nullExpression;
       }
     }
   }

--- a/lib/Solver/Z3Builder.cpp
+++ b/lib/Solver/Z3Builder.cpp
@@ -866,16 +866,11 @@ Z3Builder::QuantificationContext::QuantificationContext(
     Z3_ast bound = Z3_mk_const(ctx, s, t);
     existentials[(*it)->name] = Z3ASTHandle(bound, ctx);
     boundVariables.push_back((Z3_app)bound);
-    sorts.push_back(Z3_mk_array_sort(_ctx, Z3_mk_bv_sort(_ctx, (*it)->domain),
-                                     Z3_mk_bv_sort(_ctx, (*it)->range)));
-    symbols.push_back(Z3_mk_string_symbol(_ctx, (*it)->name.c_str()));
   }
 }
 
 Z3Builder::QuantificationContext::~QuantificationContext() {
   existentials.clear();
-  sorts.clear();
-  symbols.clear();
 }
 
 void

--- a/lib/Solver/Z3Builder.cpp
+++ b/lib/Solver/Z3Builder.cpp
@@ -43,6 +43,9 @@ void custom_z3_error_handler(Z3_context ctx, Z3_error_code ec) {
     // Solver timeout is not a fatal error
     return;
   }
+  if (INTERPOLATION_ENABLED && strcmp(errorMsg, "incomplete (theory array)")) {
+    return;
+  }
   llvm::errs() << "Error: Incorrect use of Z3. [" << ec << "] " << errorMsg
                << "\n";
   abort();

--- a/lib/Solver/Z3Builder.cpp
+++ b/lib/Solver/Z3Builder.cpp
@@ -869,10 +869,6 @@ Z3Builder::QuantificationContext::QuantificationContext(
   }
 }
 
-Z3Builder::QuantificationContext::~QuantificationContext() {
-  existentials.clear();
-}
-
 void
 Z3Builder::pushQuantificationContext(std::set<const Array *> existentials) {
   quantificationContext =

--- a/lib/Solver/Z3Builder.h
+++ b/lib/Solver/Z3Builder.h
@@ -114,6 +114,7 @@ class Z3Builder {
     std::map<std::string, Z3ASTHandle> existentials;
     std::vector<Z3_sort> sorts;
     std::vector<Z3_symbol> symbols;
+    std::vector<Z3_app> boundVariables;
     Z3_context ctx;
 
     QuantificationContext *parent;
@@ -127,6 +128,8 @@ class Z3Builder {
     ~QuantificationContext();
 
     unsigned size() { return symbols.size(); }
+
+    Z3_app *getBoundVariables() { return &boundVariables[0]; }
 
     Z3_symbol *getSymbols() { return &symbols[0]; }
 
@@ -220,6 +223,10 @@ private:
 
   Z3_sort *getQuantificationSorts() {
     return quantificationContext->getSorts();
+  }
+
+  Z3_app *getBoundVariables() {
+    return quantificationContext->getBoundVariables();
   }
 
 public:

--- a/lib/Solver/Z3Builder.h
+++ b/lib/Solver/Z3Builder.h
@@ -112,8 +112,6 @@ class Z3Builder {
   struct QuantificationContext {
 
     std::map<std::string, Z3ASTHandle> existentials;
-    std::vector<Z3_sort> sorts;
-    std::vector<Z3_symbol> symbols;
     std::vector<Z3_app> boundVariables;
     Z3_context ctx;
 
@@ -127,13 +125,9 @@ class Z3Builder {
 
     ~QuantificationContext();
 
-    unsigned size() { return symbols.size(); }
+    unsigned size() { return boundVariables.size(); }
 
     Z3_app *getBoundVariables() { return &boundVariables[0]; }
-
-    Z3_symbol *getSymbols() { return &symbols[0]; }
-
-    Z3_sort *getSorts() { return &sorts[0]; }
 
     Z3ASTHandle getBoundVar(std::string name);
 
@@ -216,14 +210,6 @@ private:
   void popQuantificationContext();
 
   unsigned getQuantificationSize() { return quantificationContext->size(); }
-
-  Z3_symbol *getQuantificationSymbols() {
-    return quantificationContext->getSymbols();
-  }
-
-  Z3_sort *getQuantificationSorts() {
-    return quantificationContext->getSorts();
-  }
 
   Z3_app *getBoundVariables() {
     return quantificationContext->getBoundVariables();

--- a/lib/Solver/Z3Builder.h
+++ b/lib/Solver/Z3Builder.h
@@ -123,7 +123,7 @@ class Z3Builder {
                           std::set<const Array *> _existentials,
                           QuantificationContext *_parent);
 
-    ~QuantificationContext();
+    ~QuantificationContext() {}
 
     unsigned size() { return boundVariables.size(); }
 

--- a/lib/Solver/Z3Builder.h
+++ b/lib/Solver/Z3Builder.h
@@ -117,8 +117,6 @@ class Z3Builder {
 
     QuantificationContext *parent;
 
-    Z3ASTHandle getBoundVarQuick(std::string name);
-
     QuantificationContext(Z3Builder *builder, Z3_context _ctx,
                           std::set<const Array *> _existentials,
                           QuantificationContext *_parent);
@@ -128,8 +126,6 @@ class Z3Builder {
     unsigned size() { return boundVariables.size(); }
 
     Z3_app *getBoundVariables() { return &boundVariables[0]; }
-
-    Z3ASTHandle getBoundVar(std::string name);
 
     QuantificationContext *getParent() { return parent; }
   };

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -208,6 +208,14 @@ bool Z3SolverImpl::internalRunSolver(
   // TODO: is the "simple_solver" the right solver to use for
   // best performance?
   Z3_solver theSolver = Z3_mk_simple_solver(builder->ctx);
+  if (INTERPOLATION_ENABLED) {
+    if (llvm::isa<ExistsExpr>(query.expr) ||
+        (llvm::isa<EqExpr>(query.expr) &&
+         llvm::isa<ExistsExpr>(query.expr->getKid(1)))) {
+      Z3_symbol abv = Z3_mk_string_symbol(builder->ctx, "ABV");
+      theSolver = Z3_mk_solver_for_logic(builder->ctx, abv);
+    }
+  }
   Z3_solver_inc_ref(builder->ctx, theSolver);
   Z3_solver_set_params(builder->ctx, theSolver, solverParameters);
 

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -348,6 +348,9 @@ SolverImpl::SolverRunStatus Z3SolverImpl::handleSolverResponse(
     if (strcmp(reason, "unknown") == 0) {
       return SolverImpl::SOLVER_RUN_STATUS_FAILURE;
     }
+    if (INTERPOLATION_ENABLED && strcmp(reason, "incomplete (theory array)")) {
+      return SolverImpl::SOLVER_RUN_STATUS_FAILURE;
+    }
     klee_warning("Unexpected solver failure. Reason is \"%s,\"\n", reason);
     abort();
   }


### PR DESCRIPTION
This resolves issue #194. `make check` succeeds and `make` in `basic` directory of `klee-examples` resulted in the increase of subsumption check counts for `pointer_symbolic.c` from 0 to 2.