### PR TITLE
Corrected the location of insertion of the value in the state to the …

### DIFF
--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -1010,8 +1010,8 @@ bool SubsumptionTableEntry::subsumed(
                                msg3.c_str());
                 }
               }
-              coreValues.insert(stateValue->getOriginalValue());
             }
+            coreValues.insert(stateValue->getOriginalValue());
           }
         }
 


### PR DESCRIPTION
…core to be marked in SubsumptionTableEntry::subsumed().

This resolves issue #146.

`make check` succeeds 100%, with `make` in `basic` directory of `klee-examples` resulted in 1 test with decreased subsumption count: `regexp_iterative.c` (from 70 to 66), with increased space traversed: to 12285 to 13192, which is normal for subsumption fix such as this one.