### PR TITLE
WIP:Backward phi node marking

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3057,8 +3057,12 @@ void Executor::run(ExecutionState &initialState) {
 
   // first BB of main()
   KInstruction *ki = initialState.pc;
-  processBBCoverage(BBCoverage, ki->inst->getParent());
-
+  BasicBlock *firstBB = ki->inst->getParent();
+  if (fBBOrder.find(firstBB->getParent()) != fBBOrder.end() &&
+      fBBOrder[firstBB->getParent()].find(firstBB) !=
+          fBBOrder[firstBB->getParent()].end()) {
+    processBBCoverage(BBCoverage, ki->inst->getParent());
+  }
   bindModuleConstants();
 
   // Delay init till now so that ticks don't accrue during

--- a/lib/Core/TxDependency.h
+++ b/lib/Core/TxDependency.h
@@ -432,7 +432,7 @@ public:
         symbolicallyAddressedHistoricalStore);
   }
 
-  std::map<llvm::Value *, std::vector<ref<TxStateValue> > > getvaluesMap() {
+  std::map<llvm::Value *, std::vector<ref<TxStateValue> > >& getValuesMap() {
     return valuesMap;
   }
 

--- a/lib/Core/TxDependency.h
+++ b/lib/Core/TxDependency.h
@@ -432,6 +432,10 @@ public:
         symbolicallyAddressedHistoricalStore);
   }
 
+  std::map<llvm::Value *, std::vector<ref<TxStateValue> > > getvaluesMap() {
+    return valuesMap;
+  }
+
   ref<TxStateValue>
   getLatestValue(llvm::Value *value,
                  const std::vector<llvm::Instruction *> &callHistory,

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -181,6 +181,7 @@ class TxSubsumptionTableEntry {
   // tree remain the same
   uintptr_t prevProgramPoint;
   std::map<llvm::Value *, std::vector<ref<Expr> > > phiValues;
+  std::map<llvm::Value *, ref<Expr> > nonPhiValues;
 
   /// \brief A procedure for building subsumption check constraints using
   /// symbolically-addressed store elements
@@ -294,6 +295,15 @@ class TxSubsumptionTableEntry {
   static void printStat(std::stringstream &stream);
 
 public:
+  void markValueMap(TxTreeNode *node);
+  void markUp(TxTreeNode *node, std::vector<llvm::Value *> &insts,
+              std::set<llvm::Value *> &markedInsts);
+  std::vector<llvm::Value *>
+  getDependants(llvm::Value *ins,
+                std::map<llvm::Value *, std::vector<ref<TxStateValue> > >
+                    &currentValuesMap,
+                std::set<llvm::Value *> &markedInstruction);
+
   const uintptr_t programPoint;
 
   const uint64_t nodeSequenceNumber;
@@ -382,6 +392,7 @@ class TxTreeNode {
   // tree remain the same
   uintptr_t prevProgramPoint;
   std::map<llvm::Value *, std::vector<ref<Expr> > > phiValues;
+
   bool phiValuesFlag;
 
   uint64_t nodeSequenceNumber;
@@ -452,6 +463,9 @@ class TxTreeNode {
   }
 
 public:
+  std::map<llvm::Value *, ref<Expr> > nonPhiValues;
+  std::vector<llvm::Value *> phiOperands;
+
   bool isSubsumed;
 
   /// \brief The entry call history
@@ -772,6 +786,8 @@ public:
   void setPhiValue(llvm::Value *instr, ref<Expr> value) {
     currentTxTreeNode->setPhiValue(instr, value);
   }
+
+  TxTreeNode *getCurrentTxTreeNode() { return currentTxTreeNode; }
 
   /// \brief Deletes the Tracer-X tree node
   ///

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -177,6 +177,8 @@ class TxSubsumptionTableEntry {
 
   std::set<const Array *> existentials;
 
+  uintptr_t prevProgramPoint;
+
   /// \brief A procedure for building subsumption check constraints using
   /// symbolically-addressed store elements
   ///
@@ -373,6 +375,8 @@ class TxTreeNode {
 
   uintptr_t programPoint;
 
+  uintptr_t prevProgramPoint;
+
   uint64_t nodeSequenceNumber;
 
   bool storable;
@@ -394,9 +398,11 @@ class TxTreeNode {
   /// \brief Indicates that a generic error was encountered in this node
   bool genericEarlyTermination;
 
-  void setProgramPoint(llvm::Instruction *instr) {
-    if (!programPoint)
+  void setProgramPoint(llvm::Instruction *instr, llvm::Instruction *prevInstr) {
+    if (!programPoint) {
       programPoint = reinterpret_cast<uintptr_t>(instr);
+      prevProgramPoint = reinterpret_cast<uintptr_t>(prevInstr);
+    }
 
     // Disabling the subsumption check within KLEE's own API
     // (call sites of klee_ and at any location within the klee_ function)
@@ -446,6 +452,8 @@ public:
   std::vector<llvm::Instruction *> callHistory;
 
   uintptr_t getProgramPoint() { return programPoint; }
+
+  uintptr_t getPrevProgramPoint() { return prevProgramPoint; }
 
   uint64_t getNodeSequenceNumber() { return nodeSequenceNumber; }
 

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -180,7 +180,7 @@ class TxSubsumptionTableEntry {
   // Used to ensure at subsumption the value of the phiNodes in the subsumed
   // tree remain the same
   uintptr_t prevProgramPoint;
-  std::map<llvm::Value *, std::set<ref<Expr> > > phiValues;
+  std::map<llvm::Value *, std::vector<ref<Expr> > > phiValues;
 
   /// \brief A procedure for building subsumption check constraints using
   /// symbolically-addressed store elements
@@ -303,12 +303,12 @@ public:
 
   ~TxSubsumptionTableEntry();
 
-  bool subsumed(
-      TimingSolver *solver, ExecutionState &state, double timeout,
-      bool leftRetrieval, TxStore::TopStateStore &__internalStore,
-      TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
-      TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore,
-      int debugSubsumptionLevel);
+  bool
+  subsumed(TimingSolver *solver, ExecutionState &state, double timeout,
+           bool leftRetrieval, TxStore::TopStateStore &__internalStore,
+           TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
+           TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore,
+           int debugSubsumptionLevel);
 
   /// Tests if the argument is a variable. A variable here is defined to be
   /// either a symbolic concatenation or a symbolic read. A concatenation in
@@ -381,7 +381,7 @@ class TxTreeNode {
   // Used to ensure at subsumption the value of the phiNodes in the subsumed
   // tree remain the same
   uintptr_t prevProgramPoint;
-  std::map<llvm::Value *, std::set<ref<Expr> > > phiValues;
+  std::map<llvm::Value *, std::vector<ref<Expr> > > phiValues;
   bool phiValuesFlag;
 
   uint64_t nodeSequenceNumber;
@@ -413,8 +413,10 @@ class TxTreeNode {
 
     // Disabling the subsumption check within KLEE's own API
     // (call sites of klee_ and at any location within the klee_ function)
-    // by never store a table entry for KLEE's own API, marked with flag storable.
-    storable = !(instr->getParent()->getParent()->getName().substr(0, 5).equals("klee_"));
+    // by never store a table entry for KLEE's own API, marked with flag
+    // storable.
+    storable = !(instr->getParent()->getParent()->getName().substr(0, 5).equals(
+                    "klee_"));
   }
 
   /// \brief for printing member function running time statistics
@@ -472,13 +474,11 @@ public:
 
   TxDependency *getDependency() { return dependency; }
 
-  std::map<llvm::Value *, std::set<ref<Expr> > > getPhiValue() {
+  std::map<llvm::Value *, std::vector<ref<Expr> > > getPhiValue() {
     return phiValues;
   };
 
   void setPhiValue(llvm::Value *instr, ref<Expr> value);
-
-  ref<Expr> getPhiValue(llvm::Instruction *instr);
 
   /// \brief Retrieve the interpolant for this node as KLEE expression object
   ///
@@ -517,8 +517,8 @@ public:
   /// arguments a pair of the store part indexed by constants, and the store
   /// part indexed by symbolic expressions.
   void getStoredExpressions(
-      const std::vector<llvm::Instruction *> &callHistory,
-      bool &leftRetrieval, TxStore::TopStateStore &__internalStore,
+      const std::vector<llvm::Instruction *> &callHistory, bool &leftRetrieval,
+      TxStore::TopStateStore &__internalStore,
       TxStore::LowerStateStore &__concretelyAddressedHistoricalStore,
       TxStore::LowerStateStore &__symbolicallyAddressedHistoricalStore) const;
 
@@ -603,7 +603,8 @@ public:
 /// from
 /// KLEE's Executor class, which is the core symbolic executor of KLEE.
 /// The main functionality of the TxTree#execute versions
-/// themselves is to simply delegate the call to TxDependency#execute and related
+/// themselves is to simply delegate the call to TxDependency#execute and
+/// related
 /// functions, which
 /// implements the construction of memory dependency used in computing the
 /// regions of memory
@@ -650,7 +651,8 @@ public:
 /// </pre>
 /// <hr>
 ///
-/// For comparison, following is the pseudocode of Tracer-X KLEE. Please note that to
+/// For comparison, following is the pseudocode of Tracer-X KLEE. Please note
+/// that to
 /// support interpolation, each leaf is now augmented with a path condition.
 /// We highlight the added procedures using CAPITAL LETTERS, and we note the
 /// functions involved.
@@ -664,7 +666,8 @@ public:
 ///       i. REGISTER IT FOR DELETION
 ///       ii. MARK CONSTRAINTS NEEDED FOR SUBSUMPTION
 ///       iii. GOTO d
-///    c. Symbolically execute the instruction (TxTree::execute, TxTree::executePHI,
+///    c. Symbolically execute the instruction (TxTree::execute,
+/// TxTree::executePHI,
 ///       TxTree::executeMemoryOperation, TxTree::executeOnNode):
 ///       i. If it is a branch instruction, test if one of branches is
 /// unsatisfiable

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -177,7 +177,10 @@ class TxSubsumptionTableEntry {
 
   std::set<const Array *> existentials;
 
+  // Used to ensure at subsumption the value of the phiNodes in the subsumed
+  // tree remain the same
   uintptr_t prevProgramPoint;
+  std::map<llvm::Value *, std::set<ref<Expr> > > phiValues;
 
   /// \brief A procedure for building subsumption check constraints using
   /// symbolically-addressed store elements
@@ -375,7 +378,11 @@ class TxTreeNode {
 
   uintptr_t programPoint;
 
+  // Used to ensure at subsumption the value of the phiNodes in the subsumed
+  // tree remain the same
   uintptr_t prevProgramPoint;
+  std::map<llvm::Value *, std::set<ref<Expr> > > phiValues;
+  bool phiValuesFlag;
 
   uint64_t nodeSequenceNumber;
 
@@ -455,7 +462,21 @@ public:
 
   uintptr_t getPrevProgramPoint() { return prevProgramPoint; }
 
+  bool getPhiValuesFlag() { return phiValuesFlag; }
+
+  void setPhiValuesFlag(bool _phiValuesFlag) { phiValuesFlag = _phiValuesFlag; }
+
   uint64_t getNodeSequenceNumber() { return nodeSequenceNumber; }
+
+  TxDependency *getDependency() { return dependency; }
+
+  std::map<llvm::Value *, std::set<ref<Expr> > > getPhiValue() {
+    return phiValues;
+  };
+
+  void setPhiValue(llvm::Value *instr, ref<Expr> value);
+
+  ref<Expr> getPhiValue(llvm::Instruction *instr);
 
   /// \brief Retrieve the interpolant for this node as KLEE expression object
   ///
@@ -733,6 +754,19 @@ public:
   ///
   /// \param state The KLEE execution state to associate the current node with.
   void setCurrentINode(ExecutionState &state);
+
+  // \brief stop collecting phi values for the current node
+  void setPhiValuesFlag(bool phiValuesFlag) {
+    currentTxTreeNode->setPhiValuesFlag(phiValuesFlag);
+  }
+
+  // \brief get the flag to store phi values for the current node
+  bool getPhiValuesFlag() { return currentTxTreeNode->getPhiValuesFlag(); }
+
+  // \brief stop collecting phi values for the current node
+  void setPhiValue(llvm::Value *instr, ref<Expr> value) {
+    currentTxTreeNode->setPhiValue(instr, value);
+  }
 
   /// \brief Deletes the Tracer-X tree node
   ///

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -462,6 +462,8 @@ public:
 
   uintptr_t getPrevProgramPoint() { return prevProgramPoint; }
 
+  TxTreeNode *getParent() { return parent; }
+
   bool getPhiValuesFlag() { return phiValuesFlag; }
 
   void setPhiValuesFlag(bool _phiValuesFlag) { phiValuesFlag = _phiValuesFlag; }


### PR DESCRIPTION
We have noticed that some of the command line arguments when running core-utils remain experimental. The approach used in this branch is a conservative fix of the over-subsumption for such experimental command-line arguments. Making this fix more lightweight is left as future work. 