### PR TITLE
Check simplification

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -904,12 +904,14 @@ public:
       if (!leftInterpolantStyleValue.get()) {
         leftInterpolantStyleValue =
             TxInterpolantValue::create(value, valueExpr, leftPointerInfo);
+        leftInterpolantStyleValue->setOriginalValue(content);
       }
       return leftInterpolantStyleValue;
     }
     if (!rightInterpolantStyleValue.get()) {
       rightInterpolantStyleValue =
           TxInterpolantValue::create(value, valueExpr, rightPointerInfo);
+      rightInterpolantStyleValue->setOriginalValue(content);
     }
     return rightInterpolantStyleValue;
   }

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -255,6 +255,8 @@ public:
 
   ref<Expr> getOffset() const { return offset; }
 
+  bool hasConstantAddress() const { return isConcrete; }
+
   /// \brief The comparator of this class' objects. This member function checks
   /// for the equality of TxInterpolantAddress#indirectionCount member variables
   /// to

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -902,9 +902,9 @@ public:
   }
 
   ref<TxInterpolantValue>
-  getInterpolantStyleValue(bool leftUse,
-                           const std::map<ref<Expr>, ref<Expr> > &substitution,
-                           std::set<const Array *> &replacements) {
+  getInterpolantValue(bool leftUse,
+                      const std::map<ref<Expr>, ref<Expr> > &substitution,
+                      std::set<const Array *> &replacements) {
     if (leftUse) {
       return TxInterpolantValue::create(
           value, valueExpr, !leftDoNotInterpolateBound, leftCoreReasons,

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -916,10 +916,16 @@ public:
     return rightInterpolantStyleValue;
   }
 
+  ref<TxInterpolantValue> getInterpolantValue(bool leftUse) const {
+    const std::map<ref<Expr>, ref<Expr> > dummySubstitution;
+    std::set<const Array *> dummyReplacements;
+    return getInterpolantValue(leftUse, dummySubstitution, dummyReplacements);
+  }
+
   ref<TxInterpolantValue>
   getInterpolantValue(bool leftUse,
                       const std::map<ref<Expr>, ref<Expr> > &substitution,
-                      std::set<const Array *> &replacements) {
+                      std::set<const Array *> &replacements) const {
     if (leftUse) {
       return TxInterpolantValue::create(
           value, valueExpr, !leftDoNotInterpolateBound, leftCoreReasons,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -308,8 +308,30 @@ namespace klee {
         TxStore::TopInterpolantStore &concretelyAddressedStore,
         TxStore::TopInterpolantStore &symbolicallyAddressedStore,
         TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
-        TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
+        TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore,
+        TxStore::TopStateStore &__internalStore,
+        TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
+        TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) {
       store->getStoredExpressions(
+          referenceStore, callHistory, substitution, replacements, coreOnly,
+          leftRetrieval, concretelyAddressedStore, symbolicallyAddressedStore,
+          concretelyAddressedHistoricalStore,
+          symbolicallyAddressedHistoricalStore, __internalStore,
+          __concretelyAddressedHistoricalStore,
+          __symbolicallyAddressedHistoricalStore);
+    }
+
+    void getStoredCoreExpressions(
+        const TxStore *referenceStore,
+        const std::vector<llvm::Instruction *> &callHistory,
+        const std::map<ref<Expr>, ref<Expr> > &substitution,
+        std::set<const Array *> &replacements, bool coreOnly,
+        bool leftRetrieval,
+        TxStore::TopInterpolantStore &concretelyAddressedStore,
+        TxStore::TopInterpolantStore &symbolicallyAddressedStore,
+        TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
+        TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
+      store->getStoredCoreExpressions(
           referenceStore, callHistory, substitution, replacements, coreOnly,
           leftRetrieval, concretelyAddressedStore, symbolicallyAddressedStore,
           concretelyAddressedHistoricalStore,
@@ -368,7 +390,10 @@ namespace klee {
         TxStore::TopInterpolantStore &concretelyAddressedStore,
         TxStore::TopInterpolantStore &symbolicallyAddressedStore,
         TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
-        TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
+        TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore,
+        TxStore::TopStateStore &__internalStore,
+        TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
+        TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) {
       bool leftRetrieval = false;
 
       if (parent->left == this)
@@ -377,6 +402,60 @@ namespace klee {
         assert(parent->right == this && "mismatched tree edge");
 
       parent->getStoredExpressions(
+          store, callHistory, substitution, replacements, coreOnly,
+          leftRetrieval, concretelyAddressedStore, symbolicallyAddressedStore,
+          concretelyAddressedHistoricalStore,
+          symbolicallyAddressedHistoricalStore, __internalStore,
+          __concretelyAddressedHistoricalStore,
+          __symbolicallyAddressedHistoricalStore);
+    }
+
+    /// \brief This retrieves the locations known at this state, and the
+    /// expressions stored in the locations. Returns as the last argument a pair
+    /// of the store part indexed by constants, and the store part indexed by
+    /// symbolic expressions.
+    ///
+    /// \param callHistory The current call history context of the state
+    /// \param replacements The replacement bound variables when
+    /// retrieving state for creating subsumption table entry: As the
+    /// resulting expression will be used for storing in the
+    /// subsumption table, the variables need to be replaced with the
+    /// bound ones.
+    /// \param coreOnly Indicates whether we are retrieving only data
+    /// for locations relevant to an unsatisfiability core.
+    /// \param leftRetrieval Whether the retrieval is requested by the left
+    /// child of the store, otherwise, we assume it is requested by the right
+    /// child of the store.
+    /// \param [out] concretelyAddressedStore The output concretely-addressed
+    /// store.
+    /// \param [out] symbolicallyAddressedStore The output
+    /// symbolically-addressed store.
+    /// \param [out] concretelyAddressedHistoricalStore The output
+    /// concretely-addressed historical store, whose domain consists of
+    /// historical concrete addresses that are no longer valid due to exiting of
+    /// scope.
+    /// \param [out] symbolicallyAddressedHistoricalStore The output
+    /// symbolically-addressed historical store, whose domain consists of
+    /// historical symbolic addresses that are no longer valid due to exiting of
+    /// scope.
+    ///
+    /// \sa TxStore#getStoredExpressions()
+    void getParentStoredCoreExpressions(
+        const std::vector<llvm::Instruction *> &callHistory,
+        const std::map<ref<Expr>, ref<Expr> > &substitution,
+        std::set<const Array *> &replacements, bool coreOnly,
+        TxStore::TopInterpolantStore &concretelyAddressedStore,
+        TxStore::TopInterpolantStore &symbolicallyAddressedStore,
+        TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
+        TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore) {
+      bool leftRetrieval = false;
+
+      if (parent->left == this)
+        leftRetrieval = true;
+      else
+        assert(parent->right == this && "mismatched tree edge");
+
+      parent->getStoredCoreExpressions(
           store, callHistory, substitution, replacements, coreOnly,
           leftRetrieval, concretelyAddressedStore, symbolicallyAddressedStore,
           concretelyAddressedHistoricalStore,

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -305,19 +305,12 @@ namespace klee {
         const std::map<ref<Expr>, ref<Expr> > &substitution,
         std::set<const Array *> &replacements, bool coreOnly,
         bool leftRetrieval,
-        TxStore::TopInterpolantStore &concretelyAddressedStore,
-        TxStore::TopInterpolantStore &symbolicallyAddressedStore,
-        TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
-        TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore,
         TxStore::TopStateStore &__internalStore,
         TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
         TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) {
       store->getStoredExpressions(
           referenceStore, callHistory, substitution, replacements, coreOnly,
-          leftRetrieval, concretelyAddressedStore, symbolicallyAddressedStore,
-          concretelyAddressedHistoricalStore,
-          symbolicallyAddressedHistoricalStore, __internalStore,
-          __concretelyAddressedHistoricalStore,
+          leftRetrieval, __internalStore, __concretelyAddressedHistoricalStore,
           __symbolicallyAddressedHistoricalStore);
     }
 
@@ -387,10 +380,6 @@ namespace klee {
         const std::vector<llvm::Instruction *> &callHistory,
         const std::map<ref<Expr>, ref<Expr> > &substitution,
         std::set<const Array *> &replacements, bool coreOnly,
-        TxStore::TopInterpolantStore &concretelyAddressedStore,
-        TxStore::TopInterpolantStore &symbolicallyAddressedStore,
-        TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
-        TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore,
         bool &leftRetrieval, TxStore::TopStateStore &__internalStore,
         TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
         TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) {
@@ -401,10 +390,7 @@ namespace klee {
 
       parent->getStoredExpressions(
           store, callHistory, substitution, replacements, coreOnly,
-          leftRetrieval, concretelyAddressedStore, symbolicallyAddressedStore,
-          concretelyAddressedHistoricalStore,
-          symbolicallyAddressedHistoricalStore, __internalStore,
-          __concretelyAddressedHistoricalStore,
+          leftRetrieval, __internalStore, __concretelyAddressedHistoricalStore,
           __symbolicallyAddressedHistoricalStore);
     }
 

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -329,13 +329,6 @@ namespace klee {
 
     ~Dependency();
 
-    static Dependency *
-    createRoot(llvm::DataLayout *targetData,
-               std::map<const llvm::GlobalValue *, ref<ConstantExpr> > *
-                   globalAddresses) {
-      return new Dependency(0, targetData, globalAddresses);
-    }
-
     Dependency *cdr() const;
 
     /// \brief This retrieves the locations known at this state, and the

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -391,11 +391,9 @@ namespace klee {
         TxStore::TopInterpolantStore &symbolicallyAddressedStore,
         TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
         TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore,
-        TxStore::TopStateStore &__internalStore,
+        bool &leftRetrieval, TxStore::TopStateStore &__internalStore,
         TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
         TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) {
-      bool leftRetrieval = false;
-
       if (parent->left == this)
         leftRetrieval = true;
       else

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -574,6 +574,8 @@ namespace klee {
     void memoryBoundViolationInterpolation(llvm::Instruction *inst,
                                            ref<Expr> address);
 
+    TxStore *getStore() const { return store; }
+
     /// \brief Print the content of the object to the LLVM error stream
     void dump() const {
       this->print(llvm::errs());

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -207,14 +207,14 @@ inline void TxStore::concreteToInterpolant(
 // An address is in the core if it stores a value that is in the core
 #ifdef ENABLE_Z3
     if (!NoExistential) {
-      map[variable] = entry->getInterpolantStyleValue(leftOfEntry, substitution,
-                                                      replacements);
+      map[variable] =
+          entry->getInterpolantValue(leftOfEntry, substitution, replacements);
     } else {
       map[variable] = entry->getInterpolantStyleValue(leftOfEntry);
     }
 #else
-    map[variable] = entry->getInterpolantStyleValue(leftOfEntry, substitution,
-                                                    replacements);
+    map[variable] =
+        entry->getInterpolantValue(leftOfEntry, substitution, replacements);
 #endif
   }
 }
@@ -244,16 +244,16 @@ inline void TxStore::symbolicToInterpolant(
     if (!NoExistential) {
       ref<TxVariable> address = TxStateAddress::create(
           entry->getAddress(), replacements)->getAsVariable();
-      map[address] = entry->getInterpolantStyleValue(leftOfEntry, substitution,
-                                                     replacements);
+      map[address] =
+          entry->getInterpolantValue(leftOfEntry, substitution, replacements);
     } else {
       map[variable] = entry->getInterpolantStyleValue(leftOfEntry);
     }
 #else
     ref<TxVariable> address = TxStateAddress::create(
         entry->getAddress(), replacements)->getAsVariable();
-    map[address] = entry->getInterpolantStyleValue(leftOfEntry, substitution,
-                                                   replacements);
+    map[address] =
+        entry->getInterpolantValue(leftOfEntry, substitution, replacements);
 #endif
   }
 }

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -194,22 +194,12 @@ void TxStore::getStoredExpressions(
     const std::vector<llvm::Instruction *> &callHistory,
     const std::map<ref<Expr>, ref<Expr> > &substitution,
     std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
-    TopInterpolantStore &_concretelyAddressedStore,
-    TopInterpolantStore &_symbolicallyAddressedStore,
-    LowerInterpolantStore &_concretelyAddressedHistoricalStore,
-    LowerInterpolantStore &_symbolicallyAddressedHistoricalStore,
     TopStateStore &__internalStore,
     LowerStateStore &__concretelyAddressedHistoricalStore,
     LowerStateStore &__symbolicallyAddressedHistoricalStore) const {
   __internalStore = internalStore;
   __concretelyAddressedHistoricalStore = concretelyAddressedHistoricalStore;
   __symbolicallyAddressedHistoricalStore = symbolicallyAddressedHistoricalStore;
-  getConcreteStore(referenceStore, callHistory, substitution, replacements,
-                   coreOnly, leftRetrieval, _concretelyAddressedStore,
-                   _concretelyAddressedHistoricalStore);
-  getSymbolicStore(referenceStore, callHistory, substitution, replacements,
-                   coreOnly, leftRetrieval, _symbolicallyAddressedStore,
-                   _symbolicallyAddressedHistoricalStore);
 }
 
 void TxStore::getStoredCoreExpressions(

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -257,7 +257,7 @@ inline void TxStore::concreteToInterpolant(
       map[variable] =
           entry->getInterpolantValue(leftOfEntry, substitution, replacements);
     } else {
-      map[variable] = entry->getInterpolantStyleValue(leftOfEntry);
+      map[variable] = entry->getInterpolantValue(leftOfEntry);
     }
 #else
     map[variable] =
@@ -292,7 +292,7 @@ inline void TxStore::symbolicToInterpolant(
       map[address] =
           entry->getInterpolantValue(leftOfEntry, substitution, replacements);
     } else {
-      map[variable] = entry->getInterpolantStyleValue(leftOfEntry);
+      map[variable] = entry->getInterpolantValue(leftOfEntry);
     }
 #else
     ref<TxVariable> address = TxStateAddress::create(

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -46,6 +46,28 @@ TxStore::MiddleStateStore::find(ref<TxStateAddress> loc) const {
   return ret;
 }
 
+ref<TxStoreEntry>
+TxStore::MiddleStateStore::findConcrete(ref<TxVariable> var) const {
+  ref<TxStoreEntry> ret;
+  TxStore::LowerStateStore::const_iterator lowerStoreIter =
+      concretelyAddressedStore.find(var);
+  if (lowerStoreIter != concretelyAddressedStore.end()) {
+    ret = lowerStoreIter->second;
+  }
+  return ret;
+}
+
+ref<TxStoreEntry>
+TxStore::MiddleStateStore::findSymbolic(ref<TxVariable> var) const {
+  ref<TxStoreEntry> ret;
+  TxStore::LowerStateStore::const_iterator lowerStoreIter =
+      symbolicallyAddressedStore.find(var);
+  if (lowerStoreIter != symbolicallyAddressedStore.end()) {
+    ret = lowerStoreIter->second;
+  }
+  return ret;
+}
+
 ref<TxStoreEntry> TxStore::MiddleStateStore::updateStore(
     const TxStore *store, ref<TxStateAddress> loc, ref<TxStateValue> address,
     ref<TxStateValue> value, uint64_t _depth) {

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -46,13 +46,27 @@ TxStore::MiddleStateStore::find(ref<TxStateAddress> loc) const {
   return ret;
 }
 
-ref<TxStoreEntry>
-TxStore::MiddleStateStore::findConcrete(ref<TxVariable> var) const {
+ref<TxStoreEntry> TxStore::MiddleStateStore::findConcrete(
+    ref<TxVariable> var,
+    std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases) const {
   ref<TxStoreEntry> ret;
   TxStore::LowerStateStore::const_iterator lowerStoreIter =
       concretelyAddressedStore.find(var);
   if (lowerStoreIter != concretelyAddressedStore.end()) {
     ret = lowerStoreIter->second;
+  } else {
+    for (TxStore::LowerStateStore::const_iterator
+             it = concretelyAddressedStore.begin(),
+             ie = concretelyAddressedStore.end();
+         it != ie; ++it) {
+      if (it->first->getOffset() == var->getOffset()) {
+        if (it->first->getAllocationInfo()->translate(var->getAllocationInfo(),
+                                                      unifiedBases)) {
+          ret = it->second;
+        }
+        break;
+      }
+    }
   }
   return ret;
 }

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -239,10 +239,8 @@ inline void TxStore::concreteToInterpolant(
     std::set<const Array *> &replacements, bool coreOnly,
     LowerInterpolantStore &map, bool leftOfEntry) const {
   if (!coreOnly) {
-    ref<TxStateValue> stateValue = entry->getContent();
     ref<TxInterpolantValue> interpolantValue =
         entry->getInterpolantStyleValue(leftOfEntry);
-    interpolantValue->setOriginalValue(stateValue);
     map[variable] = interpolantValue;
   } else if (entry->isCore(leftOfEntry)) {
     // Do not add to the map if entry is not used
@@ -274,10 +272,8 @@ inline void TxStore::symbolicToInterpolant(
     std::set<const Array *> &replacements, bool coreOnly,
     LowerInterpolantStore &map, bool leftOfEntry) const {
   if (!coreOnly) {
-    ref<TxStateValue> stateValue = entry->getContent();
     ref<TxInterpolantValue> interpolantValue =
         entry->getInterpolantStyleValue(leftOfEntry);
-    interpolantValue->setOriginalValue(stateValue);
     map[variable] = interpolantValue;
   } else if (entry->isCore(leftOfEntry)) {
     // Do not add to the map if entry is not used

--- a/lib/Core/TxStore.cpp
+++ b/lib/Core/TxStore.cpp
@@ -175,6 +175,29 @@ void TxStore::getStoredExpressions(
     TopInterpolantStore &_concretelyAddressedStore,
     TopInterpolantStore &_symbolicallyAddressedStore,
     LowerInterpolantStore &_concretelyAddressedHistoricalStore,
+    LowerInterpolantStore &_symbolicallyAddressedHistoricalStore,
+    TopStateStore &__internalStore,
+    LowerStateStore &__concretelyAddressedHistoricalStore,
+    LowerStateStore &__symbolicallyAddressedHistoricalStore) const {
+  __internalStore = internalStore;
+  __concretelyAddressedHistoricalStore = concretelyAddressedHistoricalStore;
+  __symbolicallyAddressedHistoricalStore = symbolicallyAddressedHistoricalStore;
+  getConcreteStore(referenceStore, callHistory, substitution, replacements,
+                   coreOnly, leftRetrieval, _concretelyAddressedStore,
+                   _concretelyAddressedHistoricalStore);
+  getSymbolicStore(referenceStore, callHistory, substitution, replacements,
+                   coreOnly, leftRetrieval, _symbolicallyAddressedStore,
+                   _symbolicallyAddressedHistoricalStore);
+}
+
+void TxStore::getStoredCoreExpressions(
+    const TxStore *referenceStore,
+    const std::vector<llvm::Instruction *> &callHistory,
+    const std::map<ref<Expr>, ref<Expr> > &substitution,
+    std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
+    TopInterpolantStore &_concretelyAddressedStore,
+    TopInterpolantStore &_symbolicallyAddressedStore,
+    LowerInterpolantStore &_concretelyAddressedHistoricalStore,
     LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const {
   getConcreteStore(referenceStore, callHistory, substitution, replacements,
                    coreOnly, leftRetrieval, _concretelyAddressedStore,

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -78,7 +78,10 @@ public:
 
     ref<TxStoreEntry> find(ref<TxStateAddress> loc) const;
 
-    ref<TxStoreEntry> findConcrete(ref<TxVariable> var) const;
+    ref<TxStoreEntry> findConcrete(
+        ref<TxVariable> var,
+        std::map<ref<AllocationInfo>, ref<AllocationInfo> > &unifiedBases)
+        const;
 
     ref<TxStoreEntry> findSymbolic(ref<TxVariable> var) const;
 

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -223,10 +223,6 @@ public:
       const TxStore *store, const std::vector<llvm::Instruction *> &callHistory,
       const std::map<ref<Expr>, ref<Expr> > &substitution,
       std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
-      TopInterpolantStore &_concretelyAddressedStore,
-      TopInterpolantStore &_symbolicallyAddressedStore,
-      LowerInterpolantStore &_concretelyAddressedHistoricalStore,
-      LowerInterpolantStore &_symbolicallyAddressedHistoricalStore,
       TopStateStore &__internalStore,
       LowerStateStore &__concretelyAddressedHistoricalStore,
       LowerStateStore &__symbolicallyAddressedHistoricalStore) const;

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -222,6 +222,33 @@ public:
       TopInterpolantStore &_concretelyAddressedStore,
       TopInterpolantStore &_symbolicallyAddressedStore,
       LowerInterpolantStore &_concretelyAddressedHistoricalStore,
+      LowerInterpolantStore &_symbolicallyAddressedHistoricalStore,
+      TopStateStore &__internalStore,
+      LowerStateStore &__concretelyAddressedHistoricalStore,
+      LowerStateStore &__symbolicallyAddressedHistoricalStore) const;
+
+  /// \brief This retrieves the locations known at this state, and the
+  /// expressions stored in the locations. Returns as the last argument a pair
+  /// of the store part indexed by constants, and the store part indexed by
+  /// symbolic expressions.
+  ///
+  /// \param replacements The replacement bound variables when
+  /// retrieving state for creating subsumption table entry: As the
+  /// resulting expression will be used for storing in the
+  /// subsumption table, the variables need to be replaced with the
+  /// bound ones.
+  /// \param coreOnly Indicate whether we are retrieving only data
+  /// for locations relevant to an unsatisfiability core.
+  /// \param leftRetrieval Whether the retrieval is requested by the left child
+  /// of the store, otherwise, we assume it is requested by the right child of
+  /// the store.
+  void getStoredCoreExpressions(
+      const TxStore *store, const std::vector<llvm::Instruction *> &callHistory,
+      const std::map<ref<Expr>, ref<Expr> > &substitution,
+      std::set<const Array *> &replacements, bool coreOnly, bool leftRetrieval,
+      TopInterpolantStore &_concretelyAddressedStore,
+      TopInterpolantStore &_symbolicallyAddressedStore,
+      LowerInterpolantStore &_concretelyAddressedHistoricalStore,
       LowerInterpolantStore &_symbolicallyAddressedHistoricalStore) const;
 
   /// \brief Newly relate a location with its stored value, when the value is

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -78,6 +78,10 @@ public:
 
     ref<TxStoreEntry> find(ref<TxStateAddress> loc) const;
 
+    ref<TxStoreEntry> findConcrete(ref<TxVariable> var) const;
+
+    ref<TxStoreEntry> findSymbolic(ref<TxVariable> var) const;
+
     ref<TxStoreEntry> updateStore(const TxStore *store, ref<TxStateAddress> loc,
                                   ref<TxStateValue> address,
                                   ref<TxStateValue> value, uint64_t depth);

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -126,8 +126,7 @@ ref<Expr> SubsumptionTableEntry::makeConstraint(
       }
       return constraint;
     }
-    if (!offsetsCheck->isTrue())
-      constraint = offsetsCheck;
+    constraint = offsetsCheck;
   } else {
     // Implication: if tabledConcreteAddress == stateSymbolicAddress, then
     // tabledValue->getExpression() == stateValue->getExpression()

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -850,7 +850,7 @@ bool SubsumptionTableEntry::subsumed(
            it2 != ie2; ++it2) {
         ref<TxInterpolantValue> stateValue;
 
-        ref<TxStoreEntry> e = m.findConcrete(it2->first);
+        ref<TxStoreEntry> e = m.findConcrete(it2->first, unifiedBases);
 
         if (e.isNull()) {
           // The address is not found in the state, possibly due to differing
@@ -1152,7 +1152,7 @@ bool SubsumptionTableEntry::subsumed(
                ie2 = tabledSymbolicMap.end();
            it2 != ie2; ++it2) {
 
-        ref<TxStoreEntry> e = m.findConcrete(it2->first);
+        ref<TxStoreEntry> e = m.findConcrete(it2->first, unifiedBases);
         bool leftUse =
             state.txTreeNode->getStore()->isInLeftSubtree(e->getDepth());
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -869,9 +869,7 @@ bool SubsumptionTableEntry::subsumed(
         } else {
           bool leftUse =
               state.txTreeNode->getStore()->isInLeftSubtree(e->getDepth());
-          ref<TxStateValue> originalValue = e->getContent();
           stateValue = e->getInterpolantStyleValue(leftUse);
-          stateValue->setOriginalValue(originalValue);
         }
 
         const ref<TxInterpolantValue> tabledValue = it2->second;
@@ -1016,10 +1014,8 @@ bool SubsumptionTableEntry::subsumed(
           // site and the call history) are equivalent.
           if (it2->first->getContext() == e->getAddress()->getContext()) {
 
-            ref<TxStateValue> originalContent = e->getContent();
             ref<TxInterpolantValue> interpolantValue =
                 e->getInterpolantStyleValue(leftUse);
-            interpolantValue->setOriginalValue(originalContent);
             ref<Expr> constraint = makeConstraint(
                 state, it2->second, interpolantValue, it2->first->getOffset(),
                 e->getAddress()->getOffset(), coreValues, corePointerValues,
@@ -1069,10 +1065,8 @@ bool SubsumptionTableEntry::subsumed(
           ref<TxStoreEntry> e = mIt->second;
           bool leftUse =
               state.txTreeNode->getStore()->isInLeftSubtree(e->getDepth());
-          ref<TxStateValue> originalValue = e->getContent();
           ref<TxInterpolantValue> interpolantValue =
               e->getInterpolantStyleValue(leftUse);
-          interpolantValue->setOriginalValue(originalValue);
           constraint = makeConstraint(
               state, it1->second, interpolantValue, it1->first->getOffset(),
               e->getAddress()->getOffset(), coreValues, corePointerValues,
@@ -1093,10 +1087,8 @@ bool SubsumptionTableEntry::subsumed(
         ref<TxStoreEntry> e = mIt->second;
         bool leftUse =
             state.txTreeNode->getStore()->isInLeftSubtree(e->getDepth());
-        ref<TxStateValue> originalValue = e->getContent();
         ref<TxInterpolantValue> interpolantValue =
             e->getInterpolantStyleValue(leftUse);
-        interpolantValue->setOriginalValue(originalValue);
         constraint = makeConstraint(
             state, it1->second, interpolantValue, it1->first->getOffset(),
             e->getAddress()->getOffset(), coreValues, corePointerValues,
@@ -1163,10 +1155,8 @@ bool SubsumptionTableEntry::subsumed(
           // We make sure the context part of the addresses (the allocation site
           // and the call history) are equivalent.
           if (it2->first->getContext() == e->getAddress()->getContext()) {
-            ref<TxStateValue> originalValue = e->getContent();
             ref<TxInterpolantValue> interpolantValue =
                 e->getInterpolantStyleValue(leftUse);
-            interpolantValue->setOriginalValue(originalValue);
             ref<Expr> constraint = makeConstraint(
                 state, it2->second, interpolantValue, it2->first->getOffset(),
                 e->getAddress()->getOffset(), coreValues, corePointerValues,
@@ -1193,10 +1183,8 @@ bool SubsumptionTableEntry::subsumed(
           // We make sure the context part of the addresses (the allocation site
           // and the call history) are equivalent.
           if (it2->first->getContext() == e->getAddress()->getContext()) {
-            ref<TxStateValue> originalValue = e->getContent();
             ref<TxInterpolantValue> interpolantValue =
                 e->getInterpolantStyleValue(leftUse);
-            interpolantValue->setOriginalValue(originalValue);
             ref<Expr> constraint = makeConstraint(
                 state, it2->second, interpolantValue, it2->first->getOffset(),
                 e->getAddress()->getOffset(), coreValues, corePointerValues,
@@ -1240,10 +1228,8 @@ bool SubsumptionTableEntry::subsumed(
           ref<TxStoreEntry> e = mIt->second;
           bool leftUse =
               state.txTreeNode->getStore()->isInLeftSubtree(e->getDepth());
-          ref<TxStateValue> originalValue = e->getContent();
           ref<TxInterpolantValue> interpolantValue =
               e->getInterpolantStyleValue(leftUse);
-          interpolantValue->setOriginalValue(originalValue);
           constraint = makeConstraint(
               state, it1->second, interpolantValue, it1->first->getOffset(),
               e->getAddress()->getOffset(), coreValues, corePointerValues,
@@ -1264,10 +1250,8 @@ bool SubsumptionTableEntry::subsumed(
         ref<TxStoreEntry> e = mIt->second;
         bool leftUse =
             state.txTreeNode->getStore()->isInLeftSubtree(e->getDepth());
-        ref<TxStateValue> originalValue = e->getContent();
         ref<TxInterpolantValue> interpolantValue =
             e->getInterpolantStyleValue(leftUse);
-        interpolantValue->setOriginalValue(originalValue);
         constraint = makeConstraint(
             state, it1->second, interpolantValue, it1->first->getOffset(),
             e->getAddress()->getOffset(), coreValues, corePointerValues,

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -787,7 +787,7 @@ bool SubsumptionTableEntry::subsumed(
     TxStore::TopInterpolantStore &_symbolicallyAddressedStore,
     TxStore::LowerInterpolantStore &_concretelyAddressedHistoricalStore,
     TxStore::LowerInterpolantStore &_symbolicallyAddressedHistoricalStore,
-    TxStore::TopStateStore &__internalStore,
+    bool leftRetrieval, TxStore::TopStateStore &__internalStore,
     TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
     TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore,
     int debugSubsumptionLevel) {
@@ -1809,6 +1809,7 @@ bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
     TxStore::LowerInterpolantStore concretelyAddressedHistoricalStore;
     TxStore::LowerInterpolantStore symbolicallyAddressedHistoricalStore;
 
+    bool leftRetrieval;
     TxStore::TopStateStore __internalStore;
     TxStore::LowerStateStore __concretelyAddressedHistoricalStore;
     TxStore::LowerStateStore __symbolicallyAddressedHistoricalStore;
@@ -1816,7 +1817,7 @@ bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
     txTreeNode->getStoredExpressions(
         txTreeNode->entryCallHistory, concretelyAddressedStore,
         symbolicallyAddressedStore, concretelyAddressedHistoricalStore,
-        symbolicallyAddressedHistoricalStore, __internalStore,
+        symbolicallyAddressedHistoricalStore, leftRetrieval, __internalStore,
         __concretelyAddressedHistoricalStore,
         __symbolicallyAddressedHistoricalStore);
 
@@ -1827,8 +1828,8 @@ bool SubsumptionTable::check(TimingSolver *solver, ExecutionState &state,
       if ((*it)->subsumed(
               solver, state, timeout, concretelyAddressedStore,
               symbolicallyAddressedStore, concretelyAddressedHistoricalStore,
-              symbolicallyAddressedHistoricalStore, __internalStore,
-              __concretelyAddressedHistoricalStore,
+              symbolicallyAddressedHistoricalStore, leftRetrieval,
+              __internalStore, __concretelyAddressedHistoricalStore,
               __symbolicallyAddressedHistoricalStore, debugSubsumptionLevel)) {
         // We mark as subsumed such that the node will not be
         // stored into table (the table already contains a more
@@ -2266,7 +2267,7 @@ void TxTreeNode::getStoredExpressions(
     TxStore::TopInterpolantStore &symbolicallyAddressedStore,
     TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
     TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore,
-    TxStore::TopStateStore &__internalStore,
+    bool &leftRetrieval, TxStore::TopStateStore &__internalStore,
     TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
     TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) const {
   TimerStatIncrementer t(getStoredExpressionsTime);
@@ -2281,7 +2282,7 @@ void TxTreeNode::getStoredExpressions(
         _callHistory, dummySubstitution, dummyReplacements, false,
         concretelyAddressedStore, symbolicallyAddressedStore,
         concretelyAddressedHistoricalStore,
-        symbolicallyAddressedHistoricalStore, __internalStore,
+        symbolicallyAddressedHistoricalStore, leftRetrieval, __internalStore,
         __concretelyAddressedHistoricalStore,
         __symbolicallyAddressedHistoricalStore);
   }

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -291,6 +291,9 @@ public:
       TxStore::TopInterpolantStore &_symbolicallyAddressedStore,
       TxStore::LowerInterpolantStore &_concretelyAddressedHistoricalStore,
       TxStore::LowerInterpolantStore &_symbolicallyAddressedHistoricalStore,
+      TxStore::TopStateStore &__internalStore,
+      TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
+      TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore,
       int debugSubsumptionLevel);
 
   /// Tests if the argument is a variable. A variable here is defined to be
@@ -477,8 +480,10 @@ public:
       TxStore::TopInterpolantStore &concretelyAddressedStore,
       TxStore::TopInterpolantStore &symbolicallyAddressedStore,
       TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
-      TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore)
-      const;
+      TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore,
+      TxStore::TopStateStore &__internalStore,
+      TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
+      TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) const;
 
   /// \brief This retrieves the allocations known at this state, and the
   /// expressions stored in the allocations, as long as the allocation is

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -287,10 +287,6 @@ public:
 
   bool subsumed(
       TimingSolver *solver, ExecutionState &state, double timeout,
-      TxStore::TopInterpolantStore &_concretelyAddressedStore,
-      TxStore::TopInterpolantStore &_symbolicallyAddressedStore,
-      TxStore::LowerInterpolantStore &_concretelyAddressedHistoricalStore,
-      TxStore::LowerInterpolantStore &_symbolicallyAddressedHistoricalStore,
       bool leftRetrieval, TxStore::TopStateStore &__internalStore,
       TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
       TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore,
@@ -477,10 +473,6 @@ public:
   /// part indexed by symbolic expressions.
   void getStoredExpressions(
       const std::vector<llvm::Instruction *> &callHistory,
-      TxStore::TopInterpolantStore &concretelyAddressedStore,
-      TxStore::TopInterpolantStore &symbolicallyAddressedStore,
-      TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
-      TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore,
       bool &leftRetrieval, TxStore::TopStateStore &__internalStore,
       TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
       TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) const;

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -535,6 +535,8 @@ public:
 
   void setGenericEarlyTermination() { genericEarlyTermination = true; }
 
+  TxStore *getStore() const { return dependency->getStore(); }
+
   /// \brief Print the content of the tree node object to the LLVM error stream.
   void dump() const;
 

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -291,7 +291,7 @@ public:
       TxStore::TopInterpolantStore &_symbolicallyAddressedStore,
       TxStore::LowerInterpolantStore &_concretelyAddressedHistoricalStore,
       TxStore::LowerInterpolantStore &_symbolicallyAddressedHistoricalStore,
-      TxStore::TopStateStore &__internalStore,
+      bool leftRetrieval, TxStore::TopStateStore &__internalStore,
       TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
       TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore,
       int debugSubsumptionLevel);
@@ -481,7 +481,7 @@ public:
       TxStore::TopInterpolantStore &symbolicallyAddressedStore,
       TxStore::LowerInterpolantStore &concretelyAddressedHistoricalStore,
       TxStore::LowerInterpolantStore &symbolicallyAddressedHistoricalStore,
-      TxStore::TopStateStore &__internalStore,
+      bool &leftRetrieval, TxStore::TopStateStore &__internalStore,
       TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
       TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) const;
 


### PR DESCRIPTION
For resolving issue #305. This eliminates loops for state retrieval for subsumption checks altogether and simplifies the algorithm. `make check` succeeds 100% and `make` in `basic` directory of `klee-examples` reports no change in subsumption and error counts. `Regexp.c` example runs, on average of 5 runs, 0.198 s faster.
