### PR TITLE
Fix to crashes when running with Coreutils

### DIFF
--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -677,6 +677,16 @@ public:
     return vvalue;
   }
 
+  ref<TxStateValue> copy(uint64_t depth) const {
+    ref<TxStateValue> vvalue(
+        new TxStateValue(value, callHistory, valueExpr, depth));
+    vvalue->allowBoundEntryList = allowBoundEntryList;
+    vvalue->disableBoundEntryList = disableBoundEntryList;
+    return vvalue;
+  }
+
+  uint64_t getDepth() const { return depth; }
+
   /// \brief Set the address this value was loaded from for inclusion in the
   /// interpolant
   void addLoadAddress(ref<TxStateValue> _loadAddress);

--- a/include/klee/Internal/Module/TxValues.h
+++ b/include/klee/Internal/Module/TxValues.h
@@ -655,20 +655,25 @@ private:
   /// interpolation may not be enabled.
   std::set<ref<TxStoreEntry> > disableBoundEntryList;
 
+  /// \brief The creation depth of this value.
+  uint64_t depth;
+
   TxStateValue(llvm::Value *value,
                const std::vector<llvm::Instruction *> &_callHistory,
-               ref<Expr> _valueExpr)
+               ref<Expr> _valueExpr, uint64_t _depth)
       : refCount(0), value(value), valueExpr(_valueExpr),
-        id(reinterpret_cast<uint64_t>(this)), callHistory(_callHistory) {}
+        id(reinterpret_cast<uint64_t>(this)), callHistory(_callHistory),
+        depth(_depth) {}
 
 public:
   ~TxStateValue() {}
 
   static ref<TxStateValue>
-  create(llvm::Value *value,
+  create(uint64_t depth, llvm::Value *value,
          const std::vector<llvm::Instruction *> &_callHistory,
          ref<Expr> valueExpr) {
-    ref<TxStateValue> vvalue(new TxStateValue(value, _callHistory, valueExpr));
+    ref<TxStateValue> vvalue(
+        new TxStateValue(value, _callHistory, valueExpr, depth));
     return vvalue;
   }
 

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -627,7 +627,8 @@ void Dependency::execute(llvm::Instruction *instr,
                   ? getNewPointerValue(instr, callHistory, valueExpr, 0)
                   : getNewTxStateValue(instr, callHistory, valueExpr);
 
-          store->updateStoreWithLoadedValue(loc, addressValue, loadedValue);
+          store->updateStoreWithLoadedValue(valuesMap, loc, addressValue,
+                                            loadedValue);
           break;
         } else {
           ref<TxStateAddress> pointerInfo = addressValue->getPointerInfo();
@@ -674,8 +675,8 @@ void Dependency::execute(llvm::Instruction *instr,
                     ? getNewPointerValue(instr, callHistory, valueExpr, 0)
                     : getNewTxStateValue(instr, callHistory, valueExpr);
 
-            store->updateStoreWithLoadedValue(pointerInfo, addressValue,
-                                              loadedValue);
+            store->updateStoreWithLoadedValue(valuesMap, pointerInfo,
+                                              addressValue, loadedValue);
             break;
           }
         }
@@ -691,7 +692,8 @@ void Dependency::execute(llvm::Instruction *instr,
                   ? getNewPointerValue(instr, callHistory, valueExpr, 0)
                   : getNewTxStateValue(instr, callHistory, valueExpr);
 
-          store->updateStoreWithLoadedValue(addressValue->getPointerInfo(),
+          store->updateStoreWithLoadedValue(valuesMap,
+                                            addressValue->getPointerInfo(),
                                             addressValue, loadedValue);
           break;
         }
@@ -709,7 +711,7 @@ void Dependency::execute(llvm::Instruction *instr,
                 ? getNewPointerValue(instr, callHistory, valueExpr, 0)
                 : getNewTxStateValue(instr, callHistory, valueExpr);
         // We could not find the stored value, create a new one.
-        store->updateStoreWithLoadedValue(pointerInfo, addressValue,
+        store->updateStoreWithLoadedValue(valuesMap, pointerInfo, addressValue,
                                           loadedValue);
       } else {
         // Build the loaded value
@@ -748,8 +750,8 @@ void Dependency::execute(llvm::Instruction *instr,
         }
       }
 
-      store->updateStore(addressValue->getPointerInfo(), addressValue,
-                         storedValue);
+      store->updateStore(valuesMap, addressValue->getPointerInfo(),
+                         addressValue, storedValue);
       break;
     }
     case llvm::Instruction::Trunc:
@@ -944,7 +946,8 @@ void Dependency::executeMakeSymbolic(
     }
   }
 
-  store->updateStore(addressValue->getPointerInfo(), addressValue, storedValue);
+  store->updateStore(valuesMap, addressValue->getPointerInfo(), addressValue,
+                     storedValue);
 }
 
 void Dependency::executePHI(llvm::Instruction *instr,

--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -295,8 +295,8 @@ void Dependency::populateArgumentValuesList(
     else {
       // This is for the case when latestValue was NULL, which means there is
       // no source dependency information for this node, e.g., a constant.
-      argumentValuesList.push_back(
-          TxStateValue::create(argOperand, callHistory, arguments[i]));
+      argumentValuesList.push_back(TxStateValue::create(
+          store->getDepth(), argOperand, callHistory, arguments[i]));
     }
   }
 }

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -204,7 +204,8 @@ namespace klee {
                        const std::vector<llvm::Instruction *> &callHistory,
                        ref<Expr> valueExpr) {
       return registerNewTxStateValue(
-          value, TxStateValue::create(value, callHistory, valueExpr));
+          value, TxStateValue::create(store->getDepth(), value, callHistory,
+                                      valueExpr));
     }
 
     /// \brief Create a new versioned value object, which is a pointer with
@@ -214,7 +215,7 @@ namespace klee {
                        const std::vector<llvm::Instruction *> &callHistory,
                        ref<Expr> address, uint64_t size) {
       ref<TxStateValue> vvalue =
-          TxStateValue::create(loc, callHistory, address);
+          TxStateValue::create(store->getDepth(), loc, callHistory, address);
       vvalue->addPointerInfo(
           TxStateAddress::create(loc, callHistory, address, size));
       return registerNewTxStateValue(loc, vvalue);

--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -220,17 +220,6 @@ namespace klee {
       return registerNewTxStateValue(loc, vvalue);
     }
 
-    /// \brief Create a new versioned value object, which is a pointer which
-    /// offsets existing pointer
-    ref<TxStateValue> getNewPointerValue(
-        llvm::Value *value, const std::vector<llvm::Instruction *> &callHistory,
-        ref<Expr> address, ref<TxStateAddress> loc, ref<Expr> offset) {
-      ref<TxStateValue> vvalue =
-          TxStateValue::create(value, callHistory, address);
-      vvalue->addPointerInfo(TxStateAddress::create(loc, address, offset));
-      return registerNewTxStateValue(value, vvalue);
-    }
-
     /// \brief Get a KLEE expression from a constant. This was shamelessly
     /// copied from Executor::evalConstant.
     ref<TxStateValue>

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -256,13 +256,16 @@ public:
 
   /// \brief Newly relate a location with its stored value, when the value is
   /// loaded from the location
-  void updateStoreWithLoadedValue(ref<TxStateAddress> loc,
-                                  ref<TxStateValue> address,
-                                  ref<TxStateValue> value);
+  void updateStoreWithLoadedValue(
+      std::map<llvm::Value *, std::vector<ref<TxStateValue> > > &valuesMap,
+      ref<TxStateAddress> loc, ref<TxStateValue> address,
+      ref<TxStateValue> value);
 
   /// \brief Newly relate an location with its stored value
-  void updateStore(ref<TxStateAddress> location, ref<TxStateValue> address,
-                   ref<TxStateValue> value);
+  void updateStore(
+      std::map<llvm::Value *, std::vector<ref<TxStateValue> > > &valuesMap,
+      ref<TxStateAddress> location, ref<TxStateValue> address,
+      ref<TxStateValue> value);
 
   /// \brief Register the entries in the entry list as used
   void markUsed(const std::set<ref<TxStoreEntry> > &entryList);

--- a/lib/Core/TxStore.h
+++ b/lib/Core/TxStore.h
@@ -290,6 +290,8 @@ public:
                        std::set<uint64_t> &bounds,
                        const std::string &reason) const;
 
+  uint64_t getDepth() const { return depth; }
+
   /// \brief Print the content of the object to the LLVM error stream
   void dump() const {
     this->print(llvm::errs());


### PR DESCRIPTION
This fixes crashes with the following message when running with Coreutils (e.g., executing `make dirname.tx` in `coreutils` directory of `klee-examples` repository).
```
klee: TxStore.cpp:161: bool klee::TxStore::isInLeftSubtree(uint64_t) const: Assertion `current->depth > targetDepth && "entry should have been defined in an ancestor node"' failed.
0  libLLVM-3.4.so.1 0x00007fa0b351e042 llvm::sys::PrintStackTrace(_IO_FILE*) + 34
1  libLLVM-3.4.so.1 0x00007fa0b351de34
2  libpthread.so.0  0x00007fa0b2423390
3  libc.so.6        0x00007fa0afbc2428 gsignal + 56
4  libc.so.6        0x00007fa0afbc402a abort + 362
5  libc.so.6        0x00007fa0afbbabd7
6  libc.so.6        0x00007fa0afbbac82
7  klee             0x00000000004f640b
8  klee             0x00000000004cc41f klee::TxStoreEntry::TxStoreEntry(klee::ref<klee::TxStateAddress>, klee::ref<klee::TxStateValue>, klee::ref<klee::TxStateValue>, klee::TxStore const*, unsigned long) + 863
9  klee             0x00000000004f77d3 klee::TxStore::MiddleStateStore::updateStore(klee::TxStore const*, klee::ref<klee::TxStateAddress>, klee::ref<klee::TxStateValue>, klee::ref<klee::TxStateValue>, unsigned long) + 227
10 klee             0x00000000004f84e8 klee::TxStore::updateStore(klee::ref<klee::TxStateAddress>, klee::ref<klee::TxStateValue>, klee::ref<klee::TxStateValue>) + 408
11 klee             0x00000000004dc13b klee::Dependency::execute(llvm::Instruction*, std::vector<llvm::Instruction*, std::allocator<llvm::Instruction*> > const&, std::vector<klee::ref<klee::Expr>, std::allocator<klee::ref<klee::Expr> > >&, bool) + 4507
12 klee             0x00000000004dee97 klee::Dependency::executeMemoryOperation(llvm::Instruction*, std::vector<llvm::Instruction*, std::allocator<llvm::Instruction*> > const&, std::vector<klee::ref<klee::Expr>, std::allocator<klee::ref<klee::Expr> > >&, bool, bool) + 71
13 klee             0x0000000000482b2e klee::TxTree::executeMemoryOperation(llvm::Instruction*, klee::ref<klee::Expr>, klee::ref<klee::Expr>, bool) + 206
14 klee             0x000000000047722e klee::Executor::executeMemoryOperation(klee::ExecutionState&, bool, klee::ref<klee::Expr>, klee::ref<klee::Expr>, klee::KInstruction*) + 4126
15 klee             0x0000000000478cab klee::Executor::executeInstruction(klee::ExecutionState&, klee::KInstruction*) + 2875
16 klee             0x000000000047eca9 klee::Executor::run(klee::ExecutionState&) + 1689
17 klee             0x000000000047f6c8 klee::Executor::runFunctionAsMain(llvm::Function*, int, char**, char**) + 1672
18 klee             0x00000000004581e0 main + 12688
19 libc.so.6        0x00007fa0afbad830 __libc_start_main + 240
20 klee             0x0000000000460759 _start + 41
```
With this patch, `make check` succeeded 100% and `make` in `klee-examples` `basic` did not result in change in subsumption and error counts.