### PR TITLE
Tracer-X pointer error enabling

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -89,6 +89,8 @@ extern llvm::cl::opt<bool> ExactAddressInterpolant;
 
 extern llvm::cl::opt<bool> SpecialFunctionBoundInterpolation;
 
+extern llvm::cl::opt<bool> TracerXPointerError;
+
 #endif
 
 #ifdef ENABLE_METASMT

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -44,6 +44,8 @@ class TxStateValue;
 
 class TxStoreEntry;
 
+const uint64_t symbolicBoundId = ULONG_MAX;
+
 class AllocationContext {
 
 public:
@@ -474,6 +476,10 @@ private:
       address = ZExtExpr::create(_address, pointerWidth);
     } else {
       address = _address;
+    }
+
+    if (!llvm::isa<ConstantExpr>(address)) {
+      concreteOffsetBound = symbolicBoundId;
     }
 
     ref<AllocationInfo> allocInfo;

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -154,6 +154,12 @@ llvm::cl::opt<bool> SpecialFunctionBoundInterpolation(
                    "named tracerx_check, either memory offset bound or exact "
                    "address (enabled with -exact-address-interpolant)."),
     llvm::cl::init(false));
+
+llvm::cl::opt<bool> TracerXPointerError(
+    "tracerx-pointer-error",
+    llvm::cl::desc("Enables detection of more memory errors by interpolation "
+                   "shadow memory (may be false positives)."),
+    llvm::cl::init(false));
 #endif // ENABLE_Z3
 
 #ifdef ENABLE_METASMT

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1153,6 +1153,10 @@ bool Dependency::executeMemoryOperation(
         markAllValues(val, reason);
       } else {
         ret = markAllPointerValues(val, reason);
+        if (ret && !TracerXPointerError) {
+          markAllValues(val, reason);
+          ret = false;
+        }
       }
     }
   }

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -70,6 +70,7 @@ ref<Expr> SubsumptionTableEntry::makeConstraint(
     int debugSubsumptionLevel) const {
   ref<Expr> constraint;
 
+#ifdef ENABLE_Z3
   if (tabledValue->getExpression()->getWidth() !=
       stateValue->getExpression()->getWidth()) {
     // We conservatively require that the addresses should not be
@@ -137,6 +138,7 @@ ref<Expr> SubsumptionTableEntry::makeConstraint(
 
   // We record the value of the pointer for interpolation marking
   coreValues.insert(stateValue->getOriginalValue());
+#endif
   return constraint;
 }
 
@@ -789,6 +791,7 @@ void SubsumptionTableEntry::interpolateValues(
     state.txTreeNode->valuesInterpolation(*it, reason);
   }
 
+#ifdef ENABLE_Z3
   if (Dependency::boundInterpolation() && !ExactAddressInterpolant) {
     reason = "interpolating memory bound for " + reason;
 
@@ -801,6 +804,7 @@ void SubsumptionTableEntry::interpolateValues(
       assert(!memoryError && "interpolation should not result in memory error");
     }
   }
+#endif
 }
 
 bool SubsumptionTableEntry::subsumed(

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -35,9 +35,7 @@ using namespace klee;
 
 namespace klee {
 
-const uint64_t symbolicBoundId = ULONG_MAX;
-
-bool concreteBound(uint64_t bound) { return bound < ULONG_MAX; }
+bool concreteBound(uint64_t bound) { return bound < symbolicBoundId; }
 
 /**/
 


### PR DESCRIPTION
Corrected logic error in the constructor of TxStateAddress, where if address was not concrete, then concreteOffsetBound should be set to symbolic bound id. This correction triggered another issue where Tracer-X reports memory error (false positive) with `make check`, where KLEE does not report the error. Such errors are likely to be false positive. This second issue is also fixed by adding the option `-tracerx-pointer-error` option to enable such report by Tracer-X, which by default is disabled. `make check` and `make` of `basic` directory of `klee-examples` succeeded completely.