### PR TITLE
Two small fixes

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -908,7 +908,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
       // Validity proof succeeded of a query: antecedent -> consequent.
       // We then extract the unsatisfiability core of antecedent and not
       // consequent as the Craig interpolant.
-      txTree->markPathCondition(current, solver, unsatCore);
+      txTree->markPathCondition(current, unsatCore);
     }
 
     return StatePair(&current, 0);
@@ -923,7 +923,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
       // Falsity proof succeeded of a query: antecedent -> consequent,
       // which means that antecedent -> not(consequent) is valid. In this
       // case also we extract the unsat core of the proof
-      txTree->markPathCondition(current, solver, unsatCore);
+      txTree->markPathCondition(current, unsatCore);
     }
 
     return StatePair(0, &current);

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2070,7 +2070,7 @@ TxTree::split(TxTreeNode *parent, ExecutionState *left, ExecutionState *right) {
   return ret;
 }
 
-void TxTree::markPathCondition(ExecutionState &state, TimingSolver *solver,
+void TxTree::markPathCondition(ExecutionState &state,
                                std::vector<ref<Expr> > &unsatCore) {
   TimerStatIncrementer t(markPathConditionTime);
   int debugSubsumptionLevel =

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -324,6 +324,7 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
 
         // When the if condition holds, we perform substitution
         if (interpolantAtom->getNumKids() > 0 &&
+            !llvm::isa<ConstantExpr>(equalityConstraintLeft) &&
             hasSubExpression(equalityConstraintLeft,
                              interpolantAtom->getKid(0))) {
           // Here we perform substitution, where given

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -731,9 +731,9 @@ public:
   bool subsumptionCheck(TimingSolver *solver, ExecutionState &state,
                         double timeout);
 
-  /// \brief Mark the path condition in the Tracer-X tree node associated
-  /// with the given KLEE execution state.
-  void markPathCondition(ExecutionState &state, TimingSolver *solver,
+  /// \brief Mark the path condition in the Tracer-X tree node associated with
+  /// the given KLEE execution state.
+  void markPathCondition(ExecutionState &state,
                          std::vector<ref<Expr> > &unsatCore);
 
   /// \brief Creates fresh interpolation data holder for the two given KLEE


### PR DESCRIPTION
Can already be integrated. One is a fix to simplification, to prevent situations such as 
simplifying `(!(a=0) && !(b=0))` into `(!(a=0) && ((a=0)=(b=0)))`, which actually increases the size
of the formula. `make check` succeeds 100% and no change in the number of subsumption and
error counts in `basic` folder of `klee-examples`.


