### PR TITLE
Correction to memory bounds interpolation

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -333,13 +333,13 @@ private:
 
   void init(llvm::Value *_value, ref<Expr> _expr, bool canInterpolateBound,
             const std::set<std::string> &_coreReasons,
-            const std::set<ref<TxStateAddress> > _locations,
+            ref<TxStateAddress> _locations,
             std::set<const Array *> &replacements, bool shadowing = false);
 
   TxInterpolantValue(llvm::Value *value, ref<Expr> expr,
                      bool canInterpolateBound,
                      const std::set<std::string> &coreReasons,
-                     const std::set<ref<TxStateAddress> > locations,
+                     ref<TxStateAddress> locations,
                      std::set<const Array *> &replacements) {
     init(value, expr, canInterpolateBound, coreReasons, locations, replacements,
          true);
@@ -348,30 +348,28 @@ private:
   TxInterpolantValue(llvm::Value *value, ref<Expr> expr,
                      bool canInterpolateBound,
                      const std::set<std::string> &coreReasons,
-                     const std::set<ref<TxStateAddress> > locations) {
+                     ref<TxStateAddress> location) {
     std::set<const Array *> dummyReplacements;
-    init(value, expr, canInterpolateBound, coreReasons, locations,
+    init(value, expr, canInterpolateBound, coreReasons, location,
          dummyReplacements);
   }
 
 public:
   static ref<TxInterpolantValue>
   create(llvm::Value *value, ref<Expr> expr, bool canInterpolateBound,
-         const std::set<std::string> &coreReasons,
-         const std::set<ref<TxStateAddress> > locations,
+         const std::set<std::string> &coreReasons, ref<TxStateAddress> location,
          std::set<const Array *> &replacements) {
-    ref<TxInterpolantValue> sv(
-        new TxInterpolantValue(value, expr, canInterpolateBound, coreReasons,
-                               locations, replacements));
+    ref<TxInterpolantValue> sv(new TxInterpolantValue(
+        value, expr, canInterpolateBound, coreReasons, location, replacements));
     return sv;
   }
 
   static ref<TxInterpolantValue>
   create(llvm::Value *value, ref<Expr> expr, bool canInterpolateBound,
          const std::set<std::string> &coreReasons,
-         const std::set<ref<TxStateAddress> > locations) {
+         ref<TxStateAddress> location) {
     ref<TxInterpolantValue> sv(new TxInterpolantValue(
-        value, expr, canInterpolateBound, coreReasons, locations));
+        value, expr, canInterpolateBound, coreReasons, location));
     return sv;
   }
 
@@ -618,7 +616,7 @@ private:
   const ref<Expr> valueExpr;
 
   /// \brief Set of memory locations possibly being pointed to
-  std::set<ref<TxStateAddress> > locations;
+  ref<TxStateAddress> location;
 
   /// \brief Member variable to indicate if any unsatisfiability core depends
   /// on this value.
@@ -714,13 +712,11 @@ public:
   }
 
   void addLocation(ref<TxStateAddress> loc) {
-    if (locations.find(loc) == locations.end())
-      locations.insert(loc);
+    assert(location.isNull() && "location already defined");
+    location = loc;
   }
 
-  const std::set<ref<TxStateAddress> > &getLocations() const {
-    return locations;
-  }
+  const ref<TxStateAddress> getLocation() const { return location; }
 
   bool hasValue(llvm::Value *value) const { return this->value == value; }
 
@@ -742,13 +738,13 @@ public:
 
   ref<TxInterpolantValue> getInterpolantStyleValue() {
     return TxInterpolantValue::create(value, valueExpr, canInterpolateBound(),
-                                      coreReasons, locations);
+                                      coreReasons, location);
   }
 
   ref<TxInterpolantValue>
   getInterpolantStyleValue(std::set<const Array *> &replacements) {
     return TxInterpolantValue::create(value, valueExpr, canInterpolateBound(),
-                                      coreReasons, locations, replacements);
+                                      coreReasons, location, replacements);
   }
 
   /// \brief Print minimal information about this object.

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -156,7 +156,7 @@ void Dependency::addDependency(ref<TxStateValue> source,
 
   assert(target->getLocations().empty() && "should not add new location");
 
-  addDependencyIntToPtr(source, target);
+  addDependencyOfPossiblePointer(source, target);
 }
 
 void Dependency::addTwoDependencies(ref<TxStateValue> source1,
@@ -174,15 +174,15 @@ void Dependency::addTwoDependencies(ref<TxStateValue> source1,
     addDependencyToNonPointer(source2, target);
   } else if (locCount1 == 1) {
     addDependencyToNonPointer(source1, target);
-    addDependencyIntToPtr(source2, target);
+    addDependencyOfPossiblePointer(source2, target);
   } else {
-    addDependencyIntToPtr(source1, target);
+    addDependencyOfPossiblePointer(source1, target);
     addDependencyToNonPointer(source2, target);
   }
 }
 
-void Dependency::addDependencyIntToPtr(ref<TxStateValue> source,
-                                       ref<TxStateValue> target) {
+void Dependency::addDependencyOfPossiblePointer(ref<TxStateValue> source,
+                                                ref<TxStateValue> target) {
   ref<TxStateAddress> nullLocation;
 
   if (source.isNull() || target.isNull())
@@ -930,7 +930,7 @@ void Dependency::execute(llvm::Instruction *instr,
             addDependencyToNonPointer(
                 val, getNewPointerValue(instr, callHistory, result, 0));
           } else {
-            addDependencyIntToPtr(
+            addDependencyOfPossiblePointer(
                 val, getNewTxStateValue(instr, callHistory, result));
           }
         } else {

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -268,8 +268,8 @@ namespace klee {
                             ref<TxStateValue> target);
 
     /// \brief Add flow dependency between source and target value
-    void addDependencyIntToPtr(ref<TxStateValue> source,
-                               ref<TxStateValue> target);
+    void addDependencyOfPossiblePointer(ref<TxStateValue> source,
+                                        ref<TxStateValue> target);
 
     /// \brief Add flow dependency between source and target pointers, offset by
     /// some amount

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -261,8 +261,11 @@ namespace klee {
                                                ref<Expr> expr);
 
     /// \brief Add flow dependency between source and target value
-    void addDependency(ref<TxStateValue> source, ref<TxStateValue> target,
-                       bool multiLocationsCheck = true);
+    void addDependency(ref<TxStateValue> source, ref<TxStateValue> target);
+
+    void addTwoDependencies(ref<TxStateValue> source1,
+                            ref<TxStateValue> source2,
+                            ref<TxStateValue> target);
 
     /// \brief Add flow dependency between source and target value
     void addDependencyIntToPtr(ref<TxStateValue> source,

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -205,8 +205,8 @@ public:
                                   ref<TxStateValue> value);
 
   /// \brief Newly relate an location with its stored value
-  void updateStore(const std::set<ref<TxStateAddress> > &locations,
-                   ref<TxStateValue> address, ref<TxStateValue> value);
+  void updateStore(ref<TxStateAddress> location, ref<TxStateValue> address,
+                   ref<TxStateValue> value);
 
   /// \brief Register the entries in the entry list as used
   void markUsed(const std::set<ref<TxStoreEntry> > &entryList);


### PR DESCRIPTION
Reimplementation according to the design discussed in #177 of memory bounds interpolation, namely:
1. Separation of values (`TxStateValue`) into 3 types:
    a. Non-pointer value (has `TxStateValue::location.isNull()` true).
    b. Pointer value that can be slackened (has `TxStateValue::doNotInterpolateBound` false).
    c. Pointer value that cannot be slackened (has `TxStateValue::doNotInterpolateBoud` true).
2. Replacement of `std::set<ref<TxStateAddress> > TxStateValue::locations` with `ref<TxStateAddress> TxStateValue::location`.

Now a pointer can no longer depend on two or more pointer values, correcting and simplifying memory bounds interpolation (slackening). `make check` succeeds completely (slightly faster) with no change in subsumption  and error counts of `basic` examples of `klee-examples`.