### PR TITLE
Small performance improvement by removing Dependency::directFlowSources()

### DIFF
--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -297,10 +297,6 @@ namespace klee {
     void addDependencyToNonPointer(ref<TxStateValue> source,
                                    ref<TxStateValue> target);
 
-    /// \brief All values that flows to the target in one step
-    std::set<ref<TxStateValue> >
-    directFlowSources(ref<TxStateValue> target) const;
-
     /// \brief Mark as core all the values and locations that flows to the
     /// target
     void markFlow(ref<TxStateValue> target, const std::string &reason) const;


### PR DESCRIPTION
Inlining the content of Dependency::directFlowSources() into Dependency::markFlow() avoiding iterating twice on the internal data structures of `ref<TxStateValue> target`.
`make check` time before this update on `paella.d1.comp.nus.edu.sg` (fastest recorded of 4 runs):
```
********************
Testing Time: 27.12s
********************
Failing Tests (1):
    KLEE :: Runtime/POSIX/Ioctl.c

  Expected Passes    : 181
  Expected Failures  : 2
  Unsupported Tests  : 1
  Unexpected Failures: 1
```
After update (fastest recorded of 4 runs, 3 of which < 27s):
```
********************
Testing Time: 26.94s
********************
Failing Tests (1):
    KLEE :: Runtime/POSIX/Ioctl.c

  Expected Passes    : 181
  Expected Failures  : 2
  Unsupported Tests  : 1
  Unexpected Failures: 1
```