### PR TITLE
Added missing condition for simplification

### DIFF
--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -343,7 +343,9 @@ TxSubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
           // operation
           // we could directly assign newIntpRight = D, otherwise,
           // newIntpRight == A[D/C]
-          if (!llvm::isa<BinaryExpr>(equalityConstraintLeft))
+          if (!llvm::isa<BinaryExpr>(equalityConstraintLeft) ||
+              equalityConstraintLeft->getWidth() !=
+                  interpolantAtom->getKid(1)->getWidth())
             newIntpRight = interpolantAtom->getKid(1);
           else {
             // newIntpRight is A, but with every occurrence of C replaced


### PR DESCRIPTION
 In `TxSubsumptionTableEntry::simplifyArithmeticBody()`. This resolves crashing issues with Coreutils 6.10 `date`, `seq`, and `od`, observed in experiments run finished on 5 December 2017. `make check` succeeds 100% and `make` in `basic` directory of `klee-examples` resulted in no change in subsumption and error counts.
