### PR TITLE
Corrected the logic in SubsumptionTableEntry::makeConstraint()

### DIFF
--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -125,20 +125,17 @@ ref<Expr> SubsumptionTableEntry::makeConstraint(
     }
     if (!offsetsCheck->isTrue())
       constraint = offsetsCheck;
-
-    // We record the value of the pointer for interpolation marking
-    coreValues.insert(stateValue->getOriginalValue());
-    return constraint;
+  } else {
+    // Implication: if tabledConcreteAddress == stateSymbolicAddress, then
+    // tabledValue->getExpression() == stateValue->getExpression()
+    constraint = OrExpr::create(
+        EqExpr::create(ConstantExpr::create(0, Expr::Bool),
+                       EqExpr::create(tabledOffset, stateOffset)),
+        EqExpr::create(tabledValue->getExpression(),
+                       stateValue->getExpression()));
   }
 
-  // Implication: if tabledConcreteAddress == stateSymbolicAddress, then
-  // tabledValue->getExpression() == stateValue->getExpression()
-  constraint =
-      OrExpr::create(EqExpr::create(ConstantExpr::create(0, Expr::Bool),
-                                    EqExpr::create(tabledOffset, stateOffset)),
-                     EqExpr::create(tabledValue->getExpression(),
-                                    stateValue->getExpression()));
-
+  // We record the value of the pointer for interpolation marking
   coreValues.insert(stateValue->getOriginalValue());
   return constraint;
 }


### PR DESCRIPTION
The error had been causing crashes when experimenting with Coreutils. `make check` succeeds 100%, and `make` in `basic` directory of `klee-examples` does not catch divergence in subsumption and error counts.
