### PR TITLE
Apply interpolant simplification when storing entry into the table

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -334,33 +334,38 @@ private:
   void init(llvm::Value *_value, ref<Expr> _expr, bool canInterpolateBound,
             const std::set<std::string> &_coreReasons,
             ref<TxStateAddress> _locations,
+            const std::map<ref<Expr>, ref<Expr> > &substitution,
             std::set<const Array *> &replacements, bool shadowing = false);
 
   TxInterpolantValue(llvm::Value *value, ref<Expr> expr,
                      bool canInterpolateBound,
                      const std::set<std::string> &coreReasons,
                      ref<TxStateAddress> locations,
+                     const std::map<ref<Expr>, ref<Expr> > &substitution,
                      std::set<const Array *> &replacements) {
-    init(value, expr, canInterpolateBound, coreReasons, locations, replacements,
-         true);
+    init(value, expr, canInterpolateBound, coreReasons, locations, substitution,
+         replacements, true);
   }
 
   TxInterpolantValue(llvm::Value *value, ref<Expr> expr,
                      bool canInterpolateBound,
                      const std::set<std::string> &coreReasons,
                      ref<TxStateAddress> location) {
+    const std::map<ref<Expr>, ref<Expr> > dummySubstitution;
     std::set<const Array *> dummyReplacements;
     init(value, expr, canInterpolateBound, coreReasons, location,
-         dummyReplacements);
+         dummySubstitution, dummyReplacements);
   }
 
 public:
   static ref<TxInterpolantValue>
   create(llvm::Value *value, ref<Expr> expr, bool canInterpolateBound,
          const std::set<std::string> &coreReasons, ref<TxStateAddress> location,
+         const std::map<ref<Expr>, ref<Expr> > &substitution,
          std::set<const Array *> &replacements) {
-    ref<TxInterpolantValue> sv(new TxInterpolantValue(
-        value, expr, canInterpolateBound, coreReasons, location, replacements));
+    ref<TxInterpolantValue> sv(
+        new TxInterpolantValue(value, expr, canInterpolateBound, coreReasons,
+                               location, substitution, replacements));
     return sv;
   }
 
@@ -742,9 +747,11 @@ public:
   }
 
   ref<TxInterpolantValue>
-  getInterpolantStyleValue(std::set<const Array *> &replacements) {
+  getInterpolantStyleValue(const std::map<ref<Expr>, ref<Expr> > &substitution,
+                           std::set<const Array *> &replacements) {
     return TxInterpolantValue::create(value, valueExpr, canInterpolateBound(),
-                                      coreReasons, location, replacements);
+                                      coreReasons, location, substitution,
+                                      replacements);
   }
 
   /// \brief Print minimal information about this object.

--- a/include/klee/util/TxExprUtil.h
+++ b/include/klee/util/TxExprUtil.h
@@ -1,0 +1,43 @@
+//===--- TxExprUtil.h - Utilities for handling expressions ------*- C++ -*-===//
+//
+//               The Tracer-X KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Utilities for handling expressions.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef KLEE_TXEXPRUTIL_H
+#define KLEE_TXEXPRUTIL_H
+
+#include "klee/util/ExprVisitor.h"
+
+namespace klee {
+
+/// \brief General substitution mechanism
+class TxSubstitutionVisitor : public ExprVisitor {
+private:
+  const std::map<ref<Expr>, ref<Expr> > &replacements;
+
+public:
+  TxSubstitutionVisitor(const std::map<ref<Expr>, ref<Expr> > &_replacements)
+      : ExprVisitor(true), replacements(_replacements) {}
+
+  Action visitExprPost(const Expr &e) {
+    std::map<ref<Expr>, ref<Expr> >::const_iterator it =
+        replacements.find(ref<Expr>(const_cast<Expr *>(&e)));
+    if (it != replacements.end()) {
+      return Action::changeTo(it->second);
+    } else {
+      return Action::doChildren();
+    }
+  }
+};
+}
+
+#endif // KLEE_TXEXPRUTIL_H

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -382,17 +382,18 @@ namespace klee {
     /// \sa TxStore#getStoredExpressions()
     void getStoredExpressions(
         const std::vector<llvm::Instruction *> &callHistory,
+        const std::map<ref<Expr>, ref<Expr> > &substitution,
         std::set<const Array *> &replacements, bool coreOnly,
         bool leftRetrieval,
         TxStore::TopInterpolantStore &concretelyAddressedStore,
         TxStore::TopInterpolantStore &symbolicallyAddressedStore,
         TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
         TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
-      store->getStoredExpressions(callHistory, replacements, coreOnly,
-                                  leftRetrieval, concretelyAddressedStore,
-                                  symbolicallyAddressedStore,
-                                  concretelyAddressedHistoricalStore,
-                                  symbolicallyAddressedHistoricalStore);
+      store->getStoredExpressions(
+          callHistory, substitution, replacements, coreOnly, leftRetrieval,
+          concretelyAddressedStore, symbolicallyAddressedStore,
+          concretelyAddressedHistoricalStore,
+          symbolicallyAddressedHistoricalStore);
     }
 
     ref<TxStateValue>
@@ -493,8 +494,10 @@ namespace klee {
     }
 
     /// \brief Retrieve the path condition interpolant
-    ref<Expr> packInterpolant(std::set<const Array *> &replacements) const {
-      return pathCondition->packInterpolant(replacements);
+    ref<Expr>
+    packInterpolant(std::set<const Array *> &replacements,
+                    std::map<ref<Expr>, ref<Expr> > &substitution) const {
+      return pathCondition->packInterpolant(replacements, substitution);
     }
 
     /// \brief Marking the core constraints on the path condition, and all the

--- a/lib/Core/TxPathCondition.h
+++ b/lib/Core/TxPathCondition.h
@@ -107,7 +107,9 @@ public:
 
   void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore);
 
-  ref<Expr> packInterpolant(std::set<const Array *> &replacements) const;
+  ref<Expr>
+  packInterpolant(std::set<const Array *> &replacements,
+                  std::map<ref<Expr>, ref<Expr> > &substitution) const;
 
   /// \brief Print the content of the object to the LLVM error stream
   void dump() const {

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -126,23 +126,27 @@ private:
   TxStore *parent, *left, *right;
 
   void concreteToInterpolant(ref<TxVariable> variable, ref<TxStoreEntry> entry,
+                             const std::map<ref<Expr>, ref<Expr> > &substition,
                              std::set<const Array *> &replacements,
                              bool coreOnly, LowerInterpolantStore &map,
                              bool leftRetrieval) const;
 
-  void symbolicToInterpolant(ref<TxVariable> variable, ref<TxStoreEntry> entry,
-                             std::set<const Array *> &replacements,
-                             bool coreOnly, LowerInterpolantStore &map,
-                             bool leftRetrieval) const;
+  void
+  symbolicToInterpolant(ref<TxVariable> variable, ref<TxStoreEntry> entry,
+                        const std::map<ref<Expr>, ref<Expr> > &substitution,
+                        std::set<const Array *> &replacements, bool coreOnly,
+                        LowerInterpolantStore &map, bool leftRetrieval) const;
 
   void getConcreteStore(
       const std::vector<llvm::Instruction *> &callHistory,
+      const std::map<ref<Expr>, ref<Expr> > &substitution,
       std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
       TopInterpolantStore &_concretelyAddressedStore,
       LowerInterpolantStore &_concretelyAddressedHistoricalStore) const;
 
   void getSymbolicStore(
       const std::vector<llvm::Instruction *> &callHistory,
+      const std::map<ref<Expr>, ref<Expr> > &substitution,
       std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
       TopInterpolantStore &_symbolicallyAddressedStore,
       LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const;
@@ -192,6 +196,7 @@ public:
   /// the store.
   void getStoredExpressions(
       const std::vector<llvm::Instruction *> &callHistory,
+      const std::map<ref<Expr>, ref<Expr> > &substitution,
       std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
       TopInterpolantStore &_concretelyAddressedStore,
       TopInterpolantStore &_symbolicallyAddressedStore,

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -550,9 +550,9 @@ ref<Expr> SubsumptionTableEntry::simplifyEqualityExpr(
 }
 
 void
-SubsumptionTableEntry::getSubstitution1(std::set<const Array *> &existentials,
-                                        ref<Expr> equalities,
-                                        std::map<ref<Expr>, ref<Expr> > &map) {
+SubsumptionTableEntry::getSubstitution(std::set<const Array *> &existentials,
+                                       ref<Expr> equalities,
+                                       std::map<ref<Expr>, ref<Expr> > &map) {
   // It is assumed the rhs is an expression on the free variables.
   if (llvm::isa<EqExpr>(equalities)) {
     ref<Expr> lhs = equalities->getKid(0);
@@ -580,30 +580,8 @@ SubsumptionTableEntry::getSubstitution1(std::set<const Array *> &existentials,
       }
     }
   } else if (llvm::isa<AndExpr>(equalities)) {
-    getSubstitution1(existentials, equalities->getKid(0), map);
-    getSubstitution1(existentials, equalities->getKid(1), map);
-  }
-}
-
-void
-SubsumptionTableEntry::getSubstitution2(std::set<const Array *> &replaced,
-                                        ref<Expr> equalities,
-                                        std::map<ref<Expr>, ref<Expr> > &map) {
-  // It is assumed the lhs is an expression on the existentially-quantified
-  // variable whereas the rhs is an expression on the free variables.
-  if (llvm::isa<EqExpr>(equalities)) {
-    ref<Expr> lhs = equalities->getKid(0);
-    ref<Expr> rhs = equalities->getKid(1);
-    if (isVariable(lhs) && hasVariableInSet(replaced, lhs) &&
-        !hasVariableInSet(replaced, rhs)) {
-      map[lhs] = rhs;
-    } else if (!hasVariableInSet(replaced, lhs) && isVariable(rhs) &&
-               hasVariableInSet(replaced, rhs)) {
-      map[rhs] = lhs;
-    }
-  } else if (llvm::isa<AndExpr>(equalities)) {
-    getSubstitution2(replaced, equalities->getKid(0), map);
-    getSubstitution2(replaced, equalities->getKid(1), map);
+    getSubstitution(existentials, equalities->getKid(0), map);
+    getSubstitution(existentials, equalities->getKid(1), map);
   }
 }
 
@@ -732,25 +710,19 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
 
   assert(llvm::isa<AndExpr>(body));
 
-  std::map<ref<Expr>, ref<Expr> > substitution1;
+  std::map<ref<Expr>, ref<Expr> > substitution;
   ref<Expr> equalities = body->getKid(1);
-  getSubstitution1(expr->variables, equalities, substitution1);
+  getSubstitution(expr->variables, equalities, substitution);
 
   ref<Expr> interpolant =
-      TxSubstitutionVisitor(substitution1).visit(body->getKid(0));
+      TxSubstitutionVisitor(substitution).visit(body->getKid(0));
 
   if (hasVariableInSet(expr->variables, equalities)) {
     // we could also replace the occurrence of some variables with its
     // corresponding substitution mapping.
-    equalities = TxSubstitutionVisitor(substitution1).visit(equalities);
+    equalities = TxSubstitutionVisitor(substitution).visit(equalities);
     equalities = removeUnsubstituted(expr->variables, equalities);
   }
-
-  // We look for substitutions in the interpolant part and apply them to the
-  // interpolant itself.
-  std::map<ref<Expr>, ref<Expr> > substitution2;
-  getSubstitution2(expr->variables, interpolant, substitution2);
-  interpolant = TxSubstitutionVisitor(substitution2).visit(interpolant);
 
   ref<Expr> newBody = AndExpr::create(interpolant, equalities);
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -25,6 +25,7 @@
 #include <klee/SolverStats.h>
 #include <klee/Internal/Support/ErrorHandling.h>
 #include <klee/util/ExprPPrinter.h>
+#include <klee/util/TxExprUtil.h>
 #include <klee/util/TxPrintUtil.h>
 #include <fstream>
 #include <vector>
@@ -735,12 +736,12 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
   getSubstitution1(expr->variables, equalities, substitution1);
 
   ref<Expr> interpolant =
-      ApplySubstitutionVisitor(substitution1).visit(body->getKid(0));
+      TxSubstitutionVisitor(substitution1).visit(body->getKid(0));
 
   if (hasVariableInSet(expr->variables, equalities)) {
     // we could also replace the occurrence of some variables with its
     // corresponding substitution mapping.
-    equalities = ApplySubstitutionVisitor(substitution1).visit(equalities);
+    equalities = TxSubstitutionVisitor(substitution1).visit(equalities);
     equalities = removeUnsubstituted(expr->variables, equalities);
   }
 
@@ -748,7 +749,7 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr,
   // interpolant itself.
   std::map<ref<Expr>, ref<Expr> > substitution2;
   getSubstitution2(expr->variables, interpolant, substitution2);
-  interpolant = ApplySubstitutionVisitor(substitution2).visit(interpolant);
+  interpolant = TxSubstitutionVisitor(substitution2).visit(interpolant);
 
   ref<Expr> newBody = AndExpr::create(interpolant, equalities);
 

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -446,7 +446,8 @@ public:
   /// \param replacements The replacement bound variables for replacing the
   /// variables in the path condition.
   /// \return The interpolant expression.
-  ref<Expr> getInterpolant(std::set<const Array *> &replacements) const;
+  ref<Expr> getInterpolant(std::set<const Array *> &replacements,
+                           std::map<ref<Expr>, ref<Expr> > &substitution) const;
 
   /// \brief Extend the path condition with another constraint
   ///
@@ -497,6 +498,7 @@ public:
   /// replaced with the bound ones.
   void getStoredCoreExpressions(
       const std::vector<llvm::Instruction *> &callHistory,
+      const std::map<ref<Expr>, ref<Expr> > &substitution,
       std::set<const Array *> &replacements,
       TxStore::TopInterpolantStore &concretelyAddressedStore,
       TxStore::TopInterpolantStore &symbolicallyAddressedStore,

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -254,14 +254,9 @@ class SubsumptionTableEntry {
                                           bool &hasExistentialsOnly);
 
   /// \brief Function to collect substitution from a conjunction of equalities.
-  static void getSubstitution1(std::set<const Array *> &existentials,
-                               ref<Expr> equalities,
-                               std::map<ref<Expr>, ref<Expr> > &map);
-
-  /// \brief Function to collect substitution from a conjunction of formulas.
-  static void getSubstitution2(std::set<const Array *> &replaced,
-                               ref<Expr> conjunction,
-                               std::map<ref<Expr>, ref<Expr> > &map);
+  static void getSubstitution(std::set<const Array *> &existentials,
+                              ref<Expr> equalities,
+                              std::map<ref<Expr>, ref<Expr> > &map);
 
   /// \brief Function to remove equalities whose lhs is a variable in the set.
   static ref<Expr> removeUnsubstituted(std::set<const Array *> &variables,

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -140,27 +140,6 @@ public:
 class SubsumptionTableEntry {
   friend class TxTree;
 
-  /// \brief General substitution mechanism
-  class ApplySubstitutionVisitor : public ExprVisitor {
-  private:
-    const std::map<ref<Expr>, ref<Expr> > &replacements;
-
-  public:
-    ApplySubstitutionVisitor(
-        const std::map<ref<Expr>, ref<Expr> > &_replacements)
-        : ExprVisitor(true), replacements(_replacements) {}
-
-    Action visitExprPost(const Expr &e) {
-      std::map<ref<Expr>, ref<Expr> >::const_iterator it =
-          replacements.find(ref<Expr>(const_cast<Expr *>(&e)));
-      if (it != replacements.end()) {
-        return Action::changeTo(it->second);
-      } else {
-        return Action::doChildren();
-      }
-    }
-  };
-
 #ifdef ENABLE_Z3
   /// \brief Mark begin and end of subsumption check for use within a scope
   struct SubsumptionCheckMarker {

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -21,6 +21,7 @@
 
 #include "klee/Internal/Module/TxValues.h"
 #include "klee/Internal/Support/ErrorHandling.h"
+#include "klee/util/TxExprUtil.h"
 #include "klee/util/TxPrintUtil.h"
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 3)
@@ -180,12 +181,11 @@ void TxVariable::print(llvm::raw_ostream &stream,
 
 /**/
 
-void TxInterpolantValue::init(llvm::Value *_value, ref<Expr> _expr,
-                              bool canInterpolateBound,
-                              const std::set<std::string> &_coreReasons,
-                              ref<TxStateAddress> _location,
-                              std::set<const Array *> &replacements,
-                              bool shadowing) {
+void TxInterpolantValue::init(
+    llvm::Value *_value, ref<Expr> _expr, bool canInterpolateBound,
+    const std::set<std::string> &_coreReasons, ref<TxStateAddress> _location,
+    const std::map<ref<Expr>, ref<Expr> > &substitution,
+    std::set<const Array *> &replacements, bool shadowing) {
   refCount = 0;
   id = reinterpret_cast<uintptr_t>(this);
   expr =

--- a/lib/Core/TxValues.cpp
+++ b/lib/Core/TxValues.cpp
@@ -188,8 +188,16 @@ void TxInterpolantValue::init(
     std::set<const Array *> &replacements, bool shadowing) {
   refCount = 0;
   id = reinterpret_cast<uintptr_t>(this);
-  expr =
-      shadowing ? ShadowArray::getShadowExpression(_expr, replacements) : _expr;
+  if (shadowing) {
+    _expr = ShadowArray::getShadowExpression(_expr, replacements);
+    for (std::map<ref<Expr>, ref<Expr> >::const_iterator
+             it = substitution.begin(),
+             ie = substitution.end();
+         it != ie; ++it) {
+      _expr = TxSubstitutionVisitor(substitution).visit(_expr);
+    }
+  }
+  expr = _expr;
   value = _value;
 
   doNotUseBound = !canInterpolateBound;


### PR DESCRIPTION
Some pre-solving simplification at subsumption check can be relegated to simplification when storing the interpolant to improve performance. This resolves issue #321 .
