### PR TITLE
Simplifications to memory bounds computation

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -440,11 +440,8 @@ private:
   /// \brief The absolute address
   ref<Expr> address;
 
-  /// \brief The expressions representing the bound on the offset, i.e., the
-  /// interpolant, in case it is symbolic.
-  std::set<ref<Expr> > symbolicOffsetBounds;
-
-  /// \brief This is the concrete offset bound
+  /// \brief This is the concrete offset bound. Its value is
+  /// klee::symbolicBoundId in case the bound should be symbolic
   uint64_t concreteOffsetBound;
 
   /// \brief The size of this allocation (0 means unknown)
@@ -568,9 +565,7 @@ public:
 
   ref<Expr> getBase() const { return variable->getBase(); }
 
-  const std::set<ref<Expr> > &getSymbolicOffsetBounds() const {
-    return symbolicOffsetBounds;
-  }
+  inline bool hasSymbolicOffsetBounds() const;
 
   ref<AllocationContext> getContext() const { return variable->getContext(); }
 

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -305,7 +305,7 @@ private:
   /// This constitutes the weakest liberal precondition of the memory checks
   /// against which the offsets of the pointer values of the current state are
   /// to be checked.
-  std::map<ref<AllocationInfo>, std::set<ref<Expr> > > allocationBounds;
+  std::map<ref<AllocationInfo>, std::set<uint64_t> > allocationBounds;
 
   /// \brief In case the stored value was a pointer, then this should be a
   /// non-empty map mapping of allocation sites to the set of offsets. This is
@@ -400,7 +400,7 @@ public:
   /// \return Null expression when a symbolic bound exists in the interpolant,
   /// the bound checking constraint otherwise.
   ref<Expr> getBoundsCheck(
-      ref<TxInterpolantValue> svalue, std::set<ref<Expr> > &bounds,
+      ref<TxInterpolantValue> svalue, std::set<uint64_t> &bounds,
       std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
       int debugSubsumptionLevel) const;
 
@@ -556,7 +556,7 @@ public:
   /// \brief Adjust the offset bound for interpolation (a.k.a. slackening).
   /// Returns true if a memory bound violation is detected, and false if not.
   bool adjustOffsetBound(ref<TxStateValue> checkedAddress,
-                         std::set<ref<Expr> > &bounds, bool &boundUpdated);
+                         std::set<uint64_t> &bounds, bool &boundUpdated);
 
   bool hasConstantAddress() const { return llvm::isa<ConstantExpr>(address); }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -336,7 +336,7 @@ void Dependency::markFlow(ref<TxStateValue> target,
 
 bool Dependency::markPointerFlow(ref<TxStateValue> target,
                                  ref<TxStateValue> checkedAddress,
-                                 std::set<ref<Expr> > &bounds,
+                                 std::set<uint64_t> &bounds,
                                  const std::string &reason) const {
   bool memoryError = false;
   bool boundUpdated = false;
@@ -1227,7 +1227,7 @@ void Dependency::markAllValues(ref<TxStateValue> value,
 }
 
 bool Dependency::markAllPointerValues(ref<TxStateValue> value,
-                                      std::set<ref<Expr> > &bounds,
+                                      std::set<uint64_t> &bounds,
                                       const std::string &reason) {
   if (value.isNull())
     return false;

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -312,7 +312,7 @@ namespace klee {
     void markPointerFlow(ref<TxStateValue> target,
                          ref<TxStateValue> checkedOffset,
                          const std::string &reason) const {
-      std::set<ref<Expr> > bounds;
+      std::set<uint64_t> bounds;
       markPointerFlow(target, checkedOffset, bounds, reason);
     }
 
@@ -321,7 +321,7 @@ namespace klee {
     /// slackening)
     bool markPointerFlow(ref<TxStateValue> target,
                          ref<TxStateValue> checkedOffset,
-                         std::set<ref<Expr> > &bounds,
+                         std::set<uint64_t> &bounds,
                          const std::string &reason) const;
 
     /// \brief Record the expressions of a call's arguments
@@ -459,7 +459,7 @@ namespace klee {
     /// detected; false otherwise.
     bool markAllPointerValues(ref<TxStateValue> value,
                               const std::string &reason) {
-      std::set<ref<Expr> > bounds;
+      std::set<uint64_t> bounds;
       return markAllPointerValues(value, bounds, reason);
     }
 
@@ -467,7 +467,7 @@ namespace klee {
     /// sources and mark them as in the core. Returns true if bounds error was
     /// detected; false otherwise.
     bool markAllPointerValues(ref<TxStateValue> value,
-                              std::set<ref<Expr> > &bounds,
+                              std::set<uint64_t> &bounds,
                               const std::string &reason);
 
     /// \brief Tests if bound interpolation shold be enabled

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -65,7 +65,7 @@ ref<Expr> SubsumptionTableEntry::makeConstraint(
     ExecutionState &state, ref<TxInterpolantValue> tabledValue,
     ref<TxInterpolantValue> stateValue, ref<Expr> tabledOffset,
     ref<Expr> stateOffset, std::set<ref<TxStateValue> > &coreValues,
-    std::map<ref<TxStateValue>, std::set<ref<Expr> > > &corePointerValues,
+    std::map<ref<TxStateValue>, std::set<uint64_t> > &corePointerValues,
     std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
     int debugSubsumptionLevel) const {
   ref<Expr> constraint;
@@ -79,7 +79,7 @@ ref<Expr> SubsumptionTableEntry::makeConstraint(
   } else if (Dependency::boundInterpolation() && tabledValue->isPointer() &&
              stateValue->isPointer()) {
     if (!ExactAddressInterpolant && tabledValue->useBound()) {
-      std::set<ref<Expr> > bounds;
+      std::set<uint64_t> bounds;
       ref<Expr> boundsCheck = tabledValue->getBoundsCheck(
           stateValue, bounds, unifiedBases, debugSubsumptionLevel);
 
@@ -763,7 +763,7 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
 
 void SubsumptionTableEntry::interpolateValues(
     ExecutionState &state, std::set<ref<TxStateValue> > &coreValues,
-    std::map<ref<TxStateValue>, std::set<ref<Expr> > > &corePointerValues,
+    std::map<ref<TxStateValue>, std::set<uint64_t> > &corePointerValues,
     int debugSubsumptionLevel) {
   std::string reason = "";
   if (debugSubsumptionLevel >= 1) {
@@ -794,7 +794,7 @@ void SubsumptionTableEntry::interpolateValues(
   if (Dependency::boundInterpolation() && !ExactAddressInterpolant) {
     reason = "interpolating memory bound for " + reason;
 
-    for (std::map<ref<TxStateValue>, std::set<ref<Expr> > >::iterator
+    for (std::map<ref<TxStateValue>, std::set<uint64_t> >::iterator
              it = corePointerValues.begin(),
              ie = corePointerValues.end();
          it != ie; ++it) {
@@ -838,7 +838,7 @@ bool SubsumptionTableEntry::subsumed(
   std::set<ref<TxStateValue> > coreValues;
 
   // Pointer values in the core for memory bounds interpolation.
-  std::map<ref<TxStateValue>, std::set<ref<Expr> > > corePointerValues;
+  std::map<ref<TxStateValue>, std::set<uint64_t> > corePointerValues;
 
   {
     TimerStatIncrementer t(concretelyAddressedStoreExpressionBuildTime);
@@ -929,7 +929,7 @@ bool SubsumptionTableEntry::subsumed(
                      tabledValue->isPointer() && stateValue->isPointer()) {
             ref<Expr> boundsCheck;
             if (!ExactAddressInterpolant && tabledValue->useBound()) {
-              std::set<ref<Expr> > bounds;
+              std::set<uint64_t> bounds;
               boundsCheck = tabledValue->getBoundsCheck(
                   stateValue, bounds, unifiedBases, debugSubsumptionLevel);
               if (!boundsCheck.isNull()) {

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -194,7 +194,7 @@ class SubsumptionTableEntry {
       ExecutionState &state, ref<TxInterpolantValue> tabledValue,
       ref<TxInterpolantValue> stateValue, ref<Expr> tabledOffset,
       ref<Expr> stateOffset, std::set<ref<TxStateValue> > &coreValues,
-      std::map<ref<TxStateValue>, std::set<ref<Expr> > > &corePointerValues,
+      std::map<ref<TxStateValue>, std::set<uint64_t> > &corePointerValues,
       std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
       int debugSubsumptionLevel) const;
 
@@ -289,7 +289,7 @@ class SubsumptionTableEntry {
 
   static void interpolateValues(
       ExecutionState &state, std::set<ref<TxStateValue> > &coreValues,
-      std::map<ref<TxStateValue>, std::set<ref<Expr> > > &corePointerValues,
+      std::map<ref<TxStateValue>, std::set<uint64_t> > &corePointerValues,
       int debugSubsumptionLevel);
 
   bool empty() {
@@ -535,7 +535,7 @@ public:
   /// \brief Memory bounds interpolation from a target address. Returns true if
   /// memory bounds check fails somehow.
   bool pointerValuesInterpolation(ref<TxStateValue> value,
-                                  std::set<ref<Expr> > &bounds,
+                                  std::set<uint64_t> &bounds,
                                   const std::string &reason) {
     return dependency->markAllPointerValues(value, bounds, reason);
   }

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -258,9 +258,7 @@ void TxInterpolantValue::init(llvm::Value *_value, ref<Expr> _expr,
         allocationBounds[allocInfo].insert(concreteBound);
 
       // Symbolic bounds
-      const std::set<ref<Expr> > &bounds = (*it)->getSymbolicOffsetBounds();
-
-      if (!bounds.empty()) {
+      if ((*it)->hasSymbolicOffsetBounds()) {
         allocationBounds[allocInfo].insert(symbolicBoundId);
       }
     }
@@ -733,13 +731,15 @@ bool TxStateAddress::adjustOffsetBound(ref<TxStateValue> checkedAddress,
         }
       }
 
-      symbolicOffsetBounds.insert(
-          SubExpr::create(Expr::createPointer(*it1),
-                          SubExpr::create(checkedOffset, getOffset())));
+      concreteOffsetBound = symbolicBoundId;
       boundUpdated = true;
     }
   }
   return false;
+}
+
+inline bool TxStateAddress::hasSymbolicOffsetBounds() const {
+  return !concreteBound(concreteOffsetBound);
 }
 
 ref<TxStateAddress>

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -35,6 +35,12 @@ using namespace klee;
 
 namespace klee {
 
+const uint64_t symbolicBoundId = ULONG_MAX;
+
+bool concreteBound(uint64_t bound) { return bound < ULONG_MAX; }
+
+/**/
+
 void TxStoreEntry::print(llvm::raw_ostream &stream,
                          const std::string &prefix) const {
   std::string tabsNext = appendTab(prefix);
@@ -249,32 +255,20 @@ void TxInterpolantValue::init(llvm::Value *_value, ref<Expr> _expr,
       std::set<ref<Expr> > newBounds;
 
       if (concreteBound > 0)
-        allocationBounds[allocInfo].insert(Expr::createPointer(concreteBound));
+        allocationBounds[allocInfo].insert(concreteBound);
 
       // Symbolic bounds
       const std::set<ref<Expr> > &bounds = (*it)->getSymbolicOffsetBounds();
 
-      if (shadowing) {
-        std::set<ref<Expr> > shadowBounds;
-        for (std::set<ref<Expr> >::const_iterator it1 = bounds.begin(),
-                                                  ie1 = bounds.end();
-             it1 != ie1; ++it1) {
-          shadowBounds.insert(
-              ShadowArray::getShadowExpression(*it1, replacements));
-        }
-        if (!shadowBounds.empty()) {
-          allocationBounds[allocInfo]
-              .insert(shadowBounds.begin(), shadowBounds.end());
-        }
-      } else if (!bounds.empty()) {
-        allocationBounds[allocInfo].insert(bounds.begin(), bounds.end());
+      if (!bounds.empty()) {
+        allocationBounds[allocInfo].insert(symbolicBoundId);
       }
     }
   }
 }
 
 ref<Expr> TxInterpolantValue::getBoundsCheck(
-    ref<TxInterpolantValue> other, std::set<ref<Expr> > &bounds,
+    ref<TxInterpolantValue> other, std::set<uint64_t> &bounds,
     std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases,
     int debugSubsumptionLevel) const {
   ref<Expr> res;
@@ -297,11 +291,11 @@ ref<Expr> TxInterpolantValue::getBoundsCheck(
   // information from the argument object; in this way resulting in
   // less iterations compared to doing it the other way around.
   bool matchFound = false;
-  for (std::map<ref<AllocationInfo>, std::set<ref<Expr> > >::const_iterator
+  for (std::map<ref<AllocationInfo>, std::set<uint64_t> >::const_iterator
            selfBoundsListIt = allocationBounds.begin(),
            selfBoundsListIe = allocationBounds.end();
        selfBoundsListIt != selfBoundsListIe; ++selfBoundsListIt) {
-    std::set<ref<Expr> > selfBounds = selfBoundsListIt->second;
+    std::set<uint64_t> selfBounds = selfBoundsListIt->second;
     std::map<ref<AllocationInfo>, std::set<ref<Expr> > >::iterator
     otherOffsetsListIt = other->allocationOffsets.find(selfBoundsListIt->first);
     if (otherOffsetsListIt == other->allocationOffsets.end()) {
@@ -328,13 +322,11 @@ ref<Expr> TxInterpolantValue::getBoundsCheck(
              otherOffsetsIt = otherOffsets.begin(),
              otherOffsetsIe = otherOffsets.end();
          otherOffsetsIt != otherOffsetsIe; ++otherOffsetsIt) {
-      for (std::set<ref<Expr> >::const_iterator
-               selfBoundsIt = selfBounds.begin(),
-               selfBoundsIe = selfBounds.end();
+      for (std::set<uint64_t>::const_iterator selfBoundsIt = selfBounds.begin(),
+                                              selfBoundsIe = selfBounds.end();
            selfBoundsIt != selfBoundsIe; ++selfBoundsIt) {
-        if (ConstantExpr *selfBoundObj =
-                llvm::dyn_cast<ConstantExpr>(*selfBoundsIt)) {
-          uint64_t selfBound = selfBoundObj->getZExtValue();
+        uint64_t selfBound = *selfBoundsIt;
+        if (concreteBound(selfBound)) {
           if (ConstantExpr *otherOffsetObj =
                   llvm::dyn_cast<ConstantExpr>(*otherOffsetsIt)) {
             if (selfBound > 0) {
@@ -358,12 +350,15 @@ ref<Expr> TxInterpolantValue::getBoundsCheck(
             // Symbolic state offset, but concrete tabled bound. Here the bound
             // is known (non-zero), so we create constraints
             if (res.isNull()) {
-              res = UltExpr::create(*otherOffsetsIt, *selfBoundsIt);
+              res = UltExpr::create(*otherOffsetsIt,
+                                    Expr::createPointer(selfBound));
             } else {
               res = AndExpr::create(
-                  UltExpr::create(*otherOffsetsIt, *selfBoundsIt), res);
+                  UltExpr::create(*otherOffsetsIt,
+                                  Expr::createPointer(selfBound)),
+                  res);
             }
-            bounds.insert(*selfBoundsIt);
+            bounds.insert(selfBound);
           }
           continue;
         }
@@ -383,7 +378,7 @@ ref<Expr> TxInterpolantValue::getBoundsCheck(
       return ConstantExpr::create(1, Expr::Bool);
     else {
       // Match not found; we force match via address translation
-      for (std::map<ref<AllocationInfo>, std::set<ref<Expr> > >::const_iterator
+      for (std::map<ref<AllocationInfo>, std::set<uint64_t> >::const_iterator
                selfBoundsListIt = allocationBounds.begin(),
                selfBoundsListIe = allocationBounds.end();
            selfBoundsListIt != selfBoundsListIe && !matchFound;
@@ -398,24 +393,30 @@ ref<Expr> TxInterpolantValue::getBoundsCheck(
                    otherSize = otherOffsetsListIt->first->getSize();
           if (selfSize == otherSize) {
             // Allocation sizes match
-            const std::set<ref<Expr> > &selfBounds = selfBoundsListIt->second;
+            const std::set<uint64_t> &selfBounds = selfBoundsListIt->second;
             const std::set<ref<Expr> > &otherOffsets =
                 otherOffsetsListIt->second;
             ref<Expr> expr;
-            for (std::set<ref<Expr> >::const_iterator
+            for (std::set<uint64_t>::const_iterator
                      selfBoundsIt = selfBounds.begin(),
                      selfBoundsIe = selfBounds.end();
                  selfBoundsIt != selfBoundsIe; ++selfBoundsIt) {
+              uint64_t selfBound = *selfBoundsIt;
               for (std::set<ref<Expr> >::const_iterator
                        otherOffsetsIt = otherOffsets.begin(),
                        otherOffsetsIe = otherOffsets.end();
                    otherOffsetsIt != otherOffsetsIe; ++otherOffsetsIt) {
-                // Create constraints for offset equalities
+                // Create constraints for offset inequalities
+                ref<Expr> conjunct;
+                if (concreteBound(selfBound))
+                  conjunct = UltExpr::create(*otherOffsetsIt,
+                                             Expr::createPointer(selfBound));
+                else
+                  conjunct = ConstantExpr::create(0, Expr::Bool);
                 if (expr.isNull()) {
-                  expr = UltExpr::create(*otherOffsetsIt, *selfBoundsIt);
+                  expr = conjunct;
                 } else {
-                  expr = AndExpr::create(
-                      UltExpr::create(*otherOffsetsIt, *selfBoundsIt), expr);
+                  expr = AndExpr::create(conjunct, expr);
                 }
               }
             }
@@ -602,7 +603,7 @@ void TxInterpolantValue::print(llvm::raw_ostream &stream,
 
   if (!doNotUseBound && !allocationBounds.empty()) {
     stream << prefix << "BOUNDS:";
-    for (std::map<ref<AllocationInfo>, std::set<ref<Expr> > >::const_iterator
+    for (std::map<ref<AllocationInfo>, std::set<uint64_t> >::const_iterator
              it = allocationBounds.begin(),
              ie = allocationBounds.end();
          it != ie; ++it) {
@@ -610,13 +611,15 @@ void TxInterpolantValue::print(llvm::raw_ostream &stream,
       stream << prefix << "[";
       it->first->print(stream);
       stream << "<{";
-      for (std::set<ref<Expr> >::const_iterator it1 = it->second.begin(),
-                                                is1 = it1,
-                                                ie1 = it->second.end();
+      for (std::set<uint64_t>::const_iterator it1 = it->second.begin(),
+                                              is1 = it1, ie1 = it->second.end();
            it1 != ie1; ++it1) {
         if (it1 != is1)
           stream << ",";
-        (*it1)->print(stream);
+        if (concreteBound(*it1))
+          stream << (*it1);
+        else
+          stream << "(symbolic)";
       }
       stream << "}]";
     }
@@ -669,17 +672,17 @@ void TxInterpolantValue::print(llvm::raw_ostream &stream,
 /**/
 
 bool TxStateAddress::adjustOffsetBound(ref<TxStateValue> checkedAddress,
-                                       std::set<ref<Expr> > &_bounds,
+                                       std::set<uint64_t> &_bounds,
                                        bool &boundUpdated) {
   const std::set<ref<TxStateAddress> > &locations =
       checkedAddress->getLocations();
-  std::set<ref<Expr> > bounds(_bounds);
+  std::set<uint64_t> bounds(_bounds);
 
   if (bounds.empty()) {
-    bounds.insert(Expr::createPointer(size));
+    bounds.insert(size);
   }
 
-  for (std::set<ref<Expr> >::iterator it1 = bounds.begin(), ie1 = bounds.end();
+  for (std::set<uint64_t>::iterator it1 = bounds.begin(), ie1 = bounds.end();
        it1 != ie1; ++it1) {
 
     for (std::set<ref<TxStateAddress> >::iterator it2 = locations.begin(),
@@ -688,53 +691,51 @@ bool TxStateAddress::adjustOffsetBound(ref<TxStateValue> checkedAddress,
       ref<Expr> checkedOffset = (*it2)->getOffset();
       if (ConstantExpr *c = llvm::dyn_cast<ConstantExpr>(checkedOffset)) {
         if (ConstantExpr *o = llvm::dyn_cast<ConstantExpr>(getOffset())) {
-          if (ConstantExpr *b = llvm::dyn_cast<ConstantExpr>(*it1)) {
-            uint64_t offsetInt = o->getZExtValue();
-            uint64_t newBound =
-                b->getZExtValue() - (c->getZExtValue() - offsetInt);
+          uint64_t offsetInt = o->getZExtValue();
+          uint64_t newBound = (*it1) - (c->getZExtValue() - offsetInt);
 
-            if (concreteOffsetBound > newBound) {
+          if (concreteOffsetBound > newBound) {
 
-              // FIXME: A quick hack to avoid assertion check to make DirSeek.c
-              // regression test pass.
-              llvm::Value *v = (*it2)->getContext()->getValue();
-              if (v->getType()->isPointerTy()) {
-                llvm::Type *elementType = v->getType()->getPointerElementType();
-                if (llvm::StructType *elementStructType =
-                        llvm::dyn_cast<llvm::StructType>(elementType)) {
-                  if (!elementStructType->isLiteral() &&
-                      elementType->getStructName() == "struct.dirent") {
-                    concreteOffsetBound = newBound;
-                    boundUpdated = true;
-                    continue;
-                  }
+            // FIXME: A quick hack to avoid assertion check to make DirSeek.c
+            // regression test pass.
+            llvm::Value *v = (*it2)->getContext()->getValue();
+            if (v->getType()->isPointerTy()) {
+              llvm::Type *elementType = v->getType()->getPointerElementType();
+              if (llvm::StructType *elementStructType =
+                      llvm::dyn_cast<llvm::StructType>(elementType)) {
+                if (!elementStructType->isLiteral() &&
+                    elementType->getStructName() == "struct.dirent") {
+                  concreteOffsetBound = newBound;
+                  boundUpdated = true;
+                  continue;
                 }
               }
-
-              if (newBound > offsetInt) {
-                concreteOffsetBound = newBound;
-                boundUpdated = true;
-              } else {
-                // Incorrect bounds would pass this assertion, as long as the
-                // value of the checked offset is reasonable (non-negative). We
-                // need to pass some wrong bounds since Tracer-X is more
-                // conservative than KLEE: KLEE can still determine that memory
-                // access is valid as it happens to be in a valid region.
-                // Tracer-X, on the other hand, associates every pointer with a
-                // set of allocations, and the memory bound is violated whenever
-                // there is an access to a memory outside of the region
-                // associated with any of the allocations.
-                assert(c->getZExtValue() <= LLONG_MAX && "incorrect bound");
-                return true;
-              }
             }
-            continue;
+
+            if (newBound > offsetInt) {
+              concreteOffsetBound = newBound;
+              boundUpdated = true;
+            } else {
+              // Incorrect bounds would pass this assertion, as long as the
+              // value of the checked offset is reasonable (non-negative). We
+              // need to pass some wrong bounds since Tracer-X is more
+              // conservative than KLEE: KLEE can still determine that memory
+              // access is valid as it happens to be in a valid region.
+              // Tracer-X, on the other hand, associates every pointer with a
+              // set of allocations, and the memory bound is violated whenever
+              // there is an access to a memory outside of the region associated
+              // with any of the allocations.
+              assert(c->getZExtValue() <= LLONG_MAX && "incorrect bound");
+              return true;
+            }
           }
+          continue;
         }
       }
 
       symbolicOffsetBounds.insert(
-          SubExpr::create(*it1, SubExpr::create(checkedOffset, getOffset())));
+          SubExpr::create(Expr::createPointer(*it1),
+                          SubExpr::create(checkedOffset, getOffset())));
       boundUpdated = true;
     }
   }


### PR DESCRIPTION
To use `uint64_t` bounds instead of `ref<Expr>` (symbolic expression) bounds, as the bounds should in most cases be concrete anyway. This shaves off the running time of `make check` on my machine by about 1 s. 
Before:
```
Passing extra KLEE command line args: -solver-backend=z3
Testing Time: 12.86s
  Expected Passes    : 181
  Expected Failures  : 2
  Unsupported Tests  : 2
```
After:
```
Passing extra KLEE command line args: -solver-backend=z3
Testing Time: 11.89s
  Expected Passes    : 181
  Expected Failures  : 2
  Unsupported Tests  : 2
```
Running `make` in `basic` directory of `klee-examples` does not change subsumption/error counts.
