### PR TITLE
Fixed dockerfile, now tracer-x can be built using Dockerfile

### DIFF
--- a/.travis/stp.sh
+++ b/.travis/stp.sh
@@ -17,13 +17,27 @@ if [ "x${STP_VERSION}" != "x" ]; then
     sudo make install
     cd ../../
 
+# Determine STP build flags
+  if [ "X${STP_VERSION}" = "Xmaster" ]; then
+    # 5e9ca6339a2b3b000aa7a90c18601fdcf1212fe1 Silently BUILD_SHARED_LIBS removed. STATICCOMPILE does something similar
+    STP_CMAKE_FLAGS=( \
+      "-DENABLE_PYTHON_INTERFACE:BOOL=OFF" \
+      "-DSTATICCOMPILE:BOOL=ON" \
+    )
+  else
+    STP_CMAKE_FLAGS=( \
+      "-DENABLE_PYTHON_INTERFACE:BOOL=OFF" \
+      "-DBUILD_SHARED_LIBS:BOOL=OFF" \
+    )
+  fi
+
     # Build STP
     git clone --depth 1 -b "${STP_VERSION}" git://github.com/stp/stp.git src
     mkdir build
     cd build
     # Disabling building of shared libs is a workaround.
     # Don't build against boost because that is broken when mixing packaged boost libraries and gcc 4.8
-    cmake -DBUILD_SHARED_LIBS:BOOL=OFF -DENABLE_PYTHON_INTERFACE:BOOL=OFF -DNO_BOOST:BOOL=ON ../src
+    cmake "${STP_CMAKE_FLAGS[@]}" ../src
 
     set +e # Do not exit if build fails because we need to display the log
     make >> "${STP_LOG}" 2>&1
@@ -34,6 +48,7 @@ fi
 
 # Only show build output if something went wrong to keep log output short
 if [ $? -ne 0 ]; then
-    echo "Build error"
-    cat "${STP_LOG}"
+  echo "Build error"
+  cat "${STP_LOG}"
+  exit 1
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
         libcap-dev \
         git \
         subversion \
-        cmake \
+        cmake3 \
         make \
         libboost-program-options-dev \
         python3 \


### PR DESCRIPTION
The STP build script was outdated. This pr fixed docker build by updating cmake version from `2` to `3` and updating STP build script