### PR TITLE
Fix to assertion failure crash with statemate.c

### DIFF
--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -320,7 +320,8 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
         ref<Expr> newIntpRight;
 
         // When the if condition holds, we perform substitution
-        if (hasSubExpression(equalityConstraintLeft,
+        if (interpolantAtom->getNumKids() > 0 &&
+            hasSubExpression(equalityConstraintLeft,
                              interpolantAtom->getKid(0))) {
           // Here we perform substitution, where given
           // an interpolant atom and an equality constraint,


### PR DESCRIPTION
Crash was caused by recent fix to handle switch() instruction in #299. `make check` succeeds and `make` in `basic` directory of `klee-examples` does not change subsumption and error counts.
