### PR TITLE
Removing Simplify CFG LLVM optimization. 

### DIFF
--- a/lib/Module/KModule.cpp
+++ b/lib/Module/KModule.cpp
@@ -365,7 +365,7 @@ void KModule::prepare(const Interpreter::ModuleOptions &opts,
   // going to be unresolved. We really need to handle the intrinsics
   // directly I think?
   PassManager pm3;
-  pm3.add(createCFGSimplificationPass());
+  // pm3.add(createCFGSimplificationPass());
   switch(SwitchType) {
   case eSwitchTypeInternal: break;
   case eSwitchTypeSimple: pm3.add(new LowerSwitchPass()); break;


### PR DESCRIPTION
This optimization is the caused of bug #335. The bug get's fixed with this change.