### PR TITLE
Bug mcdc

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -93,6 +93,8 @@ extern llvm::cl::opt<bool> SpecialFunctionBoundInterpolation;
 
 extern llvm::cl::opt<bool> TracerXPointerError;
 
+extern llvm::cl::opt<bool> EmitAllErrorsInSamePath;
+
 #endif
 
 #ifdef ENABLE_METASMT

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -153,6 +153,14 @@ llvm::cl::opt<int>
 
                llvm::cl::init(0));
 
+llvm::cl::opt<bool> EmitAllErrorsInSamePath(
+    "emit-all-errors-in-same-path",
+    llvm::cl::desc("Enables detection of multiple errors "
+                   "in same paths (default=false (off)). Note: Specially used for achieving MC/DC."),
+    llvm::cl::init(false));
+
+
+
 llvm::cl::opt<bool> ExactAddressInterpolant(
     "exact-address-interpolant",
     llvm::cl::desc("This option uses exact address for interpolating "

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3537,8 +3537,8 @@ void Executor::terminateStateOnError(ExecutionState &state,
     interpreterHandler->incErrorTerminationTest();
     interpreterHandler->processTestCase(state, msg.str().c_str(), suffix);
   }
-    
-  terminateState(state);
+    //Sanghu commented this
+  //terminateState(state);
 
   if (shouldExitOn(termReason))
     haltExecution = true;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3537,8 +3537,11 @@ void Executor::terminateStateOnError(ExecutionState &state,
     interpreterHandler->incErrorTerminationTest();
     interpreterHandler->processTestCase(state, msg.str().c_str(), suffix);
   }
-    //Sanghu commented this
-  //terminateState(state);
+
+  if(!EmitAllErrorsInSamePath)
+  {
+  terminateState(state);
+  }
 
   if (shouldExitOn(termReason))
     haltExecution = true;


### PR DESCRIPTION
Adding a feature of emitting all errors in same path for TX and KLEE. It useful for achieving MC/DC. Also, added a command line option to enable this feature whenever user wants to use. By default it is off, and to use we need to use this command "-emit-all-errors-in-same-path=true". 